### PR TITLE
DS-3307: Remove oss-parent and replace with release settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+
+# DSpace XMLUI Language Packs
+
+## Layout of the source tree
+
+The `messages.xml` files for each language are stored in the `src/main/webapp/i18n/` directory.
+
+The file naming conventions are as follows:
+
+`messages_<ISO 639-1>_<ISO 3166-1>.xml`
+
+* `ISO 639-1`: language code, in lower case.
+* `ISO 3166-1`: codes for country, if required.  For example:
+
+For example:
+* `src/main/webapp/i18n/`
+    * `messages.xml` - file for default (English)
+    * `messages_el.xml` - file for Greek
+    * `messages_fr_FR.xml` - file for French (France)
+    * `messages_fr_CA.xml` - file for French (Canada)
+
+More information on the format of these `messages.xml` files can be found in the Apache Cocoon documentation at https://cocoon.apache.org/2.1/userdocs/i18nTransformer.html
+
+
+## Release tags
+
+Language packs are versioned according to the main DSpace version, but also include an incrementing `sequence-number` which allows language packs to be updated more frequently than DSpace releases.
+
+So, DSpace software releases are of the format: `[major].[minor]` (e.g. 4.0, 4.1, 5.0, 5.1, etc.)
+
+Whereas, DSpace language packs use the format: `[major].[minor].[sequence-number]` (e.g. 5.0.0, 5.0.1, 5.0.2 for 5.0 releases of the language packs).
+
+Language packs are automatically installed into DSpace via Maven dependencies. In the case of the XMLUI language packs, they are installed as a WAR (e.g. `dspace-xmlui-lang-[version].war`) dependency.
+
+## Documentation
+
+Additional documentation on language packs and I18N (internationalization) may be found at [Internationalization Support](https://wiki.duraspace.org/pages/viewpage.action?pageId=19006307)
+
+Documentation for each release may be viewed online or downloaded via our [Documentation Wiki](https://wiki.duraspace.org/display/DSDOC/).
+
+## Contributing
+
+DSpace is a community built and supported project. We do not have a centralized development or support team,
+but have a dedicated group of volunteers who help us improve the software, documentation, resources, etc.
+
+We welcome contributions of any type. Here's a few basic guides that provide suggestions for contributing to DSpace:
+* [How to Contribute to DSpace](https://wiki.duraspace.org/display/DSPACE/How+to+Contribute+to+DSpace): How to contribute in general (via code, documentation, bug reports, expertise, etc)
+* [Code Contribution Guidelines](https://wiki.duraspace.org/display/DSPACE/Code+Contribution+Guidelines): How to give back code or contribute features, bug fixes, etc.
+* [DSpace Community Advisory Team (DCAT)](https://wiki.duraspace.org/display/cmtygp/DSpace+Community+Advisory+Team): If you are not a developer, we also have an interest group specifically for repository managers. The DCAT group meets virtually, once a month, and sends open invitations to join their meetings via the [DCAT mailing list](https://groups.google.com/d/forum/DSpaceCommunityAdvisoryTeam).
+
+We also encourage GitHub Pull Requests (PRs) at any time. Please see our [Development with Git](https://wiki.duraspace.org/display/DSPACE/Development+with+Git) guide for more info.
+
+In addition, a listing of all known contributors to DSpace software can be
+found online at: https://wiki.duraspace.org/display/DSPACE/DSpaceContributors
+
+## Getting Help
+
+DSpace provides public mailing lists where you can post questions or raise topics for discussion.
+We welcome everyone to participate in these lists:
+
+* [dspace-community@googlegroups.com](https://groups.google.com/d/forum/dspace-community) : General discussion about DSpace platform, announcements, sharing of best practices
+* [dspace-tech@googlegroups.com](https://groups.google.com/d/forum/dspace-tech) : Technical support mailing list. See also our guide for [How to troubleshoot an error](https://wiki.duraspace.org/display/DSPACE/Troubleshoot+an+error).
+* [dspace-devel@googlegroups.com](https://groups.google.com/d/forum/dspace-devel) : Developers / Development mailing list
+
+Additional support options are listed at https://wiki.duraspace.org/display/DSPACE/Support
+
+DSpace also has an active service provider network. If you'd rather hire a service provider to
+install, upgrade, customize or host DSpace, then we recommend getting in touch with one of our
+[Registered Service Providers](http://www.dspace.org/service-providers).
+
+## Issue Tracker
+
+The DSpace Issue Tracker can be found at: https://jira.duraspace.org/projects/DS/summary
+
+## License
+
+DSpace source code is freely available under a standard [BSD 3-Clause license](https://opensource.org/licenses/BSD-3-Clause).
+The full license is available at http://www.dspace.org/license/

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,8 @@
         </plugins>
     </build>
 
-    <!--
+    <profiles>
+       <!--
          The 'release' profile is used by the 'maven-release-plugin' (see above)
          to actually perform a DSpace lang packs release to Maven central.
          This profile contains settings which are ONLY enabled when performing

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,69 @@
     </build>
 
     <!--
-      The SCM repository location is used by Continuum to update against
-      when changes have occurred.  This spawns a new build cycle and releases
-      snapshots into the snapshot repository below.
+         The 'release' profile is used by the 'maven-release-plugin' (see above)
+         to actually perform a DSpace lang packs release to Maven central.
+         This profile contains settings which are ONLY enabled when performing
+         a DSpace release. See alse https://wiki.duraspace.org/display/DSPACE/Release+Procedure
+        -->
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Configure Nexus plugin for new releases via Sonatype.
+                         See: http://central.sonatype.org/pages/apache-maven.html -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!-- In your settings.xml, your username/password
+                                 MUST be specified for server 'ossrh' -->
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <!-- Require manual verification / release to Maven Central -->
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <!-- For new releases, generate Source JAR files -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Sign any new releases via GPG.
+                         NOTE: you may optionall specify the "gpg.passphrase" in your settings.xml -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <!--
+      Information about the SCM repository where source code exists.
     -->
     <scm>
         <connection>scm:git:git@github.com:DSpace/dspace-xmlui-lang.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -8,24 +8,141 @@
       DSpace Language Packs to support multiple languages in XMLUI.
     </description>
     <version>6.0.2-SNAPSHOT</version>
+    <url>https://github.com/dspace/dspace-xmlui-lang</url>
 
     <organization>
         <name>DuraSpace</name>
         <url>http://www.dspace.org</url>
     </organization>
 
-    <!-- brings the sonatype snapshot repository and signing requirement on board -->
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
+        <java.version>1.7</java.version>
+    </properties>
 
     <build>
+        <!-- Define Maven Plugin Settings / versions. -->
+        <pluginManagement>
+            <plugins>
+                <!-- Use to enforce a particular version of Java and ensure no conflicting dependencies -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>1.4.1</version>
+                    <executions>
+                        <execution>
+                            <id>enforce-java</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <requireJavaVersion>
+                                        <version>${java.version}</version>
+                                    </requireJavaVersion>
+                                </rules>
+                            </configuration>
+                        </execution>
+                        <!-- Make sure that we do not have conflicting dependencies-->
+                        <execution>
+                            <id>enforce-versions</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <DependencyConvergence />
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <!-- Used to compile all Java classes -->
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5.1</version>
+                    <configuration>
+                      <source>${java.version}</source>
+                      <target>${java.version}</target>
+                    </configuration>
+                </plugin>
+                <!-- Used to package all DSpace JARs -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.6</version>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            </manifest>
+                        </archive>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <!-- Used to generate a new release via Sonatype (see release profile). -->
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                </plugin>
+                <!-- Used to generate JavaDocs for new releases (see release profile). -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.3</version>
+                    <configuration>
+                        <!-- Never fail a build based on Javadoc errors -->
+                        <failOnError>false</failOnError>
+                    </configuration>
+                </plugin>
+                <!-- Used to generate source JARs for new releases (see release profile). -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <!-- Used to sign new releases via GPG (see release profile). -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
+            <!-- Specify our settings for new releases via 'mvn release:*' -->
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.5.3</version>
+                <configuration>
+                    <!-- During release:perform, enable the "release" profile (see below) -->
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                    <!-- Suggest tagging the release in SCM as "dspace-[version]" -->
+                    <tagNameFormat>dspace-xmlui-lang-@{project.version}</tagNameFormat>
+                    <!-- Auto-Version all modules the same as the parent module -->
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -42,6 +159,19 @@
         <tag>HEAD</tag>
     </scm>
 
+    <!-- Configure our release repositories to use Sonatype.
+         See: http://central.sonatype.org/pages/apache-maven.html -->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <licenses>
         <license>
             <name>DuraSpace BSD License</name>
@@ -56,5 +186,4 @@
         <system>JIRA</system>
         <url>https://jira.duraspace.org/browse/DS</url>
     </issueManagement>
-   
 </project>


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-3307

* Removed Sonatype `oss-parent` and instead embedded release settings in this project's POM. This syncs the POM up with that in `DSpace/DSpace` in this PR: DSpace/DSpace#1367
* Created a `README.md` similar to the one in the [dspace-api-lang project
](https://github.com/DSpace/dspace-api-lang/)

Only light testing so far. I successfully ran a `dryRun` release. A real release is also warranted once this code is merged.
