### PR TITLE
Migration of non-English translations to v5.5 using messages.xml as the basic structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Migration of DSpace XMLUI lang
+## About
+The aim of this project is to migrate all non-English translations to 
+v5.5
+
+##Quick usage
+1. Place `messages.xml`, `lang-util.py`, `file-iterator.py` in the _i18n_ 
+folder.
+2. Issue the command `python3 file-iterator.py` to convert all old xml 
+files to the latest version.
+
+###Notes
+- Translation strings from the old translation file are migrated over 
+by comparing keys.
+- If a key in the latest version does not exist in the older version, 
+it defaults to English
+- `messages.xml` is taken from the master 5.5 release of DSpace.
+

--- a/file_iterator.py
+++ b/file_iterator.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+for file in os.listdir("."):
+    if file.endswith(".xml"):
+        if file is not "messages.xml":
+            print(file)
+            os.system('python3 lang-util.py migrate -f ' + file)
+            os.system('rm ' + file)
+            os.system('cp output.xml ' + file)

--- a/src/main/webapp/i18n/messages_ar.xml
+++ b/src/main/webapp/i18n/messages_ar.xml
@@ -1,48 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-  messages.xml
- 
-  Version: $Revision: 5694 $
-
-  Date: $Date: 2010-10-29 21:13:49 +0000 (Fri, 29 Oct 2010) $
-
-  Copyright (c) 2002-2005, Hewlett-Packard Company and Massachusetts
-  Institute of Technology.  All rights reserved.
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are
-  met:
-
-  - Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-
-  - Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-
-  - Neither the name of the Hewlett-Packard Company nor the name of the
-  Massachusetts Institute of Technology nor the names of their
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-  DAMAGE.
--->
-
-<!-- Arabic Translation by KnowledgeWare Technologies الترجمة العربية بواسطة مؤسسة تقنية المعارف -->
-
-
-<catalogue xml:lang="ar" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -72,6 +28,11 @@
         <message key="xmlui.general.perform">أداء</message>
         <message key="xmlui.general.queue">طابور</message>
 
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">يرجى الاتصال بمدير الموقع إذا كنت تريد التبليغ عن هذا الخطأ.  إذا أمكن، يرجى توفير التفاصيل حول ما كنت تقوم به أثناء حدوث هذا الخطأ .</message>
+        <message key="xmlui.error.contact">الاتصال بمدير الموقع</message>
+        <message key="xmlui.error.show_stack">عرض كومة الخطأ الضمنية</message>
+
 	<!--
 		Page not found keys
 
@@ -81,189 +42,6 @@
 	<message key="xmlui.PageNotFound.title">لم يتم العثور على الصفحة</message>
 	<message key="xmlui.PageNotFound.head">لم يتم العثور على الصفحة</message>
 	<message key="xmlui.PageNotFound.para1">لم نتمكن من العثور على الصفحة التي قمت بطلبها.</message>
-
-
-
-
-
-
-
-
- <!-- Keys which are used by exception2dri.xsl on error pages -->
-        <message key="xmlui.error.contact_msg">يرجى الاتصال بمدير الموقع إذا كنت تريد التبليغ عن هذا الخطأ.  إذا أمكن، يرجى توفير التفاصيل حول ما كنت تقوم به أثناء حدوث هذا الخطأ .</message>
-        <message key="xmlui.error.contact">الاتصال بمدير الموقع</message>
-        <message key="xmlui.error.show_stack">عرض كومة الخطأ الضمنية</message>
-
-
-
-	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
-	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">مواد مسحوبة بالعنوان</message>
-	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">مواد مسحوبة بالعنوان</message>
-
-	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">مواد مسحوبة بتاريخ الإصدار</message>
-	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">مواد مسحوبة بتاريخ الإصدار</message>
-
-	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">مواد مسحوبة بتاريخ التقديم</message>
-	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">مواد مسحوبة بتاريخ التقديم</message>
-
-	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
-	<message key="xmlui.Administrative.PrivateItems.title.item.title">مواد خاصة بالعنوان</message>
-	<message key="xmlui.Administrative.PrivateItems.trail.item.title">مواد خاصة بالعنوان</message>
-
-	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">مواد خاصة بتاريخ الإصدار</message>
-	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">مواد خاصة بتاريخ الإصدار</message>
-
-	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">مواد خاصة بتاريخ التقديم</message>
-	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">مواد خاصة بتاريخ التقديم</message>
-
-
- <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">رد مبدئي على الطلب</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> طلب إذن المؤلف</message>
-    
-
-<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">طلب نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">طلب نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">طلب نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">الاتصال المبدئي مع الطالب،لإعلامه بأن طلبه قيد المعالجة.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">إلى</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">الرسالة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">إرسال</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">رجوع</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">طلب نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">طلب نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">طال نسخة من الوثيقة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">هذا ما سيتم إرساله بعد ذلك إلى الطالب  (إلى جانب الوثيقة).</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">إلى</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">الرسالة</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">إرسال</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">رجوع</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">تم إرسال الرد.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">تم إرسال الرد.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">تم إرسال الرد.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">تم إرسال الرد.</message>
-
-<message key="xmlui.administrative.Navigation.administrative_content">إدارة المحتوى</message>
-
-<message key="xmlui.administrative.Navigation.administrative_batch_import">استيراد كمي (ZIP)</message>
-
- <!-- Batch Import Tool -->
-    <!-- org.dspace.app.xmlui.administrative.batchimport -->
-    <message key="xmlui.administrative.batchimport.general.select_collection">تحديد حاوية</message>
-    <message key="xmlui.administrative.batchimport.general.collection">الحاوية</message>
-    <message key="xmlui.administrative.batchimport.general.collection_help">قم بتحديد الحاوية التي تريد تقديم المادة لها .</message>
-    <message key="xmlui.administrative.batchimport.general.collection_default">تحديد حاوية...</message>
-
-    <message key="xmlui.administrative.batchimport.general.title">تحميل الاستيراد الكمي (ZIP)</message>
-    <message key="xmlui.administrative.batchimport.general.head1">تحميل الاستيراد الكمي (ZIP)</message>
-    <message key="xmlui.administrative.batchimport.general.trail">تحميل الاستيراد الكمي (ZIP)</message>
-    <message key="xmlui.administrative.batchimport.general.changes">تغييرات</message>
-    <message key="xmlui.administrative.batchimport.general.no_changes">لم يتم العثور على تغييرات</message>
-    <message key="xmlui.administrative.batchimport.general.new_item">مادة جديدة</message>
-    <message key="xmlui.administrative.batchimport.flow.upload_successful">تم التحميل بنجاح</message>
-    <message key="xmlui.administrative.batchimport.flow.upload_failed">فشل التحميل أو لم يتم تحديد ملف</message>
-    <message key="xmlui.administrative.batchimport.flow.upload_badschema">مخطط ميتاداتا غير معروف في الرأس</message>
-    <message key="xmlui.administrative.batchimport.flow.upload_badelement">عنصر ميتاداتا غير معروف في الرأس</message>
-    <message key="xmlui.administrative.batchimport.flow.import_successful">تم الاستيراد بنجاح</message>
-    <message key="xmlui.administrative.batchimport.flow.import_failed">فشل الاستيراد</message>
-    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">لم يتم تحديد حاوية مستهدفة</message>
-
-    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
-    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">تحميل SimpleArchiveFormat ZIP</message>
-
-    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
-    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">تمت المعالجة بنجاح</message>
-    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">تم تطبيق التغييرات على المادة</message>
-    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">تمت الإضافة: </message>
-    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">تمت الإزالة: </message>
-
-    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
-    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">إضافة: </message>
-    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">إزالة: </message>
-
- <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">عرض احصائيات الاستخدام</message>
-
- <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-                     Google Analytics Statistics Aspect
-
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
-    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">عرض احصائيات جوجل التحليلية</message>
-    <message key="xmlui.statisticsGoogleAnalytics.trail">احصائيات</message>
-    <message key="xmlui.statisticsGoogleAnalytics.title">احصائيات جوجل التحليلية</message>
-
-    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">تاريخ البدء</message>
-    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">تاريخ الانتهاء</message>
-    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">تحديث</message>
-
-    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">عروض الصفحة</message>
-    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">تنزيلات الملف</message>
-
-
-<message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
-
-
-<message key="xmlui.aspect.sherpa.submission.consult">للتحقق من سياسات حقوق الطبع والنشر والإنجاز الذاتي للدورية أو الناشر ‘ يرجى استشارة <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
-    <message key="xmlui.aspect.sherpa.submission.title">معلومات الناشر</message>
-    <message key="xmlui.aspect.sherpa.submission.journal">الدورية: </message>
-    <message key="xmlui.aspect.sherpa.submission.publisher">معلومات الناشر: </message>
-    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO لون: </message>
-    <message key="xmlui.aspect.sherpa.submission.more">(المزيد من المعلومات)</message>
-    <message key="xmlui.aspect.sherpa.submission.green">أخضر</message>
-    <message key="xmlui.aspect.sherpa.submission.blue">أزرق</message>
-    <message key="xmlui.aspect.sherpa.submission.white">أبيض</message>
-    <message key="xmlui.aspect.sherpa.submission.yellow">أصفر</message>
-    <!-- End Versioning -->
-
-
-    <message key="xmlui.mirage2.itemSummaryView.MetaData">ميتاداتا</message>
-    <message key="xmlui.mirage2.itemSummaryView.Collections">الحاويات</message>
-
-    <message key="xmlui.mirage2.discovery.reset">إعادة ضبط</message>
-    <message key="xmlui.mirage2.discovery.newFilter">إضافة مرشح جديد</message>
-    <message key="xmlui.mirage2.discovery.showAdvancedFilters">عرض المرشحات المتقدمة</message>
-    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">إخفاء المرشحات المتقدمة</message>
-
-
-    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">إضافة</message>
-    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">حذف</message>
-    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">خطأ: حقل الإدخال مع "اقتراح" (إكمال تلقائي) سلوك الاختيار لم ينفذ مع الحقول المركبة (مثال: "الاسم") .</message>
-    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">خطأ: حقل الإدخال مع "اقتراح" (إكمال تلقائي) سلوك الاختيار لم ينفذ مع الحقول المركبة  for Composite (e.g. "name") fields.</message>
-    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">إضافة</message>
-    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">حذف</message>
-
-    <message key="xmlui.mirage2.page-structure.aboutThisRepository">حول هذا المستودع</message>
-    <message key="xmlui.mirage2.page-structure.toggleNavigation">الإبحار بالتنقل</message>
-
-    <message key="xmlui.mirage2.page-structure.heroUnit.title">حول هذا المستودع</message>
-    <message key="xmlui.mirage2.page-structure.heroUnit.content">لإضافة المحتوى الخاص بك إلى هذه الصفحة، قم بتحرير تطبيقات الويب /xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl وإضافة محتواك إلى العنوان، والمسار، والموضوع. إذا كنت ترغب في إضافة صفحات إضافية،  يجب عليك إنشاء xsl إضافي:  عند الحظر ومطابقة uri الطلب إلى الصفحة التي تقوم بإضافتها . حاليا، يتم إنشاء الصفحات الثابتة عبر تعديل XSL  متاحة فقط أدنى سابقة URI للصفحة /.</message>
-
-    <message key="xmlui.mirage2.navigation.rss.feed">تلقيمة</message>
-
-    <message key="xmlui.mirage2.choice-authority-control.loading">جاري التحميل...</message>
-
-    <message key="xmlui.mirage2.item-list.thumbnail">صورة مصغرة</message>
-
-
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">مستخدمي هذا النظام، يمكنهم تسجيل الدخول لعرض هذه الوثيقة .</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">تسجيل الدخول</message>
-
-
-
-
-
-
-
-
-
 
 
 	<!--
@@ -278,7 +56,7 @@
 		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">نظام المستودع الرقمي دي سبيس يلتقط ويخزن ويفهرس ويحفظ ويوزع مواد البحث الرقمي.</message>
-	<message key="xmlui.feed.header">RSS تلقيمات</message>
+    <message key="xmlui.feed.header">RSS تلقيمات</message>
 	<message key="xmlui.feed.logo_title">صورة القناة</message>
 	<message key="xmlui.feed.untitled">غير معنون</message>
 
@@ -295,123 +73,10 @@
 
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
-<!-- discovery facts  -->
-
-  
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">المؤلف</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">المواضيع</message>
-        <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject.lcsh_filter">المواضيع</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.title_filter">العنوان</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">نوع المحتوى</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">تاريخ النشر</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued.year">سنة النشر</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.language.iso_filter">اللغة</message>
-
-
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">مواد أضيفت حديثا</message>
-    
-  <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">عرض المزيد</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0} آخر التقديمات</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">آخر التقديمات </message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">آخر الاضافات</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">النوع</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.publisher_filter">الناشر</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">الأب</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">تجميع النتائج حسب</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">لا يوجد</message>
-  
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">اكتشف</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more"> . . . . . . . . اعرض المزيد </message>
-     <message key="xmlui.Discovery.SimpleSearch.filter.contains">يحتوى</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">يساوي</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">رقم الهوية</message>
-	<message key="xmlui.Discovery.SimpleSearch.filter.notcontains">لا يحتوي</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">لا يساوي</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">رقم هوية غير</message>
-    
-    
-      <message key="xmlui.Discovery.AbstractSearch.startswith"> يبدأ ب</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">او ادخل بعض الحروف:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">خيارات الترتيب:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">وثيق الصلة</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">العنوان تنازليا</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">تاريخ النشر تنازليا</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">العنوان تصاعديا</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">تاريخ النشر تصاعديا</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">نتيجة في الصفحة:</message>
-     <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">أضف عنصر تصفية</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">تطبيق</message>
-        <message key="xmlui.Discovery.AbstractSearch.filters.controls.reset-filters">مسح</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">حذف</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">تصفية جديدة:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">التصفية الحالية:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">أضف عناصر تصفية</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">لا يوجد قيمة لعنصر التصفية</message>
-    
-    
-     <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dc.title_sort">العنوان</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dc.date.issued_dt_sort">تاريخ النشر</message>
-  
-   <message key="xmlui.Discovery.SimpleSearch.filter_help">أدخل بعض النص في الصندوق أدناه لإضافة محددات تصفية لنتائج بحثك، مع الاحاطة بان هذا الصندوق يوفر خدمة تكملة النص التلقائية والتي تحتوي على جميع القيم الموجودة في الحقل المُختار من حقول القائمة المنسدلة على يمين صندوق النص. وفي جميع الأحوال نرجو الاحاطة أنه على الرغم ان خيار البحث في النص الكامل مدعوم ايضاً بخاصية التكملة التلقائية، الا ان هذه القيم سوف تظهر من الحقول التي يمكن اختيارها فقط ولا تشمل كافة القيم في المستودع الرقمي حيث يتم البحث عند اختيارها.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">اضافة تصفية</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.all">كل التسجيلة</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.title">العنوان</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.contributor.author">المؤلف</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.subject">الموضوع</message>
-        <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.subject.lcsh">الموضوع</message>
-     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.language.iso">اللغة</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.description">الوصف</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.date.issued.year">تاريخ النشر</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">المؤلف</message>
-        <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">العنوان</message>
-        <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">الموضوع</message>
-        <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">تاريخ النشر</message>
-
-     <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.language.iso_filter"> اللغة</message>
 
 
 
 
-	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-	<message key="xmlui.Discovery.AbstractSearch.head1_community">نتائج البحث عن المجتمع: {0}</message>
-	<message key="xmlui.Discovery.AbstractSearch.head1_collection">نتائج البحث عن الحاوية: {0}</message>
-	<message key="xmlui.Discovery.AbstractSearch.head1_none">نتائج البحث</message>
-	<message key="xmlui.Discovery.AbstractSearch.result_query">استعلامك "{0}" أنتج {1} نتيجة.</message>
-	<message key="xmlui.Discovery.AbstractSearch.head2">المجتمعات أو الحاويات التي توافق استعلامك</message>
-	<message key="xmlui.Discovery.AbstractSearch.head3">المواد المطابقة لاستفسارك</message>
-	<message key="xmlui.Discovery.AbstractSearch.no_results">لم يسفر البحث عن نتائج.</message>
-	<message key="xmlui.Discovery.AbstractSearch.all_of_dspace">جميع محتويات المستودع</message>
-
-   <message key="xmlui.Discovery.AbstractSearch.sort_by.title">عنوان</message>
-   <message key="xmlui.Discovery.AbstractSearch.sort_by.dateissued">تاريخ النشر</message>
-   <message key="xmlui.Discovery.AbstractSearch.sort_by.dateaccessioned">تاريخ اﻹشتراك</message>
-	<message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">الصلة</message>
-	<message key="xmlui.Discovery.AbstractSearch.sort_by">فرز المواد حسب</message>
-	<message key="xmlui.Discovery.AbstractSearch.order">مرتب</message>
-	<message key="xmlui.Discovery.AbstractSearch.order.asc">تصاعدي</message>
-	<message key="xmlui.Discovery.AbstractSearch.order.desc">تنازلي</message>
-	<message key="xmlui.Discovery.AbstractSearch.rpp">النتائج / الصفحة</message>
-	<message key="xmlui.Discovery.AbstractSearch.type_author">تصفية بواسطة : المؤلف</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject"> تصفية بواسطة : الموضوع</message>
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">عرض المواد  {0}-{1}</message>
-
-	
-    <!-- end my adds (by ahmad maher) -->
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
@@ -434,8 +99,6 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">تنازلي</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">النتائج / الصفحة</message>
 
-	<message key="xmlui.Discovery.AbstractSearch.type_dc.language.iso_filter"> اللغة </message>
-
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">بحث متقدم</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">بحث متقدم</message>
@@ -454,16 +117,10 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">المعرف</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">لغة (أيزو)</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">كلمة مفتاحية</message>
-	
-	<!--discovery box -->
-
-  
 
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">المساهم</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">المنشئ</message>
-
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">الموضوع</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">الوصف</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">العلاقة</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">نوع الـ MIME</message>
@@ -518,6 +175,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">استعرض {0} حسب تاريخ اﻹشتراك {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">استعرض {0} حسب تاريخ اﻹشتراك</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">مواد مسحوبة بالعنوان</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">مواد مسحوبة بالعنوان</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">مواد مسحوبة بتاريخ الإصدار</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">مواد مسحوبة بتاريخ الإصدار</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">مواد مسحوبة بتاريخ التقديم</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">مواد مسحوبة بتاريخ التقديم</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">مواد خاصة بالعنوان</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">مواد خاصة بالعنوان</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">مواد خاصة بتاريخ الإصدار</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">مواد خاصة بتاريخ الإصدار</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">مواد خاصة بتاريخ التقديم</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">مواد خاصة بتاريخ التقديم</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">نطاق البحث</message>
@@ -575,18 +252,14 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">تم ارسال الملاحظات</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">تم استقبال تعليقاتك.</message>
 
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">إبحث في مستودع جامعة طيبة الرقمي</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">أدخل نص في المربع أدناه للبحث في مستودع جامعة طيبة الرقمي.</message>
-
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">عرض المادة</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">هذه المادة تظهر في الحاويات التالية</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">عرض سجل المادة البسيط</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">عرض سجل المادة الكامل</message>
-		
-		<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">لقد تم سحب هذه المادة ولم تعد متاحة .</message>
-		
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">لقد تم سحب هذه المادة ولم تعد متاحة .</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">استعرض</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">جميع محتويات المستودع</message>
@@ -605,11 +278,6 @@
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">بحث</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">نطاق البحث</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">بحث النص الكامل</message>
-	<!-- adds by ahmad maher -->
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.publisher_filter">الناشر </message> 
- <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.subject.lcsh_filter">الموضوع</message> 
- <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.contributor.author_filter">المؤلف</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dc.date.issued.dt_filter">سنة النشر</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">هذا المصدر مقيد</message>
@@ -630,14 +298,13 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">المادة</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">المصدر</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">غير معروف</message>
-	
-		<message key="xmlui.ArtifactBrowser.RestrictedItem.login">الاستمرار إلى شاشة تسجيل الدخول</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">الاستمرار إلى شاشة تسجيل الدخول</message>
 
         <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">هذه المادة مسحوبة</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">المادة المحددة مسحوبة ولم تعد متاحة حاليا.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">المادة المحددة يحظر الوصول إليها وتتطلب اعتمادات لعرضها. الرجاء تسجيل الدخول للوصول إلى المادة.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">لا يوجد لحساب المستخدم الخاص بك الاعتمادات الكافية لعرض هذه المادة. الرجاء الاتصال بإدارة النظام إذا كان لديك أي استفسارات.</message>
-
+        
 	<!-- Authentication messages used at the top of the login page:  -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">المادة مقيدة</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">المادة التي تحاول الوصول اليها هي مادة مقيدة وتحتاج الى تفويض لعرضها. يرجي تسجيل الدخول باﻷسفل للوصول الى المادة.</message>
@@ -655,14 +322,16 @@
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">أرشيف التصدير مقيد</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">أرشيف التصدير الذي تحاول الوصول اليه هو مصدر مقيد ويحتاج الى تفويض لعرضه. يرجى تسجيل الدخول باﻷسفل للوصول الى أرشيف التصدير.</message>
-	
-	
-		<!-- REQUEST COPY -->
+
+
+	<!-- REQUEST COPY -->
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">اطلب نسخة من الوثيقة</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">اطلب نسخة من الوثيقة</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">اطلب نسخة من الوثيقة</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">أدخل البيانات التالية لإرسال طلب نسخة من الوثيقة إلى الشخص صاحب المادة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">مستخدمي هذا النظام، يمكنهم تسجيل الدخول لعرض هذه الوثيقة .</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">تسجيل الدخول</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">أدخل البيانات التالية لإرسال طلب نسخة من الوثيقة إلى الشخص صاحب المادة</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">عنوان البريد الإلكتروني</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">هذا البريد يستخدم لإرسال الوثيقة عليه.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">عنوان البريد الإلكتروني مطلوب</message>
@@ -687,7 +356,9 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">رد مبدئي على الطلب</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> طلب إذن المؤلف</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
@@ -727,17 +398,37 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
-	
-	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-		                EPerson Aspect
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">طلب نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">طلب نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">طلب نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">الاتصال المبدئي مع الطالب،لإعلامه بأن طلبه قيد المعالجة.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">إلى</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">الموضوع</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">الرسالة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">إرسال</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">رجوع</message>
 
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">طلب نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">طلب نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">طال نسخة من الوثيقة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">هذا ما سيتم إرساله بعد ذلك إلى الطالب  (إلى جانب الوثيقة).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">إلى</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">الموضوع</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">الرسالة</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">إرسال</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">رجوع</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">تم إرسال الرد.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">تم إرسال الرد.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">تم إرسال الرد.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">تم إرسال الرد.</message>
+
 
 	
-	
-	
-
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		                EPerson Aspect
@@ -757,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">التسجيل غير متاح</message>
 	<message key="xmlui.EPerson.CannotRegister.head">التسجيل غير متاح</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">اعداد هذا المستودع لمستودع جامعة طيبة الرقمي ﻻ يسمح بالتسجيل في هذا السياق. يرجى الاتصال <a href="../contact">بمشرف الموقع</a> مع اﻷسئلة أو التعليقات.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">اعداد هذا المستودع لمستودع جامعة طيبة الرقمي ﻻ يسمح بالتسجيل في هذا السياق. يرجى الاتصال <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">تحديث الملف الشخصي</message>
@@ -818,7 +509,6 @@
 	<message key="xmlui.EPerson.PasswordLogin.title">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.PasswordLogin.trail">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.PasswordLogin.head1">تسجيل الدخول الى مستودع جامعة طيبة الرقمي</message>
-	<message key="xmlui.EPerson.PasswordLogin.title">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.PasswordLogin.email_address">عنوان البريد الالكتروني</message>
 	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">عنوان البريد الالكتروني و/أو كلمة المرور الموفرة غير صالحة.</message>
 	<message key="xmlui.EPerson.PasswordLogin.password">كلمة المرور</message>
@@ -828,11 +518,10 @@
 	<message key="xmlui.EPerson.PasswordLogin.para1">تسجيل حساب جديد للاشتراك في مجموعات تحديث البريد الالكتروني وتقديم مواد جديدة في مستودع جامعة طيبة الرقمي.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">انقر هنا للتسجيل</message>
 
-	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java --> 
+	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.LDAPLogin.head1">تسجيل الدخول الى مستودع جامعة طيبة الرقمي</message>
-	<message key="xmlui.EPerson.LDAPLogin.title">تسجيل الدخول</message>
 	<message key="xmlui.EPerson.LDAPLogin.username">اسم المستخدم</message>
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">اسم المستخدم و/أو كلمة المرور الموفرة غير صالحة.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">كلمة المرور</message>
@@ -957,13 +646,13 @@
 	<message key="xmlui.Submission.Submissions.title">تقديمات &amp; سير عمل</message>
 	<message key="xmlui.Submission.Submissions.trail">تقديمات</message>
 	<message key="xmlui.Submission.Submissions.head">تقديمات &amp; مهمات سير العمل</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>غير معنون</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">بريد الكتروني: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">مهمات سير العمل</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">هذه المهام هي بنود تنتظر الموافقة قبل اضافتها الى المستودع. يوجد طابورين للمهام، أحدهما للمهام التي اخترتها للقبول واﻵخر للمهام التي لم تتخذ من قبل أحد آخر حتى اﻵن.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">المهام التي تمتلكها</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">مهمة</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">مادة</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">مجموعة</message>
@@ -982,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">يوجد تقديمات مادة غير مكتملة. يمكنك أيضا </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">بدء تقديم آخر</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">العنوان</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">الحاوية</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">المقدم</message>
@@ -1006,7 +695,7 @@
 	<message key="xmlui.Submission.Submissions.status_6">التقديم تحت التحرير</message>
 	<message key="xmlui.Submission.Submissions.status_7">تم حفظ التقديم في اﻷرشيف</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">حالة غير معروفة</message>
-	 <!-- Same transformer, completed submissions section -->
+        <!-- Same transformer, completed submissions section -->
         <message key="xmlui.Submission.Submissions.completed.head">التقديمات المحفوظة</message>
         <message key="xmlui.Submission.Submissions.completed.info">هذه هي تقديماتك الكاملة التي تمت الموافقة عليها في دي سبيس.</message>
         <message key="xmlui.Submission.Submissions.completed.column1">تاريخ القبول</message>
@@ -1015,16 +704,15 @@
         <message key="xmlui.Submission.Submissions.completed.limit">لقد قمنا بإدراج 50 فقط من تقديماتك المحفوظة أعلاه. </message>
         <message key="xmlui.Submission.Submissions.completed.displayall">عرض كل تقديماتي المحفوظة.</message>
 
-
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">أسئلة أولية</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">اوصف</message>
-	<message key="xmlui.Submission.submit.progressbar.access">الوصول</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">حمل</message>
+    <message key="xmlui.Submission.submit.progressbar.access">الوصول</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">حمل</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">راجع</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">موسوعة ابداعية</message>
 	<message key="xmlui.Submission.submit.progressbar.CClicense">CC رخصة</message>
-	<message key="xmlui.Submission.submit.progressbar.license">ترخيص</message>
+    <message key="xmlui.Submission.submit.progressbar.license">ترخيص</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">اكمال</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
@@ -1052,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">عناوين متعددة</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">المادة لها أكثر من عنوان،  على سبيل المثال <i>عنوان مترجم</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">المادة لها أكثر من عنوان،  على سبيل المثال <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">اذا لم يتم اختيار مربع اﻻختيار أعلاه فان العنوان التالي سوف تتم ازالته من المادة:</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">نشر</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">تم نشر المادة أو توزيعها علنا من قبل</message>
@@ -1065,21 +753,21 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">وصف المادة</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">خطأ: نوع حقل غير معروف</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">هذا الحقل مطلوب</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">اﻻسم اﻷخير، على سبيل المثال<i> زاهد</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">اﻻسم اﻷول + "اﻻبن"، على سبيل المثال <i>عبد الرحمن</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">اﻻسم اﻷخير، على سبيل المثال<i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">اﻻسم اﻷول + "اﻻبن"، على سبيل المثال <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">سنة</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">شهر</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">يوم</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">اسم السلسلة</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">رقم الورقة أو التقرير</message>
-	
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">فئات الموضوع</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">فئات الموضوع</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">ترشيح الموضوعات</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">ترشيح</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">الرجاء الانتظار بينما يتم تحميل المفردات المقننة .</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">لقد حدثت مشكلة أثناء تحميل المفردات المقننة , الرجاء المحاولة لاحقا.</message>
-	
+
+
     <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
     <message key="xmlui.Submission.submit.AccessStep.head">إعدادات الوصول</message>
     <message key="xmlui.Submission.submit.AccessStep.access_settings">مرئي لمجموعة من المستخدمين المحددين (لا حاجة إلى التحديد بالنسبة لغير المعروف)</message>
@@ -1087,16 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">حظر الوصول حتى التاريخ المحدد</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">مرئي/محظور</message>
     <message key="xmlui.Submission.submit.AccessStep.name">الاسم</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">اسماً وصفياً قصيراً للسياسة (حتى 30 حرفاً). يمكن أن يتم عرضه للمستخدمين. مثال: "للموظفين-فقط". اختياري لكن يوصى به.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">الوصف</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">السبب</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">سبب الحظر، للاستخدام الداخلي فقط عادةً. اختياري .</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">تأكيد السياسة &amp; إضافة أخرى</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">المجموعات</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">خطأ في تنسيق التاريخ</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">عند تحديد الحظر, التاريخ مطلوب</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">توجد سياسة مطابقة لهذ المجموعة وهذا الإجراء بالفعل.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">قائمة السياسات</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">السياسات المدرجة في هذا القسم تتخطى أي سياسات افتراضية للحاوية التي تقوم بالتقديم لها. إذا كنت ترغب في ضبط حظر لكن الحاوية المستهدفة  تتيح الوصول لأي مستخدم، يجب عليك ضبط سياسة تتيح الوصول  للمجموعة المجهولة فقط منذ تاريخ محدد فصاعداً .</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">لم يتم تنصيب أي سياسات مجموعة لهذه المادة .</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">حظر</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">مادة خاصة</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">في حالة التحديد, لن تكون المادة قابلة للبحث</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">خاص</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">الاسم</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">الإجراء</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">المجموعة</message>
@@ -1105,20 +799,25 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">تحرير</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">حذف</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">التنسيق المقبول: العام, العام-الشهر, العام-الشهر-اليوم</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">الاسم: {0}; الإجراء: {1}, المجموعة: {2}, تاريخ البدء: {3}, تاريخ الانتهاء: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">ستكون المادة قابلة للبحث</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">لن تكون المادة قابلة للبحث</message>
+
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">تحرير السياسة</message>
 
-
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">تحميل الملفات</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">ملف</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">الرجاء ادخال المسار الكامل للملف على جهاز الحاسب الخاص بك المقابل لمادتك، اذا نقرت فوق "استعرض..." سوف تسمح لك نافذة جديدة بتحديد ملف من حاسوبك.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">ينبغي أن تحتوي المادة على ملف واحد على اﻷقل.</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">كانت هناك مشكلة أثناء تحميل ملفك، فاما أن اسم الملف الذي أدخلته غير صحيح. أو كان هناك مشكلة في الشبكة منعت الملف من الوصول لنا بشكل صحيح، أو أو أنك حاولت تحميل تنسيق ملف معلم للنظام الداخلي فقط. يرجى المحاولة مرة أخرى.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">وصف الملف</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>مقال رئيسي</i>"، أو "<i>قراءات بيانات تجربة</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">لم يتم تحميل الملف حيث يبدو أمه يحتوي على فيروس. يرجى الاتصال بإدارة  النظام .</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">لقد حدثت مشكلة تقنية أثناء محاولة مسح الملف بحثا عن الفيروسات. يرجى الاتصال بإدارة النظام.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">وصف الملف</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">تحميل ملف &amp; اضافة آخر</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">الملفات حملت</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">ابتدائي</message>
@@ -1127,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">الحجم</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">الوصف</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">التنسيق</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">غير معروف</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">تنسيق غير معروف</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(مدعوم)</message>
@@ -1136,17 +835,18 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">تحرير</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">تدقيق مجموع الملف:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">ازالة الملفات المحددة</message>
-	
+
+
 
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">تحميل الملف (الملفات)</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">الملف</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">الرجاء إدخال المسار الكامل للملف على حاسبك بما يتماشى مع الملف، إذا قمت بالنقر على "استعراض...", سوف تتيح لك نافذة جديدة اختيار الملف من حاسبك.</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">يجب أن تحتوي المادة ملفا واحدا على الأقل.</message>    
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">يجب أن تحتوي المادة ملفا واحدا على الأقل.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">واجهتنامشكلة عتد تحميل ملفك. اما ان اسم الملف غير صحيح، او ان هناك مشكلة في الشبكة حالت دون وصول ملفك الينا بشكل صحيح او انك حاولت تحميل ملق مُعلم على أنه للاسخدام الداخلي للنظام فقط. نرجو اعادة المحاولة مرة أخرى‬‬ </message>
-	<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error"> تعذر تحميل الملف لأنه ظهر احتوائه على فيروس. نرجو الاتصال بمدير النظام.</message>
-	<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error"> واجهتنا مشكلة فنية خلال محاولة مسح الملف ضد الفيروسوات. نرجو الاتصال بمدير النظام. </message>  
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error"> تعذر تحميل الملف لأنه ظهر احتوائه على فيروس. نرجو الاتصال بمدير النظام.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error"> واجهتنا مشكلة فنية خلال محاولة مسح الملف ضد الفيروسوات. نرجو الاتصال بمدير النظام. </message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">وصف الملف</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">اختياريا, قم بتوفير وصفا مختصرا للملف , على سبيل المثال "<i>مقال رئيسي</i>", or "<i>قراءات بيانات تجريبية</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">اختياريا, قم بتوفير وصفا مختصرا للملف , على سبيل المثال "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">تحميل ملف &amp; إضافة آخر</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">تم تحميل الملف</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">أولي</message>
@@ -1155,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">الحجم</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">الوصف</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">التنسيق</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">غير معروف</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">تنسيق غير معروف</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(مدعوم)</message>
@@ -1166,21 +866,21 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">حذف الملفات المحددة</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">السياسات</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">تحرير الملف</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">ملف</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">وصف الملف</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">اختياريا، قدم وصفا موجزا للمحتوى؛ على سبيل المثال "<i>مقال رئيسي</i>"، أو "<i>قراءات بيانات تجربة</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">حدد تنسيق الملف من القائمة أدناه، على سبيل المثال "<i>Adobe PDF</i>" أو "<i>Microsoft Word</i>." <strong>اذا لم يكن التنسيق موجودا في القائمة</strong>, يرجى وصفه في مربع اﻻدخال أدنى القائمة.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">اختياريا، قدم وصفا موجزا للمحتوى؛ على سبيل المثال "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">حدد تنسيق الملف من القائمة أدناه، على سبيل المثال "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">تنسيق مكتشف</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">تنسيق محدد</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">التنسيق ليس في القائمة</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">اذا كان التنسيق غير موجود في القائمة أعلاه, <strong>اختر "التنسيق ليس في القائمة" أعلاه</strong>وقم بوصف تنسيق الملف في المربع أدناه.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">اذا كان التنسيق غير موجود في القائمة أعلاه, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">تنسيق آخر</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">اسم التطبيق الذي استخدمته في انشاء الملف، ورقم اﻻصدار (علي سبيل المثال "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	
-	<!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">تحرير وصول Bitstream </message>
 
 
@@ -1200,11 +900,10 @@
 	<message key="xmlui.Submission.submit.ReviewStep.known">معروف</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">مدعوم</message>
 
-	
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">لقد حدث خطأ ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">ترخيص عملك</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">إذا كنت ترغب, يمكنك إضافة <a href="http://creativecommons.org/">إبداعية عامة</a> رخصة لمادتك. <strong>تتحكم الرخص الإبداعية العامة في  ما قد يقوم به الأشخاص الذين يقرؤون أعمالك فيما بعد .</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">إذا كنت ترغب, يمكنك إضافة <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">اختر رخصة</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">الاستمرار إلى موقع الإبداعية العامة لتحديد رخصة </message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">نوع الرخصة</message>
@@ -1212,10 +911,9 @@
         <message key="xmlui.Submission.submit.CCLicenseStep.no_license">لا توجد رخص إبداعية عامة</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">يجب أن تنقر التالي لحفظ التغييرات.</message>
 
-
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">رخصة التوزيع</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>هذه آخر خطوة: </strong> لكي يقوم المستودع الرقمي في جامعة طيبة باعادة انتاج وترجمة وتوزيع تقديمك هذا على مستوى العالم، يجب أن توافق على الشروط التالية.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">منح رخصة التوزيع القياسي عن طريق تحديد "أنا أمنح الرخصة"، ثم النقر فوق "اكمال التقديم".</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">اذا كانت لديك أسئلة تتعلق بهذه الرخصة يرجى الاتصال بمشرفي النظام.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">رخصة التوزيع</message>
@@ -1243,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">موافقة على المادة</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">بمجرد تحرير المادة، استخدم هذا الخيار لايداع المادة في اﻷرشيف.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">ايداع في اﻷرشيف</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">اذا قمت بمراجعة المادة ووجدت أنها   <strong>غير</strong> مناسبة للادراج في المجموعة، حدد "رفض". سوف يطلب منك عند ذلك ادخال رسالة توضح لماذا تعد المادة غير مناسبة، واذا كان ينبغي على المقدم تغيير شيئا ثم اعادة التقديم.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">اذا قمت بمراجعة المادة ووجدت أنها   <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">رفض المادة</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">حدد هذا الخيار لتغيير واصفات بيانات المادة.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">تحرير واصفات البيانات</message>
@@ -1267,7 +965,11 @@
 
 	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
 
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">تم اضافة المستخدم بنجاح.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">لقد تمت المهمة بنجاح.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">لقد انتهت العملية بشكل غير متوقع أو فشلت. للمزيد من المعلومات، يرجى الاتصال بمدير الموقع أو التحقق من  سجلات نظامك.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">تم صف المهمة بنجاح.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">لم يتم صف المهمة. حدث خطأ. للمزيد من المعلومات،  يرجى الاتصال بمدير الموقع أو التحقق من سجلات نظامك .</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">تم اضافة المستخدم بنجاح.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">تم تحرير المستخدم بنجاح.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">تم ارسال رسالة بريد الكتروني الى المستخدم تحتوي رمز قد يستخدم في اختيار كلمة مرور جديدة.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">تم حذف المستخدم بنجاح.</message>
@@ -1295,14 +997,6 @@
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">تم تعيين المواد بنجاح.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">تم حذف تعيين المواد.</message>
 
-	<message key="xmlui.administrative.CurateForm.title">نموذج التكريت</message>  
-	<message key="xmlui.administrative.CurateForm.object_label_name">اسم نموذج التكريت</message>
-	<message key="xmlui.administrative.CurateForm.object_hint">ادخل اسم لنموذج التكريت هنا</message>
-	<message key="xmlui.administrative.CurateForm.task_label_name">مهمة و استخدامات النموذج</message>
-	
-	<message key="xmlui.administrative.Navigation.administrative_curation">نموذج التكريت</message>
-	<message key="xmlui.administrative.CurateForm.trail">تدفق نموج التكريت</message>
-	
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">ادارة اﻷشخاص الالكتروني</message>
 
@@ -1330,11 +1024,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">تسجيلات</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">واصفات البيانات</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">التنسيق</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">إدارة المحتوى</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">المواد</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">مواد مسحوبة</message>
     <message key="xmlui.administrative.Navigation.administrative_private">مواد خاصة</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">لوحة الضبط</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">لوحة الضبط</message>
     <message key="xmlui.administrative.Navigation.statistics">احصائيات</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">استيراد كمي (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">استيراد واصفات البيانات</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">مهام التكريت</message>
 
@@ -1369,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">يتم البحث عن اﻷشخاص الالكتروني عن طريق أي تطابق جزئي مع البريد الالكتروني أو الاسم</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">فيما يلي قائمة باﻷشخاص الالكتروني التي تطابق استعلام بحثك. حدد اﻷشخاص الالكتروني الذين ترغب في حذفهم ثم انقر زر الحذف للاستمرار أو انقر فوق البريد الالكتروني أو اسم الشخص الالكتروني لتحريره.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">نتائج البحث</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">المعرف</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">الاسم</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">البريد الالكتروني</message>
@@ -1444,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">بحث عن المجموعات</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">يتم البحث عن المجموعات عن طريق أي تطابق جزئي مع اسمها.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">نتائج البحث</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">المعرف</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">الاسم</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">اﻷعضاء</message>
@@ -1476,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">المعرف</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">الاسم</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">البريد الالكتروني</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">المعرف</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">الاسم</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">الأعضاء</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">الحاوية</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">العرض</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">اﻷعضاء</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">المعرف</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">الاسم</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">البريد الالكتروني</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">مجموعة: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">هذه المجموعة ليس بها أعضاء.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[معلق]</message>
@@ -1521,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">حذف الحقول</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">حذف الحقول</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">تأكيد الحذف</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">هل أنت <b>واثق تماما</b> من رغبتك في حذف هذه الحقول؟ اذا كان هناك مواد تحتوي واصفات بيانات لهذه الحقول فلن يمكن حذفها. عليك التأكد من أنه لا يوجد مواد تستخدم هذه الحقول.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">هل أنت <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">تحذير: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">هذا سوف يسبب خطأ اذا كانت أي مادة تحتوي واصفات بيانات لهذا الحقل.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">المعرف</message>
@@ -1532,24 +1228,12 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">حذف المخطط</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">حذف المخطط</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">تأكيد الحذف</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">هل أنت <b>واثق تماما</b> واثق تماما من رغبتك في حذف هذا المخطط؟ اذا كان هناك مواد تحتوي واصفات بيانات للحقول المحتواه ضمن هذا المخطط فلن يمكن حذف المخطط. عليك التأكد من أنه لا يوجد مواد تحتوي واصفات بيانات من هذا المخطط.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">هل أنت <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">تحذير: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">هذا سوف يسبب خطأ اذا كان هناك أي مادة تحتوي واصفات بيانات ضمن هذا المخطط.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">المعرف</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">مساحة الاسم</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">الاسم</message>
-
-   <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-	<message key="xmlui.administrative.item.MoveItemForm.title">نقل</message>
-	<message key="xmlui.administrative.item.MoveItemForm.trail">نقل</message>
-	<message key="xmlui.administrative.item.MoveItemForm.head1">نقل المادة: {0}</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection">الحاوية</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_help">اختر الحاوية التى تريد نقل هذه المادة لها.</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_default">اختر حاوية...</message>
-	<message key="xmlui.administrative.item.MoveItemForm.submit_move">نقل</message>
-    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">استخدم سياسات</message>
-    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">استخدم سياسات الحاوية التي سيتم النقل لها </message>
-
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">تنسيق دفق البت</message>
@@ -1579,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">مخطط واصفات البيانات: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">هذا هو مخطط واصفات البيانات ل "{0}". يمكنك اضافة أو تحديث حقول واصفات البيانات لهذا المخطط. يمكن تحديد الحقول أيضا ﻷجل الحذف أو نقلها الى مخطط آخر. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">حقول واصفات بيانات المخطط</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">المعرف</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">الحقل</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">ملحوظة النطاق</message>
@@ -1605,14 +1289,13 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.title">تسجيل التنسيق</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">تسجيل تنسيق دفق البت</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">هذه القائمة لتنسيقات دفق البت توفر معلومات عن تنسيقات معروفة ومستوى دعمها. تمكنك تحرير أو اضافة تنسيقات دفق بت جديدة بهذه اﻷداة. التنسيقات المعلمة كداخلية تكون مخفية عن المستخدم وتستخدم ﻷغراض ادارية.</message>
-
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">اضف تنسيق دفق بت جديد</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">المعرف</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">الاسم</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">نوع الـ MIME</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">مستوى الدعم</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>داخلي</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">غير معروف</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">معروف</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">الدعم</message>
@@ -1622,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">تسجيل واصفات البيانات</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">تسجيل واصفات البيانات</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">تسجيل واصفات البيانات يبقي قائمة بجميع حقول واصفات البيانات المتاحة في المستودع. ويمكن تقسيم هذه الحقول بين مخططات متعددة. ومع ذلك فان الدي سبيس يحتاج مخطط دبلن كور المؤهل. ويمكنك توسيع مخطط دبلن كور بحقول اضافية أو اضافة مخططات اضافية الى التسجيل.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">المعرف</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">مساحة الاسم</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">الاسم</message>
@@ -1677,10 +1360,10 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">انقر هنا لاضافة سياسة جديدة. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">اضف</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">معرف</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">الاسم</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">الاسم</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">اجراء</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">مجموعة</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">تاريخ البدء</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">تاريخ البدء</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">تاريخ الانتهاء</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">حذف المحدد</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">تحرير</message>
@@ -1710,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">تحرير السياسة {0} ل {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">لم يتم تحديد مجموعة</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">لم يتم تحديد اجراء</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">المعرف</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">الاسم</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">الاجراءات لهذا المصدر</message>
@@ -1722,6 +1405,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">بحث عن مجموعة</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">بحث</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">تحديد الاجراء</message>
+
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">الاسم</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">الوصف</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">تاريخ البدء</message>
@@ -1731,9 +1415,7 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">تاريخ البدء أكبر من تاريخ الانتهاء</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">التنسيق المقبول: السنة, السنة-الشهر, السنة-الشهر-اليوم</message>
 
-
-
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">مدير السياسة المتقدمة</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">تصاريح متقدمة</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">مدير السياسة المتقدمة</message>
@@ -1751,7 +1433,7 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">الحاوية</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">اضف سياسات</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">مسح سياسات</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">التنسيق المقبول: السنة, السنة-الشهر, السنة-الشهر-اليوم</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">التنسيق المقبول: السنة, السنة-الشهر, السنة-الشهر-اليوم</message>
 
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">الاسم</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">الوصف</message>
@@ -1762,7 +1444,6 @@
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">قم بتحديد مجموعة على الأقل</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">قم بتحديد حاوية على الأقل</message>
 
-
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">أكد حذف السياسة</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">أكد الحذف</message>
@@ -1771,6 +1452,41 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">المعرف</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">الاجراء</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">المجموعة</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">تحديد حاوية</message>
+    <message key="xmlui.administrative.batchimport.general.collection">الحاوية</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">قم بتحديد الحاوية التي تريد تقديم المادة لها .</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">تحديد حاوية...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">تحميل الاستيراد الكمي (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">تحميل الاستيراد الكمي (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">تحميل الاستيراد الكمي (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">تغييرات</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">لم يتم العثور على تغييرات</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">مادة جديدة</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">تم التحميل بنجاح</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">فشل التحميل أو لم يتم تحديد ملف</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">مخطط ميتاداتا غير معروف في الرأس</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">عنصر ميتاداتا غير معروف في الرأس</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">تم الاستيراد بنجاح</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">فشل الاستيراد</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">لم يتم تحديد حاوية مستهدفة</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">تحميل SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">تمت المعالجة بنجاح</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">تم تطبيق التغييرات على المادة</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">تمت الإضافة: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">تمت الإزالة: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">إضافة: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">إزالة: </message>
 
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">المواد</message>
@@ -1792,11 +1508,11 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">ملفات واصفات البيانات</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">الصور المصغرة</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">التراخيص</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">تراخيص الموسوعة الابداعية</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">رخص المشاع الإبداعي</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">ملف</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">الرجاء ادخال اسم الملف على الحاسب الخاص بك المقابل لمادتك. اذا نقرت فوق "استعراض..." سوف تظهر نافذة جديدة حيث يمكنك تحديد موقع الملف على الحاسب الخاص بك.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">الوصف</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>مقال رئيسي</i>", أو "<i>قراءات بيانات تجربة</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">تحميل</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">أنت تحتاج امتياز الاضافة &amp; الكتابة في حزمة واحدة على اﻷقل لكي تتمكن من تحميل دفق بت جديد.</message>
 
@@ -1821,7 +1537,7 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">اللغة</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">سحب</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">اعادة تنصيب</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.submit_private">اجعلها خاصة</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">اجعلها خاصة</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">اجعلها عامة</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
@@ -1832,6 +1548,8 @@
 	<message key="xmlui.administrative.item.MoveItemForm.collection_help">حدد الحاوية التي ترغب في نقل هذه المادة اليها.</message>
 	<message key="xmlui.administrative.item.MoveItemForm.collection_default">حدد حاوية...</message>
 	<message key="xmlui.administrative.item.MoveItemForm.submit_move">نقل</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">استخدم سياسات</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">استخدم سياسات الحاوية التي سيتم النقل لها </message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">تحرير دفق البت</message>
@@ -1842,28 +1560,28 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">نعم</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">لا</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">الوصف</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>مقال رئيسي</i>", أو "<i>قراءات بيانات تجربة</i>"."</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">حدد تنسيق الملف من القائمة أدناه، على سبيل المثال "<i>Adobe PDF</i>" أو "<i>Microsoft Word</i>", <b>أو</b> اذا كان التنسيق غير موجود في القائمة فيرجى وصفه في المربع أدناه.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">اختياريا، قدم وصفا موجزا للملف، على سبيل المثال "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">حدد تنسيق الملف من القائمة أدناه، على سبيل المثال "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">التنسيق المحدد</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">التنسيق ليس في القائمة</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">اذا كان التنسيق غير موجود في القائمة أعلاه <strong>حدد "التنسيق ليس في القائمة" أعلاه</strong> ثم قم بوصفه في الحقل أدناه.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">اذا كان التنسيق غير موجود في القائمة أعلاه <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">تنسيق آخر</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">التطبيق المستخدم في انشاء الملف ورقم الاصدار (على سبيل المثال, "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.name_label">اسم الملف</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">اسم الملف</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">تغيير اسم الملف لهذا ال bitstream. لاحظ أن ذلك سيغير عرض ال bitstream URL, ولكن ستظل الروابط القديمة طالما لم يتم تغيير المعرّف التابع.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">دفق بت المادة</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">دفق بت المادة</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">دفق البت</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">الاسم</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">الوصف</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">تنسيق</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">عرض</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">ترتيب</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>الحزمة: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (ابتدائي) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">عرض</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">تحميل دفق بت جديد</message>
@@ -1874,7 +1592,6 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">السابق:</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">انتقل لأعلى</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">انتقل لأسفل</message>
-
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">واصفات بيانات المادة</message>
@@ -1914,10 +1631,11 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(مشرفي النظام فقط)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(مشرفي الحاوية فقط)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(ليس مسموحا لك أداء هذا الاجراء)</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_private">اجعلها خاصة</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">اجعلها خاصة</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">اجعلها عامة</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">اجعلها خاصة...</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">اجعلها عامة...</message>
+
 
 
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
@@ -1945,8 +1663,8 @@
         <message key="xmlui.administrative.metadataimport.general.new_item">مادة جديدة</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_successful">تحميل ناجح</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_failed">فشل التحميل</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badschema">مخطط واصفات بيانات غير معروف في العنونة</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badelement">مادة واصفات بيانات غير معروف في العنونة</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">مخطط واصفات بيانات غير معروف في العنونة</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">مادة واصفات بيانات غير معروف في العنونة</message>
         <message key="xmlui.administrative.metadataimport.flow.import_successful">استيراد ناجح</message>
         <message key="xmlui.administrative.metadataimport.flow.import_failed">فشل الاستيراد</message>
         <message key="xmlui.administrative.metadataimport.flow.over_limit">عدد من التغييرات يتجاوز الحد اﻷقصى المسموح به. حد التغييرات أو التعديل bulkedit.gui-item-limit في dspace.cfg</message>
@@ -1966,7 +1684,6 @@
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">المادة محذوفة</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">المادة مسحوبة</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">المادة معاد قيدها</message>
-
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">اضافة: </message>
@@ -1991,7 +1708,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">المجموعة: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">هذه هي أداة معين المادة التي تسمح لمشرفي المجموعات بتعيين المواد من مجموعات أخرى الى هذه المجموعة. يمكنك البحث عن مواد من مجموعة اخرى وتعيينها أو استعراض قائمة المواد المعينة حاليا.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">احصائيات</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} من {1}</strong> مادة من هذه المجموعة معينة من مجموعات أخرى</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">بحث</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">بحث المواد</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">استعراض المواد المعينة</message>
@@ -2002,7 +1719,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">بحث المواد</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">بحث المواد المطابقة: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">تعيين المواد المحددة</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">المجموعة</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">المؤلف</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">العنوان</message>
@@ -2012,7 +1729,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">استعراض المواد المعينة</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">استعراض المواد المعينة</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">حذف تعيين المواد المحددة</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">المجموعة</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">المؤلف</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">العنوان</message>
@@ -2051,9 +1768,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">خطوة تحرير واصفات البيانات</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">المقدمون</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">وصول القراءة الافتراضي</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(مديري النظام فقط)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(مجموعة المستودع, مديري الموقع فقط)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(ليس مسموحا لك باعداد هذا)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">أكرت الحاوية: {0}</message>
@@ -2096,7 +1813,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">ازالة الشعار</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">حذف الحاوية</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">حفظ التحديثات</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(مشرفي النظام فقط)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">إنشاء حاوية</message>
@@ -2123,7 +1840,6 @@
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">يجب عليك توفير تعيين معرف للحاوية الهدف.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">المعرف الثابت المستخدم في موفر OAI للدلالة على الحاوية الهدف</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">يجب عليك توفير تعيين معرف للحاوية الهدف.</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">المحتوى الذي يتم حصاده</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">المحتوى الذي يتم حصاده</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">حصاد واصفات البيانات فقط.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">حصاد واصفات البيانات والمراجع الى دفق البت (يتطلب دعم ORE).</message>
@@ -2191,7 +1907,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">مجموعة مرتبطة</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">المشرفين</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(مشرفي النظام فقط)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">أكرتة المجتمع: {0}</message>
@@ -2260,16 +1976,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">الذاكرة المخصصة</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">الذاكرة المستخدمة</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">الذاكرة الحرة</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon معلومات</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon إصدار</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon مسار الذاكرة المخبأة</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon مسار عمل</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">حجم الذاكرة المخبأة الرئيسية ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(مسح الذاكرة المخبأة حالا)</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">حجم الذاكرة المخبأة الثابتة ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">حجم الذاكرة المخبأة العابرة ({0})</message>	
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon معلومات</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon إصدار</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon مسار الذاكرة المخبأة</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon مسار عمل</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">حجم الذاكرة المخبأة الرئيسية ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(مسح الذاكرة المخبأة حالا)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">حجم الذاكرة المخبأة الثابتة ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">حجم الذاكرة المخبأة العابرة ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">اعدادات الدي سبيس</message>
-	<message key="xmlui.administrative.ControlPanel.dspace_version">إصدار دي سبيس</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">إصدار دي سبيس</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">دليل تثبيت الدي سبيس</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">عنوان الدي سبيس اﻷساسي</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">اسم مضيف الدي سبيس</message>
@@ -2285,7 +2001,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">متلقي الملاحظات</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">البريد الالكتروني العام لاشراف الموقع</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">تنبيهات على مستوى النظام</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>تحذير لتحميل اﻷنظمة المتوازنة</strong>: التنبيهات على مستوى النظام تكون فعالة فقط عند العقدة التي تم تنشيطها عندها. عليك التأكد من أن كل عقدة في المجموعة تتلقى أمر التنبيه المنشط.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">رسالة التنبيه</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">سوف يتم تعطيل النظام ﻷجل الصيانة الدورية. يرجى حفظ عملك وتسجيل الخروج.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">العد التنازلي</message>
@@ -2299,7 +2015,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">استمر في السماح بالجلسات المصادقة</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">تقييد المصادقة ولكن الحفاظ على الجلسات الحالية</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">تقييد المصادقة وانهاء الجلسات الحالية</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>ملحوظة:</strong> مشرفي الموقع معفون من ادارة الجلسة.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">تفعيل</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">تعطيل</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">النشاط الحالي ({0} صفحات كحد أقصى)</message>
@@ -2318,7 +2034,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">استخدم علامات التبويب بالأعلى لتحديد المعلومات التي سوف تعرض.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>في {0} دقيقة</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">غير مصرح</message>
@@ -2328,7 +2044,8 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">مشرفي النظام</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">تسجيل الدخول كمستخدم آخر</message>
-	<!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
         <message key="xmlui.administrative.CurateForm.title">مهام اكرتة للنظام</message>
         <message key="xmlui.administrative.CurateForm.trail">مهام الأكرتة</message>
         <message key="xmlui.administrative.CurateForm.object_label_name">هاندل مادة دي سبيس</message>
@@ -2336,7 +2053,6 @@
         <message key="xmlui.administrative.CurateForm.task_label_name">المهام</message>
     <!-- Used by Curate<DSO>Form classes also -->
         <message key="xmlui.administrative.CurateForm.taskgroup_label_name">اختر من المجموعات التالية</message>
-
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2359,10 +2075,10 @@
     <message key="xmlui.statistics.visits.bitstreams">عدد زيارات الملف</message>
     <message key="xmlui.statistics.Navigation.title">احصائيات</message>
     <message key="xmlui.statistics.Navigation.usage.view">عرض إحصائيات الاستخدام</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">عرض احصائيات الاستخدام</message>
     <message key="xmlui.statistics.Navigation.search.view">عرض إحصائيات البحث</message>
     <message key="xmlui.statistics.Navigation.workflow.view">عرض إحصائيات سيرالعمل</message>
     <message key="xmlui.statistics.trail">احصائيات</message>
-    
     <message key="xmlui.statistics.trail-search">إحصائيات البحث</message>
     <message key="xmlui.statistics.trail-workflow">إحصائيات سير العمل</message>
     <message key="xmlui.statistics.workflow.no-results">لا توجد إحصائيات سير عمل متاحة للفترة المحددة.</message>
@@ -2397,7 +2113,6 @@
     <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">قبول/رفض/تحرير مجمع خطوات البيانات الفوقية</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">قبول/رفض/تحرير مجمع خطوات البيانات الفوقية</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">تحرير مجمع خطوات البيانات الفوقية </message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">تحرير خطوات البيانات الفوقية</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">تحرير خطوة البيانات الفوقية</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">مجمع معاينة الهدف</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">معاينة الهدف</message>
@@ -2408,12 +2123,23 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">إجراء معاينة لسمتخدم مفرد</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">عرض احصائيات جوجل التحليلية</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">احصائيات</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">احصائيات جوجل التحليلية</message>
 
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">تاريخ البدء</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">تاريخ الانتهاء</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">تحديث</message>
 
-
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">عروض الصفحة</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">تنزيلات الملف</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2429,12 +2155,13 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			هذا الموقع يستخدم ماناكين، وهي واجهة جديدة للدي سبيس أنشأها مكتبات جامعة A&amp;M تكساس. يمكن تعديل الواجهة على نطاق واسع من خلال سمات ماناكين وثيمات مبنية على XSL.
-			لمزيد من المعلومات يمكنك زيارة
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> و
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
@@ -2479,7 +2206,6 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">التاريخ</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">الناشر</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">الموضوع</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-type">نوع المادة</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">الملفات في هذه المادة</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">الملفات</message>
@@ -2488,7 +2214,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">التنسيق</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">عرض</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">الوصف</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">عرض/<wbr/>افتح</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">عرض/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">لا يوجد ملفات مرتبطة بهذه المادة.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">بايت</message>
@@ -2497,8 +2223,8 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">ملفات الرخصة التالية مرتبطة بهذه المادة:</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
-	
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		عرض الملخص للحاوية غير مستخدم حاليا أو منفذ. يمكن اصلاح هذا عن طريق تجاوز قالب dri2xhtml المسمى collectionSummaryView.
 	</message>
@@ -2518,6 +2244,8 @@
 
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">مواد دبلن كور</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">بنود دبلن كور</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">محظور</message>
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->
@@ -2606,7 +2334,7 @@
 
   <!-- explanatory messages for choice authority confidence values -->
   <message key="xmlui.authority.confidence.description.cf_unset">لم يتم تسجيل ثقة لهذه القيمة</message>
-  <message key="xmlui.authority.confidence.description.cf_novalue"></message>
+  <message key="xmlui.authority.confidence.description.cf_novalue"/>
   <message key="xmlui.authority.confidence.description.cf_rejected">لم يتم ارجاع أي قيمة ثقة معقولة من المرجع</message>
   <message key="xmlui.authority.confidence.description.cf_failed">المرجع يواجه فشل داخلي</message>
   <message key="xmlui.authority.confidence.description.cf_notfound">ﻻ يوجد اجابات مطابقة في المرجع</message>
@@ -2630,6 +2358,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">النتائج @1@ ل @2@ من @3@ ﻷجل "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">فشل تحميل بيانات الاختيار: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">اسم الناشر</message>
@@ -2643,7 +2372,7 @@
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">الاسم الأول ،على سبيل المثال "عبد الرحمن"</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">بحث مؤلف مرجع اسم LC</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">القيمة المحلية "@1@" (ليست في تسمية المرجع)</message>
-  
+
   <!-- mobile theme -->
   <message key="xmlui.mobile.home_mobile">مكتبة العرب الرقمية</message>
   <message key="xmlui.mobile.search_all">بحث الكل</message>
@@ -2717,7 +2446,19 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">إخطار</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">النسخة الأحدث من هذه المادة لا تزال في طور العمل.</message>
 
-    <!-- End Versioning --> 
+    <message key="xmlui.aspect.sherpa.submission.consult">للتحقق من سياسات حقوق الطبع والنشر والإنجاز الذاتي للدورية أو الناشر ‘ يرجى استشارة <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">معلومات الناشر</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">الدورية: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">معلومات الناشر: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO لون: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(المزيد من المعلومات)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">أخضر</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">أزرق</message>
+    <message key="xmlui.aspect.sherpa.submission.white">أبيض</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">أصفر</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
 
     <message key="xmlui.mirage2.itemSummaryView.MetaData">واصفات البيانات</message>
     <message key="xmlui.mirage2.itemSummaryView.Collections">حاويات</message>
@@ -2726,9 +2467,7 @@
     <message key="xmlui.mirage2.discovery.newFilter">اضافة تصفية جديدة</message>
     <message key="xmlui.mirage2.discovery.showAdvancedFilters">عرض التصفية المتقدمة</message>
     <message key="xmlui.mirage2.discovery.hideAdvancedFilters">اخفاء التصفية المتقدمة</message>
-    
 
-   
 
     <message key="xmlui.mirage2.forms.instancedCompositeFields.add">اضافة</message>
     <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">حذف</message>
@@ -2748,347 +2487,4 @@
     <message key="xmlui.mirage2.choice-authority-control.loading">تحميل...</message>
 
     <message key="xmlui.mirage2.item-list.thumbnail">مصغرات</message>
-        <message key="xmlui.mirage2.collections.Taibah University">جامعة طيبة</message>
-
-        <message key="xmlui.Submission.submit.AccessStep.name_help">اسماً وصفياً قصيراً للسياسة (حتى 30 حرفاً). يمكن أن يتم عرضه للمستخدمين. مثال: "للموظفين-فقط". اختياري لكن يوصى به.</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.reason_help">سبب الحظر، للاستخدام الداخلي فقط عادةً. اختياري .</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.policies_help">السياسات المدرجة في هذا القسم تتخطى أي سياسات افتراضية للحاوية التي تقوم بالتقديم لها. إذا كنت ترغب في ضبط حظر لكن الحاوية المستهدفة  تتيح الوصول لأي مستخدم، يجب عليك ضبط سياسة تتيح الوصول  للمجموعة المجهولة فقط منذ تاريخ محدد فصاعداً .</message>
-
-
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.no_policies">لم يتم تنصيب أي سياسات مجموعة لهذه المادة .</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">حظر</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">خاص</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">الاسم: {0}; الإجراء: {1}, المجموعة: {2}, تاريخ البدء: {3}, تاريخ الانتهاء: {4}</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.review_public_item">ستكون المادة قابلة للبحث</message>
-
-
-
-    <message key="xmlui.Submission.submit.AccessStep.review_private_item">لن تكون المادة قابلة للبحث</message>
-
-
-
-	<message key="xmlui.Submission.submit.UploadStep.virus_error">لم يتم تحميل الملف حيث يبدو أمه يحتوي على فيروس. يرجى الاتصال بإدارة  النظام .</message>
-
-
-
-    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">لقد حدثت مشكلة تقنية أثناء محاولة مسح الملف بحثا عن الفيروسات. يرجى الاتصال بإدارة النظام.</message>
-
-
-
-        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">لقد تمت المهمة بنجاح.</message>
-
-        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">لقد انتهت العملية بشكل غير متوقع أو فشلت. للمزيد من المعلومات، يرجى الاتصال بمدير الموقع أو التحقق من  سجلات نظامك.</message>
-
-
-
-        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">تم صف المهمة بنجاح.</message>
-
-        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">لم يتم صف المهمة. حدث خطأ. للمزيد من المعلومات،  يرجى الاتصال بمدير الموقع أو التحقق من سجلات نظامك .</message>
-
-
-
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">رخص المشاع الإبداعي</message>
-
-
-
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">وصول القراءة متاح لـ</message>
-
-
-
-        <message key="xmlui.dri2xhtml.METS-1.0.blocked">محظور</message>
-        
-        
-            <!-- Discovery statements -->
-
-        
-        
-
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">المؤلف</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">نوع المحتوى</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">تاريخ الإصدار</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">تاريخ الإصدار</message>
-
-
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">مضاف حديثاً</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">عرض المزيد</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: التقديمات الحديثة</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">التقديمات الحديثة</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">مضاف حديثاً</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">نوع</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">الناشر</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">أبوي</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">تجميع النتائج بـ</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">لا شيء</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">النشر</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">المجتمع</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">الحاوية</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">سلاسل</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">استعراض بواسطة: المؤلف</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">استعراض بواسطة: العنوان</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">استعراض بواسطة: الموضوع</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">استعراض بواسطة: الخلاصة</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">استعراض بواسطة: السلاسل</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">استعراض بواسطة: الراعي</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">استعراض بواسطة: المعرّف</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">استعراض بواسطة: اللغة (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">استعراض بواسطة: الكلمة المفتاحية</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">استعراض بواسطة: الاسم العلمي</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">استعراض بواسطة: المساهم</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">استعراض بواسطة: المنشئ</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">استعراض بواسطة: الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">استعراض بواسطة: الوصف</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">استعراض بواسطة: العلاقة</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">استعراض بواسطة: Mime-نوع</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">استعراض بواسطة: مساهم آخر</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">استعراض بواسطة: المستشار</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">استعراض بواسطة: القسم</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">استعراض بواسطة: تاريخ الإصدار</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">المؤلف</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">العنوان</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">تاريخ الإصدار</message>
-
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">المواد المعروضة الآن {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">ترشيح بواسطة: المؤلف</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">المؤلف</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">المؤلف</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">ترشيح بواسطة: الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">الموضوع</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">تاريخ الإصدار</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">يبدأ بـ</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">أو قم بإدخال الحروف الأولى:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">فرز الخيارات:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">الصلة</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">العنوان تنازلياً</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">تاريخ الإصدار تنازلياً</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">العنوان تصاعدياً</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">تاريخ الإصدار تصاعدياً</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">النتائج لكل صفحة:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">إضافة مرشح</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">تطبيق</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">إزالة</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">مرشحات جديدة:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">المرشحات الحالية:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">إضافة مرشحات</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">لم يتم العثور على قيم ترشيح</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">اكتشف</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... عرض المزيد</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">بحث</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">بحث</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">المرشحات</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">استخدم المرشحات لتنقيح نتائج البحث .</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">يحتوي على</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">يساوي</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">المعرّف</message>
-	<message key="xmlui.Discovery.SimpleSearch.filter.notcontains">لا يحتوي على</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">لا يساوي</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">ليس معرّف</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">مواد ذات صلة</message>
-    <message key="xmlui.Discovery.RelatedItems.help">عرض الملفات ذات الصلة بواسطة: العنوان، المؤلف، المنشئ والموضوع. </message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">عرض {0} من إجمالي {1} نتيجة للمجتمع: {2}. <span class="searchTime">({3} ثوان)</span></message>
-   	<message key="xmlui.Discovery.AbstractSearch.head1_collection">عرض {0} من إجمالي {1} نتيجة للحاوية: {2}. <span class="searchTime">({3} ثوان)</span></message>
-   	<message key="xmlui.Discovery.AbstractSearch.head1_none">عرض {0} من إجمالي {1} النتائج. <span class="searchTime">({2} ثوان)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">المجتمعات أو الحاويات المطابقة لاستعلامك</message>
-   	<message key="xmlui.Discovery.AbstractSearch.head3">المواد المطابقة لاستعلامك</message>
-
-   	<message key="xmlui.Discovery.SimpleSearch.did_you_mean">هل تعني: </message>
-
-    <!-- Sword Statements -->
-    
-    
-    
-    <!--   Sword Client  -->
-    <message key="xmlui.swordclient.Navigation.context_head">Sword نسخة</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">نسخ المادة إلى مستودع آخر</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">Sword نسخة</message>
-    <message key="xmlui.swordclient.general.main_head">نسخ المادة: {0}</message>
-
-
-    <message key="xmlui.swordclient.SelectTarget.title">Sword هدف نسخة</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">تحديد هدف</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">بديل URL</message>
-    <message key="xmlui.swordclient.SelectTarget.username">اسم المستخدم</message>
-    <message key="xmlui.swordclient.SelectTarget.password">كلمة المرور</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">بالنيابة عن</message>
-
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">غير صحيح URL</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">اسم مستخدم غير صحيح</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">كلمة مرور غير صحيحة</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">لقد حدث خطأ أثناء الحصول على وثيقة خدمة  Sword : {0}</message>
-
-    <message key="xmlui.swordclient.SelectCollection.title"> المستهدفة Sword حاويات</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">تحديد الحاويات</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">الحاوية: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">العنوان: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">السياسة: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">الوسيط: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">أنواع الملفات: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">تنسيقات الباقة: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">الإيداع في هذا الموقع</message>
-
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">هدف الخدمة الفرعية</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">الحصول على وثيقة الخدمة الفرعية</message>
-
-    <message key="xmlui.swordclient.SelectPackagingAction.head">الحاوية:{0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">العنوان: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">السياسة: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">الوسيط:{0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">نوع الملف</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">تنسيق الباقة</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">تم تحديد تنسيق باقة غير مدعوم </message>
-
-    <message key="xmlui.swordclient.DepositAction.success">تم نسخ المادة بنجاح</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">خطأ في تنسيق الباقة</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">هاندل غير صحيح</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">لقد حدث خطأأثناء إنشاء كائن الباقة </message>
-    <message key="xmlui.swordclient.DepositAction.error">لقد حدث خطأ أثناء الإيداع: {0}</message>
-
-    <message key="xmlui.swordclient.SwordResponse.title">Sword رد</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">Sword رد</message>
-
-
-
-
-<!-- WorkFlow Statements -->
-
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">الإجراءات الممكن أدائها لهذه المهمة:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">تعيين هذه المهمة لنفسك.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">أخذ المهمة</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">ترك هذه المهمة في المجمع ليأخذها مستخدم آخر .</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">ترك المهمة</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">العودة إلى النظرة العامة</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">قبول/رفض المهمة </message>
-
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">أداء المهمة: قبول/رفض المادة</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">الإجراءات التي يمكن أدائها على هذه المادة:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">إذا قمت بمراجعة المادة ووجدت أنها<strong>غير</strong> ملائمة للإدراج في الحاوية، قم بتحديد  "رفض".  عندها سيطلب منك إدخال رسالة توضح سبب عدم ملائمة المادة، وما  إذا كان على المقدم تغيير شيء ما وإعادة تقديمها.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">رفض المادة</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">إذا قمت بمراجعة المادة وكانت ملائمة للإدراج في الحاوية، قم بتحديد "موافقة"..</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">الموافقة على المادة</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">أداء مهمة: قبول/رفض/تحرير المادة </message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">الإجراءات التي يمكن أدائها على هذه المادة:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">إذا قمت بمراجعة المادة ووجدت أنها <strong>غير</strong> ملائمة للإدراج في الحاوية، قم بتحديد  "رفض".  عندها سيطلب منك إدخال رسالة توضح سبب عدم ملائمة المادة، وما  إذا كان على المقدم تغيير شيء ما وإعادة تقديمها.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">رفض المادة</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">إذا قمت بمراجعة المادة وكانت ملائمة للإدراج في الحاوية، قم بتحديد "موافقة".</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">الموافقة على المادة</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">تحديد هذا الخيار لتغيير ميتاداتا المادة </message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">تحرير الميتاداتا</message>
-
-    <message key="xmlui.XMLWorkflow.step.unknown">حالة غير معروفة</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">أداء المهمة: تعيين مراجع</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">قم باستخدام مربع البحث الموجود أدناه للبحث عن شخص الكتروني لتعيين مهام المراجعة له.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">البحث عن مراجع</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">البحث عن شخص الكتروني</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">التحديد كمراجع</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">إذا لم تكن الشخص ال مناسب لمعاينة هذه المادة فبإمكانك دائما رفض المهمة عن طريق تحديد زر  "رفض المهمة" .</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">رفض المهمة</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">معاينة التقديم</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">معاينة التقديم</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">إدخال الهدف لهذا التقديم</message>
-
-
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">نظرة عامة على سير العمل</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">نظرة عامة على سير العمل</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">نظرة عامة على سير العمل</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">خطوة</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">المادة</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">الحاوية</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">المقدم</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">إعادة إرسال المواد إلى المقدم</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">حذف المواد</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">لا توجد نتائج</message>
-
-
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">عرض مادة سير العمل: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">عرض مادة سير العمل</message>
-
-    <message key="xmlui.XMLWorkflow.default.reviewstep">قبول/رفض</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">قبول/رفض</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">قبول/رفض</message>
-
-    <message key="xmlui.XMLWorkflow.default.editstep">قبول/تحرير/رفض خطوة</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">قبول/تحرير/رفض</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">قبول/تحرير/رفض</message>
-
-    <message key="xmlui.XMLWorkflow.default.finaleditstep"> القبول/التحرير النهائي</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction"> القبول/التحرير النهائي</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction"> القبول/التحرير النهائي</message>
-
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">خطوة تعيين مراجع</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">تعيين مراجع</message>
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">خطوة معاينة المستخدم المفرد</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">معاينة التقديم</message>
-
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">معاينة الهدف</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">معاينة الهدف</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">معاينة الهدف</message>
-
 </catalogue>

--- a/src/main/webapp/i18n/messages_ar.xml
+++ b/src/main/webapp/i18n/messages_ar.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ar">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_bg.xml
+++ b/src/main/webapp/i18n/messages_bg.xml
@@ -1,20 +1,4 @@
-<?xml version="1.0"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-	
-
--->
-<catalogue xml:lang="bg" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	<!--
-		Translator : Vladislav Zhivkov
-		DSpace 3.0
-		Date : November 5, 2012
-		-->
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -43,6 +27,11 @@
 	<message key="xmlui.general.untitled">Неозаглавен</message>
         <message key="xmlui.general.perform">Изпълняване</message>
         <message key="xmlui.general.queue">Опашка</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
 		Page not found keys
@@ -187,6 +176,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Подреждане {0} по Дата на депозиране</message>
 
 
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Обхват на търсене</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">В цялото хранилище</message>
@@ -242,10 +251,6 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Споделете мнение</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Мнението изпратено</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Вашите коментари са получени.</message>
-
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Търсене в хранилището</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Въведете текст в долната кутия, за търсене в хранилището.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Преглед на Публикация</message>
@@ -318,6 +323,112 @@
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Този експортен архив е ограничен.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Експортният архив, който се опитвате да достигнете е ограничен ресурс и изисква права, за да бъде прегледан. Моля, идентифицирайте се долу, за да достигнете експортния архив.</message>
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		                EPerson Aspect
@@ -337,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Регистрация неразрешена</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Регистрация неразрешена</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Конфигурацията на това хранилище не позволява регистрация в този контекст. Моля, свържете се с <a href="../contact">администратора на сайта</a> за въпроси и коментари.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Конфигурацията на това хранилище не позволява регистрация в този контекст. Моля, свържете се с <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Обновяване на профил</message>
@@ -535,13 +646,13 @@
 	<message key="xmlui.Submission.Submissions.title">Депозирания &amp; Работен поток</message>
 	<message key="xmlui.Submission.Submissions.trail">Депозирания</message>
 	<message key="xmlui.Submission.Submissions.head">Депозирания &amp; задачи на работен поток</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Неозаглавен</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">Емейл: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Задачи на работен поток</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Тези задачи са публикации, които чакат одобрение, преди да бъдат добавени в хранилището. Съществуват две опашки със задачи: една за задачи, които Вие сте приели и друга за задачи, които никой все още не е приел.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Задачи, които притежавате</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Задача</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Публикация</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Колекция</message>
@@ -560,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Има незавършени депозирания на публикации. Вие можете също да </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">започнете друго депозиране.</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Заглавие</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Колекция</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Депозиращ</message>
@@ -597,7 +708,7 @@
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Начални въпроси</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Описване</message>
     <message key="xmlui.Submission.submit.progressbar.access">Достъпи</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Качване</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Качване</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Разлистване</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Криейтив Комънс</message>
 	<message key="xmlui.Submission.submit.progressbar.CClicense">Криейтив Комънс договор</message>
@@ -629,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Няколко заглавия</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Публикацията има повече от едно заглавие, <i>т.е. преведено заглавие</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Публикацията има повече от едно заглавие, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Ако горният чекбокс не е маркиран, тогава следното заглавие ще бъде изтрито от публикацията: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Публикувана</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Публикацията е била публикувана или физически разпространявана преди</message>
@@ -642,8 +753,8 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Описване на публикация</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Грешка: Неизвестен тип на поле</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Това поле е задължително</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Фамилия, <i>т.е. Петров</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Име, <i>т.е. Иван</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Фамилия, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Име, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Година</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Месец</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Ден</message>
@@ -664,16 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Ембарго Достъп до Определена Дата</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Видима/Ембарго</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Име</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Описание</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Причина</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Потвърждаване на Политика &amp; добавяне на нова</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Групи</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Грешен формат на дата</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Когато е избрано Ембарго, датата е задължителна</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Идентична политика за тази група и тази дейност вече е в сила.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Списък с Политики</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Частна Публикация</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Ако бъде избрано, публикацията няма да може да бъде търсена</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Име</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Действие</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Група</message>
@@ -682,12 +799,16 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Редактиране</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Премахване</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Допустим формат: гггг, гггг-мм, гггг-мм-дд</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Редактиране на Политика</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Качване на файл(ове)</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Файл</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Моля, въведете пълния път до файла на Вашия компютър, съответстващ на Вашата публикация. Ако кликнете "Browse...", нов прозорец ще Ви позволи да изберете файл от Вашия компютър.</message>
@@ -696,7 +817,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Файлът не е качен, защото има вероятност да съдържа вирус. Моля, свържете се със системния администратор.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Възникна технически проблем при опита файлът да бъде сканиран за вируси. Моля, свържете се със системния администратор.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Описание на файл</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Възможно е да се въведе кратко описание на файла, например "<i>Основна статия</i>", или "<i>Експериментално четене на данни</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Възможно е да се въведе кратко описание на файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Качване на файл &amp; добавяне на друг</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Качени файлове</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Основен</message>
@@ -705,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Размер</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Описание</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Формат</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Неизвестен</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">Неизвестен формат</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Поддържан)</message>
@@ -725,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Файлът не е качен, тъй като изглежда че съдържа вирус. Моля, свържете се със системния администратор.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Възникна технически проблем, докато файлът се сканираше за вируси. Моля, свържете се с администратора на системата.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Описание на Файл</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Допълнително осигирете кратко описание на файла, например "<i>Основна статия</i>" или "<i>Експериментални данни</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Допълнително осигирете кратко описание на файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Качване на файл &amp; добавяне на друг</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">качени Файлове</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Основен</message>
@@ -734,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Размер</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Описание</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Формат</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Неизвестен</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">неизвестен формат</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Поддържан)</message>
@@ -750,19 +871,19 @@
 	<message key="xmlui.Submission.submit.EditFileStep.head">Редактиране на файл</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Файл</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Описание на файл</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Възможно е да се въведе кратко описание на файла, например "<i>Основна статия</i>", или "<i>Експериментално четене на данни</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Изберете формат на файла от списъка, например "<i>Adobe PDF</i>" или "<i>Microsoft Word</i>." <strong>Ако форматът не е в списъка</strong>, моля, опишете го в полето под списъка.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Възможно е да се въведе кратко описание на файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Изберете формат на файла от списъка, например "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Разпознат формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Избран формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Форматът не е в списъка</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Ако форматът не е в горния списък, <strong>изберете отгоре "Форматът не е в списъка"</strong> и опишете формата на файла в долното поле.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Ако форматът не е в горния списък, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Друг формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Името на използваното приложение за създаване на файла и номерът на версията (например, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Редактиране на достъпите до битов поток</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Преглед на депозиране</message>
 	<message key="xmlui.Submission.submit.ReviewStep.yes">Да</message>
@@ -782,7 +903,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Грешка ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Лицензирайте Вашия труд</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Ако желаете, можете да добавите <a href="http://creativecommons.org/">Криейтив Комънс</a> договор към Вашата публикация. <strong>Криейтив Комънс договорът определя какво могат да правят с Вашия труд тези, които го четат.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Ако желаете, можете да добавите <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Избиране на договор</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Посетете уеб сайта на Криейтив Комънс, за да изберете договор</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Тип на договора</message>
@@ -792,7 +913,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Договор за разпространение</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Една последна стъпка:</strong> За да може DSpace да възпроизвежда, превежда и разпрострянява Вашата публикация по целия свят, Вие трябва да се съгласите със следните условия.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Предоставете стандартен договор за разпространение, като изберете 'Аз предоставям договора'; и след това кликнете 'Завършване на депозиране'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Ако имате въпроси относно договора, моля свържете се със системните администратори.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Договор за разпространение</message>
@@ -820,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Одобряване на публикация</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">След редактиране на публикацията, използвайте тази опция за предаване на публикацията на съхранение в архива.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Предаване на съхранение в архива</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Ако сте прегледали публикацията и тя <strong>не</strong> е подходяща за включване в колекцията, изберете "Отхвърляне". Вие ще бъдете попитан(а) да въведете обяснение, защо публикацията е неподходяща и дали депозиращият трябва да промени нещо и да депозира отново.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Ако сте прегледали публикацията и тя <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Отхвърляне на публикация</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Изберете тази опция, за да редактирате метаданните на публикацията.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Редактиране на метаданните</message>
@@ -903,11 +1024,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Регистри</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Метаданни</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Формат</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Публикации</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Оттеглени публикации</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Частни Публикации</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Контролен панел</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Контролен панел</message>
     <message key="xmlui.administrative.Navigation.statistics">Статистики</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Импорт на метаданни</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">Библиотечни задачи</message>
 
@@ -942,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Е-потребителите се търсят по частично съответствие на емейл или име</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">По-долу е списъка с Е-потребителите, които съответстват на Вашата заявка за търсене. Изберете Е-потребителите, които искате да изтриете и кликнете бутон изтриване, за да продължите или клинете върху емейла или името на Е-потребителя, за да го редактирате.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Резултати от търсенето</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Име</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Емейл</message>
@@ -1017,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Търсене на групи</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Групите се търсят чрез частично съответствие на тяхното име</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Резултати от търсене</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Име</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Членове</message>
@@ -1049,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Име</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Емейл</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Име</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Членове</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Колекция</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">изглед</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Членове</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Име</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Емейл</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">група: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Тази група няма членове.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[висящ]</message>
@@ -1094,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Изтриване на полета</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Изтриване на полета</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Потвърждаване изтриване</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1"><b>Абсолютно</b> сигурни ли сте, че искате да изтриете тези полета? Ако някоя публикация съдържа метаданни за тези полета, полетата няма да могат да бъдат изтрити. Трябва да се убедите, че нито една публикация не използва тези полета.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1"><b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ПРЕДУПРЕЖДЕНИЕ</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Ще възникне грешка, ако някоя публикация съдържа метаданни за тези полета.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1105,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Изтриване на схема</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Изтриване на схема</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Потвърждаване изтриване</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1"><b>Абсолютно</b> сигурни ли сте, че искате да изтриете тази схема? Ако някоя публикация съдържа метаданни за полета от тази схема, схемата няма да може да бъде изтрита. Трябва да се убедите, че нито една публикация не съдържа метаданни от тази схема.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1"><b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ПРЕДУПРЕЖДЕНИЕ</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Ще възникне грешка, ако някоя публикация съдържа метаданни от тази схема.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1140,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Схема на метаданни: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Това е схемата на метаданни за "{0}". Можете да добавяте нови или да обновявате съществуващите полета метаданни на тази схема. Освен това полета могат да бъдат избирани за изтриване или за преместване в друга схема. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Полета метаданни на схема</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Поле</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Бележка за обхват</message>
@@ -1167,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Регистър на формати на битов поток</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Този списък на формати на битов поток дава информация за известните формати и тяхното ниво на поддръжка. С помощта на този инструмент можете да добавяте нови формати на битов поток. Маркираните като 'вътрешни' формати са скрити за потребителя и се използват за административни цели.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Добавяне на нов формат на битов поток</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Име</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME тип</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Ниво на поддръжка</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>вътрешен</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Неизвестен</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Известен</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Поддръжка</message>
@@ -1182,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Регистър метаданни</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Регистър метаданни</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Регистърът метаданни съдържа списък на всички полета метаданни, налични в хранилището. Тези полета могат да бъдат разделени в няколко схеми. Въпреки това, DSpace изисква квалифицирана Dublin Core схема. Вие можете да разширите Dublin Core схемата с допълнителни полета или да добавите нови схеми в регистъра.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Пространство на имена</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Име</message>
@@ -1270,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Редактиране на политика {0} за {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Не е избрана група</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Не е избрано действие</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Име</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Действия за този ресурс</message>
@@ -1283,7 +1406,7 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Търсене</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Избиране на действие</message>
 
-	<message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Име</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Име</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Описание</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Начална Дата</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Крайна Дата</message>
@@ -1327,6 +1450,41 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Действие</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Група</message>
 
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Публикации</message>
 	<message key="xmlui.administrative.item.general.template_head">Редактиране на публикация шаблон за колекция: {0}</message>
@@ -1351,7 +1509,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Файл</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Моля, въведете името на файла на Вашия компютър, съответстващ на Вашата публикация. Ако кликнете "Разлистване...", ще се покаже нов прозорец, в който ще можете да намерите и изберете файла от Вашия компютър.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Описание</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Допълнително, добавете кратко описание на файла, например "<i>Главна статия</i>", или "<i>Анализ на данни от експерименти</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Допълнително, добавете кратко описание на файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Качване</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Вие се нуждаете от права за ДОБАВЯНЕ &amp; ПИСАНЕ в поне един комплект, за да можете да качвате нови битови потоци.</message>
 
@@ -1399,11 +1557,11 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">да</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">не</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Описание</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Допълнително, добавете кратко описание на файла, например "<i>Главна статия</i>", или "<i>Анализ на данни от експерименти</i>".</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Избиране на формат на файл от долния списък, например "<i>Adobe PDF</i>" или "<i>Microsoft Word</i>", <b>или</b> ако форматът не е в списъка, моля опишете го в долното поле.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Допълнително, добавете кратко описание на файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Избиране на формат на файл от долния списък, например "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Избиран формат</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Форматът не е в списъка</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Ако форматът не е в горния списък, <strong>изберете "Форматът не е в списъка" горе</strong> и го опишете в долното поле.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Ако форматът не е в горния списък, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Друг формат</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Приложението, използвано за създаване на файла и номерът на версията (например, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Име на файл</message>
@@ -1413,14 +1571,14 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Битови потоци на публикация</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Битови потоци на публикация</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Битови потоци</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Име</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Описание</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Формат</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Изглед</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Подреждане</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Комплект: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (основен) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">изглед</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Качване на нов битов поток</message>
@@ -1547,7 +1705,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Колекция: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Това е инструмент за съпоставяне, което позволява администраторите на колекции да съпоставят публикации от други колекции в тази колекция. Вие можете да търсите публикации от други колекции и да ги съпоставяте или да преглеждате списъка с текущо съпоставени публикации.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Статистики</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} от {1}</strong> публикации в тази колекция са съпоставени от други колекции</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Търсене</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Търсенр на публикации</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Разлистване на съпоставени публикации</message>
@@ -1558,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Търсене на публикации</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Търсене на публикации подобни на: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Съпоставяне на избраните публикации</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Колекция</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Автор</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Заглавие</message>
@@ -1568,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Разлистване на съпоставени публикации</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Подреждане на съпоставени публикации</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Изваждане на избраните съпоставени публикации</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Колекция</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Автор</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Заглавие</message>
@@ -1607,9 +1765,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Стъпка редактиране на метаданни</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Депозиращи</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Права за четене по подразбиране</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(само системни администратори)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Група на ниво хранилище, само за системни администратори)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(Вие нямате права да конфигурирате това)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Обслужване на колекция: {0}</message>
@@ -1652,7 +1810,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Премахване на лого</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Изтриване на колекция</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Запазване на обновленията</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(само системен администратор)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Създаване на колекция</message>
@@ -1746,7 +1904,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Асоциирана група</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Администратори</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(само системни администратори)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Обслужване на общност: {0}</message>
@@ -1840,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Обратна връзка на получателя</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Основен емейл за администриране на сайта</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Системни аларми</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Преудпреждение за системи с балансиране на натоварването</strong>: Системните аларми са ефективни само за възела, в който са активирани. Трябва да се убедите, че всеки възел в множеството получава команда за активиране на аларми.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Аларма</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Системата ще бъде спряна за регулярна поддръжка. Моля, запазете своята работа и излезте.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Обратно броене</message>
@@ -1854,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Продължаване на разрешаване на идентификационни сесии</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Ограничаване на идентифицирането, но запазване на текущите сесии</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Ограничаване на идентифицирането и спиране на текущите сесии</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Бележка:</strong> Администраторите на сайта са изключени от управлението на сесии.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Активиране</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Деактивиране</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Текуща активност ({0} страници максимум)</message>
@@ -1873,7 +2031,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">От горните табове изберете каква информация да се показва</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>За {0} минути</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Не е разрешено</message>
@@ -1914,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Посещения на файл</message>
     <message key="xmlui.statistics.Navigation.title">Статистики</message>
     <message key="xmlui.statistics.Navigation.usage.view">Разглеждане на Статистики на Използване</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Разглеждане на Статистики на Търсене</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Разглеждане на Статистики на Работен поток</message>
     <message key="xmlui.statistics.trail">Статистики</message>
@@ -1961,10 +2120,23 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Резензия на Действие на Единичен Потребител</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
 
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1980,13 +2152,13 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Този уеб сайт използва Manakin, нов фронт енд за DSpace, създаден от Texas A&amp;M University
-			Libraries. Интерфейсът може да бъде модифициран чрез Manakin Aspects и XSL Теми.
-			За повече информация посетете
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> и
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
@@ -2042,7 +2214,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Формат</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Изглед</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Описание</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Изглед/<wbr/>Отваряне</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Изглед/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Няма асоциирани файлове към тази публикация.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">байтове</message>
@@ -2077,6 +2249,8 @@
 
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core елементи</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core термини</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->
@@ -2189,6 +2363,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Резултати @1@ до @2@ от @3@ за "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Неуспешно зареждане на избрани данни: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Име на издател</message>
@@ -2203,7 +2378,7 @@
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Търсене на име в имена на автори в библиотеката на конгреса</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Локална стойност "@1@" (не в имена на автори)</message>
 
-    <!-- mobile theme -->
+  <!-- mobile theme -->
   <message key="xmlui.mobile.home_mobile">DSpace Мобилен</message>
   <message key="xmlui.mobile.search_all">Търсене Всички</message>
   <message key="xmlui.mobile.browse_all">Разлистване Всичко по</message>
@@ -2276,6 +2451,45 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Предупреждение</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">По-нова версия на тази публикация е в работния поток.</message>
 
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_bg.xml
+++ b/src/main/webapp/i18n/messages_bg.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="bg">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_ca.xml
+++ b/src/main/webapp/i18n/messages_ca.xml
@@ -1,1241 +1,2479 @@
-<?xml version="1.0"?>
-<!--Translated by Francisco Javier Herrero Vicente (fherrero@uji.es) at Universitat Jaume I de Castellon (http://www.uji.es/)-->
-<catalogue xml:lang="ca" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-  <message key="au.edu.mq.melcoe.mams.dspace.eperson.ShibAuthentication.title">Autenticació amb Shibboleth</message>
-  <message key="org.dspace.eperson.LDAPAuthentication.title">Autenticació amb LDAP</message>
-  <message key="org.dspace.eperson.PasswordAuthentication.title">Autenticació amb contrasenya</message>
-  <message key="org.dspace.eperson.X509Authentication.title">Autenticació amb certificat web</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tot DSpace</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultats de la cerca en la col·lecció {0}</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultats de la cerca en la comunitat {0}</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultats de la cerca</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunitats o col·leccions que coincideixen amb la vostra consulta</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Elements que coincideixen amb la vostra consulta</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La cerca no ha donat cap resultat.</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.order">en ordre</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendent</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendent</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">La vostra consulta "{0}" ha produït {1} resultat(s).</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultats/pàgina</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordena els elements per</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data d'enviament</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data de publicació</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinència</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">títol</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunció</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Cerca avançada</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Cerca</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Àmbit de la cerca</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiteu la vostra cerca a una comunitat o col·lecció.</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipus de cerca</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Cerca avançada</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Cerca avançada</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Text complet</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resum</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Assessor</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor/a</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Col·laborador/a</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Autor/a</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departament</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripció</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Mot clau</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Llengua (ISO)</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipus MIME</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Altres col·laboradors</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relació</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sèrie</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Matèria</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Títol</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Cerca avançada</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tot DSpace</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autors</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Dates</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títols</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Cerca de text complet:</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Visualitza per</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Enviaments recents</message>
-  <message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Àmbit de la cerca</message>
-  <message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunitats a DSpace</message>
-  <message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Seleccioneu una comunitat per visualitzar-ne les col·leccions.</message>
-  <message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Llista de comunitats</message>
-  <message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Llista de comunitats</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Cerca avançada</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Tot DSpace</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autors</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Dates</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títols</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Cerca de text complet:</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Visualitza per</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Enviaments recents</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Col·leccions en aquesta comunitat</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunitats dins d'aquesta comunitat</message>
-  <message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Àmbit de la cerca</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nom de l'autor/a</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Tots</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Seleccioneu el mes)</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Seleccioneu l'any)</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autors/Element:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Salta a un punt de l'índex:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O introduïu un any:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Visualitza els elements que siguen d'un any determinat.</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Ordre:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultats:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordena per:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introduïu les primeres lletres:</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Visualitza els elements que comencen amb aquestes lletres</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendent</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendent</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data d'enviament</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data de publicació</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">títol</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Matèria</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Visualitzant {0} per data d'enviament {1}</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Visualitzant {0} per data de publicació {1}</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Visualitzant {0} per títol {1}</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Visualitza {0} per autor {1}</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Visualitza {0} per matèria {1}</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Visualitzant {0} per data d'enviament</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Visualitzant {0} per data de publicació</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Visualitzant {0} per títol</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Visualitza {0} per autor</message>
-  <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Visualitza {0} per matèria</message>
-  <message key="xmlui.ArtifactBrowser.Contact.email">Correu electrònic</message>
-  <message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulari electrònic</message>
-  <message key="xmlui.ArtifactBrowser.Contact.feedback_link">Informació</message>
-  <message key="xmlui.ArtifactBrowser.Contact.head">Poseu-vos en contacte amb nosaltres</message>
-  <message key="xmlui.ArtifactBrowser.Contact.para1">Podeu posar-vos en contacte amb {0} administradors a:</message>
-  <message key="xmlui.ArtifactBrowser.Contact.title">Poseu-vos en contacte amb nosaltres</message>
-  <message key="xmlui.ArtifactBrowser.Contact.trail">Poseu-vos en contacte amb nosaltres</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentaris</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.email">Correu electrònic</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Utilitzarem aquesta adreça per respondre als vostres comentaris.</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.head">Suggeriments</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gràcies pels suggeriments sobre el sistema DSpace.</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.email">Correu</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Envieu-nos informació</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.title">Suggeriments</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Suggeriments</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackSent.head">Suggeriments enviats</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Hem rebut els vostres comentaris.</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackSent.title">Suggeriments</message>
-  <message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Suggeriments</message>
-  <message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Cerca a DSpace</message>
-  <message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Introduïu algun mot en la casella de sota per fer una cerca a DSpace.</message>
-  <message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Aquest element apareix en la col·lecció o col·leccions següent(s)</message>
-  <message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostra el registre complet de l'element</message>
-  <message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostra el registre parcial de l'element</message>
-  <message key="xmlui.ArtifactBrowser.ItemViewer.trail">Visualitza element</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autor/a</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Per data d'enviament</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Per data de publicació</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Matèries</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títols</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunitats i col·leccions</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tot DSpace</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.head_browse">Visualitza</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Aquesta col·lecció</message>
-  <message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Aquesta comunitat</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'element és restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">L'element al qual voleu accedir és un element restringit i per veure'l heu de tenir permisos. Identifiqueu-vos a sota per accedir a l'element.</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Aquest document és restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Aquesta col·lecció és restringida</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Aquesta comunitat és restringida</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Aquest element és restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Aquest recurs és restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No teniu permisos suficients per accedir al document restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No teniu permisos suficients per accedir a la comunitat restringida</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No teniu permisos suficients per accedir a la comunitat restringida</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No teniu permisos suficients per accedir a l'element restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No teniu permisos suficients per accedir al recurs restringit.</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.title">Aquest recurs és restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringit</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">document</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">col·lecció</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunitat</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">element</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurs</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconegut</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Cerca de text complet</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.head">Cerca</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Àmbit de la cerca</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.title">Cerca</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Cerca</message>
-  <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes mensuals</message>
-  <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Ara mateix no hi ha cap informe disponible per a aquest servei. Comproveu si n'hi ha algun més endavant.</message>
-  <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">No hi ha informes disponibles</message>
-  <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resum estadístic</message>
-  <message key="xmlui.BitstreamReader.auth_header">El fitxer és restringit</message>
-  <message key="xmlui.BitstreamReader.auth_message">El fitxer al qual voleu accedir és un element restringit i per veure'l heu de tenir permisos. Identifiqueu-vos a sota per accedir al fitxer.</message>
-  <message key="xmlui.EPerson.CannotRegister.head">Registre no disponible</message>
-  <message key="xmlui.EPerson.CannotRegister.para1">La configuració d'aquest repositori DSpace no permet registrar-vos-hi en aquest context. Poseu-vos en contacte amb &lt;a href="../contact"&gt;administrador&lt;/a&gt;</message>
-  <message key="xmlui.EPerson.CannotRegister.title">Registre no disponible</message>
-  <message key="xmlui.EPerson.EPersonUtils.forgot_finished">Finalitzat</message>
-  <message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restaura contrasenya</message>
-  <message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Comproveu l'adreça electrònica</message>
-  <message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crea perfil</message>
-  <message key="xmlui.EPerson.EPersonUtils.register_finished">Finalitzat</message>
-  <message key="xmlui.EPerson.EPersonUtils.register_verify_email">Comproveu l'adreça electrònica</message>
-  <message key="xmlui.EPerson.EditProfile.confirm_password">Torneu a escriure-la per confirmar-la</message>
-  <message key="xmlui.EPerson.EditProfile.create_password_instructions">Introduïu una nova contrasenya en la casella de sota i confirmeu-la tornant-la a escriure en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
-  <message key="xmlui.EPerson.EditProfile.email_address">Adreça de correu electrònic</message>
-  <message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscripcions per correu electrònic</message>
-  <message key="xmlui.EPerson.EditProfile.error_invalid_password">Trieu una contrasenya d'almenys sis caràcters</message>
-  <message key="xmlui.EPerson.EditProfile.error_required">Aquest camp és obligatori</message>
-  <message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
-  <message key="xmlui.EPerson.EditProfile.first_name">Nom</message>
-  <message key="xmlui.EPerson.EditProfile.head_auth">Grups d'autorització als quals pertanyeu</message>
-  <message key="xmlui.EPerson.EditProfile.head_create">Crea perfil</message>
-  <message key="xmlui.EPerson.EditProfile.head_identify">Identifica</message>
-  <message key="xmlui.EPerson.EditProfile.head_security">Seguretat</message>
-  <message key="xmlui.EPerson.EditProfile.head_update">Actualitza perfil</message>
-  <message key="xmlui.EPerson.EditProfile.last_name">Cognoms</message>
-  <message key="xmlui.EPerson.EditProfile.password">Contrasenya</message>
-  <message key="xmlui.EPerson.EditProfile.select_collection">(Seleccioneu col·lecció)</message>
-  <message key="xmlui.EPerson.EditProfile.submit_create">Actualitza perfil</message>
-  <message key="xmlui.EPerson.EditProfile.submit_update">Completa el registre</message>
-  <message key="xmlui.EPerson.EditProfile.subscriptions">Subscripcions</message>
-  <message key="xmlui.EPerson.EditProfile.subscriptions_help">Podeu subscriure-us a col·leccions per rebre missatges diaris de correu electrònic sobre nous elements incorporats. Podeu subscriure-us a tantes col·leccions com desitgeu. Una alternativa als missatges diaris de correu electrònic és l'ús de canals RSS disponibles per a totes les col·leccions.</message>
-  <message key="xmlui.EPerson.EditProfile.telephone">Telèfon</message>
-  <message key="xmlui.EPerson.EditProfile.title_create">Crea perfil</message>
-  <message key="xmlui.EPerson.EditProfile.title_update">Actualitza perfil</message>
-  <message key="xmlui.EPerson.EditProfile.trail_update">Actualitza perfil</message>
-  <message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalment, podeu introduir una nova contrasenya en la casella de sota, que haureu de confirmar tornant a escriure-la en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
-  <message key="xmlui.EPerson.FailedAuthentication.BadArgs">L'autenticació no ha sigut possible perquè els arguments rebuts són no vàlids.</message>
-  <message key="xmlui.EPerson.FailedAuthentication.BadCreds">Les credencials facilitades no són vàlides.</message>
-  <message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No s'ha trobat cap usuari amb les credencials facilitades.</message>
-  <message key="xmlui.EPerson.FailedAuthentication.h1">L'autenticació ha fallat</message>
-  <message key="xmlui.EPerson.FailedAuthentication.title">L'autenticació ha fallat</message>
-  <message key="xmlui.EPerson.FailedAuthentication.trail">L'autenticació ha fallat</message>
-  <message key="xmlui.EPerson.ForgotPasswordFinished.head">Restauració de contrasenya</message>
-  <message key="xmlui.EPerson.ForgotPasswordFinished.para1">S'ha restaurat la vostra contrasenya.</message>
-  <message key="xmlui.EPerson.ForgotPasswordFinished.title">Restauració de contrasenya</message>
-  <message key="xmlui.EPerson.InvalidToken.head">Cadena no vàlida</message>
-  <message key="xmlui.EPerson.InvalidToken.para1">La URL que heu facilitat no és vàlida. La URL pot haver-se dividit en diverses línies en el vostre client de correu, com per exemple així:</message>
-  <message key="xmlui.EPerson.InvalidToken.para2">Si és així, copieu la URL completa i enganxeu-la directament en la barra d'adreces del vostre navegador, en comptes de fer simplement clic en l'enllaç. La barra d'adreces hauria de mostrar alguna cosa com ara:</message>
-  <message key="xmlui.EPerson.InvalidToken.title">Cadena no vàlida</message>
-  <message key="xmlui.EPerson.InvalidToken.trail">Cadena no vàlida</message>
-  <message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nom d'usuari o la contrasenya introduïdes no són vàlides.</message>
-  <message key="xmlui.EPerson.LDAPLogin.head1">Identifiqueu-vos a DSpace</message>
-  <message key="xmlui.EPerson.LDAPLogin.password">Contrasenya</message>
-  <message key="xmlui.EPerson.LDAPLogin.submit">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.LDAPLogin.title">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.LDAPLogin.trail">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.LDAPLogin.username">Nom d'usuari</message>
-  <message key="xmlui.EPerson.LoginChooser.head1">Escolliu un mètode d'accés</message>
-  <message key="xmlui.EPerson.LoginChooser.para1">Accediu per mitjà de:</message>
-  <message key="xmlui.EPerson.LoginChooser.title">Escolliu un mètode d'accés</message>
-  <message key="xmlui.EPerson.LoginChooser.trail">Escolliu nom d'usuari</message>
-  <message key="xmlui.EPerson.Navigation.login">Entra</message>
-  <message key="xmlui.EPerson.Navigation.logout">Ix</message>
-  <message key="xmlui.EPerson.Navigation.my_account">El meu compte</message>
-  <message key="xmlui.EPerson.Navigation.profile">Perfil</message>
-  <message key="xmlui.EPerson.Navigation.register">Registre</message>
-  <message key="xmlui.EPerson.PasswordLogin.email_address">Adreça electrònica</message>
-  <message key="xmlui.EPerson.PasswordLogin.error_bad_login">L'adreça electrònica o la contrasenya introduïdes no són vàlides.</message>
-  <message key="xmlui.EPerson.PasswordLogin.forgot_link">Heu oblidat la vostra contrasenya?</message>
-  <message key="xmlui.EPerson.PasswordLogin.head1">Autentiqueu-vos a DSpace</message>
-  <message key="xmlui.EPerson.PasswordLogin.head2">Registre com a usuari nou</message>
-  <message key="xmlui.EPerson.PasswordLogin.para1">Registreu un compte per subscriure'm a col·leccions per a actualitzacions per correu electrònic i enviament de nous elements a DSpace.</message>
-  <message key="xmlui.EPerson.PasswordLogin.password">Contrasenya</message>
-  <message key="xmlui.EPerson.PasswordLogin.register_link">Feu clic ací per registrar-vos.</message>
-  <message key="xmlui.EPerson.PasswordLogin.submit">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.PasswordLogin.title">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.PasswordLogin.trail">Identifiqueu-vos</message>
-  <message key="xmlui.EPerson.ProfileUpdated.head">Perfil actualitzat</message>
-  <message key="xmlui.EPerson.ProfileUpdated.para1">La informació del vostre perfil ha estat actualitzada.</message>
-  <message key="xmlui.EPerson.ProfileUpdated.title">Perfil actualitzat</message>
-  <message key="xmlui.EPerson.ProfileUpdated.trail">Actualitza perfil</message>
-  <message key="xmlui.EPerson.RegistrationFinished.head">El registre ha finalitzat</message>
-  <message key="xmlui.EPerson.RegistrationFinished.para1">Ara ja us heu registrat per usar el sistema DSpace. Podeu subscriure-us a col·leccions per rebre actualitzacions per correu electrònic sobre nous elements.</message>
-  <message key="xmlui.EPerson.RegistrationFinished.title">El registre ha finalitzat</message>
-  <message key="xmlui.EPerson.ResetPassword.confirm_password">Torneu a escriure-la per confirmar-la</message>
-  <message key="xmlui.EPerson.ResetPassword.email_address">Adreça electrònica</message>
-  <message key="xmlui.EPerson.ResetPassword.error_invalid_password">Trieu una contrasenya d'almenys 6 caràcters</message>
-  <message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
-  <message key="xmlui.EPerson.ResetPassword.head">Restaura contrasenya</message>
-  <message key="xmlui.EPerson.ResetPassword.new_password">Nova contrasenya</message>
-  <message key="xmlui.EPerson.ResetPassword.para1">Introduïu una nova contrasenya en la casella de sota i confirmeu-la tornant-la a escriure en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
-  <message key="xmlui.EPerson.ResetPassword.submit">Restaura contrasenya</message>
-  <message key="xmlui.EPerson.ResetPassword.title">Restaura contrasenya</message>
-  <message key="xmlui.EPerson.StartForgotPassword.email_address">Adreça electrònica</message>
-  <message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduïu la mateixa adreça que vau usar a l'hora de registrar-vos.</message>
-  <message key="xmlui.EPerson.StartForgotPassword.error_not_found">Adreça electrònica no trobada</message>
-  <message key="xmlui.EPerson.StartForgotPassword.head">He oblidat la contrasenya</message>
-  <message key="xmlui.EPerson.StartForgotPassword.para1">Introduïu l'adreça electrònica que vau facilitar quan vau registrar-vos a DSpace. Us arribarà un missatge a aquesta adreça amb les indicacions que heu de seguir.</message>
-  <message key="xmlui.EPerson.StartForgotPassword.submit">Envieu informació</message>
-  <message key="xmlui.EPerson.StartForgotPassword.title">He oblidat la contrasenya</message>
-  <message key="xmlui.EPerson.StartRegistration.email_address">Adreça electrònica</message>
-  <message key="xmlui.EPerson.StartRegistration.email_address_help">Aquesta adreça serà verificada i utilitzada com a nom d'usuari.</message>
-  <message key="xmlui.EPerson.StartRegistration.error_bad_email">No ha estat possible enviar correu a aquesta adreça.</message>
-  <message key="xmlui.EPerson.StartRegistration.head1">Aquesta adreça electrònica ja l'usa algú</message>
-  <message key="xmlui.EPerson.StartRegistration.head2">Registre com a nou usuari</message>
-  <message key="xmlui.EPerson.StartRegistration.para1">Que l'adreça electrònica ja l'usa algú més. Si voleu restaurar la contrasenya per aquest compte, feu clic al botó de restauració de contrasenya de sota.</message>
-  <message key="xmlui.EPerson.StartRegistration.para2">Registra un compte per subscriure'm a col·leccions per rebre actualitzacions per correu electrònic i enviar nous elements a DSpace.</message>
-  <message key="xmlui.EPerson.StartRegistration.reset_password_for">Restaura contrasenya per a</message>
-  <message key="xmlui.EPerson.StartRegistration.submit_register">Registre</message>
-  <message key="xmlui.EPerson.StartRegistration.submit_reset">Restaura contrasenya</message>
-  <message key="xmlui.EPerson.StartRegistration.title">Registre com a nou usuari</message>
-  <message key="xmlui.EPerson.VerifyEmail.head">S'ha enviat una verificació de correu electrònic</message>
-  <message key="xmlui.EPerson.VerifyEmail.para">S'ha enviat un correu electrònic a {0} amb una URL especial i instruccions pertinents.</message>
-  <message key="xmlui.EPerson.VerifyEmail.title">S'ha enviat una verificació de correu electrònic</message>
-  <message key="xmlui.EPerson.trail_forgot_password">He oblidat la contrasenya</message>
-  <message key="xmlui.EPerson.trail_new_registration">Registre d'usuari nou</message>
-  <message key="xmlui.ItemExportDownloadReader.auth_header">Aquest arxiu d'exportació és restringit.</message>
-  <message key="xmlui.ItemExportDownloadReader.auth_message">L'arxiu d'exportació al qual tracteu d'accedir és un recurs restringit i per visualitzar-lo calen permisos. Autentiqueu-vos a continuació per accedir l'arxiu d'exportació.</message>
-  <message key="xmlui.PageNotFound.head">Pàgina no trobada</message>
-  <message key="xmlui.PageNotFound.para1">No es pot trobar la pàgina que heu sol·licitat.</message>
-  <message key="xmlui.PageNotFound.title">Pàgina no trobada</message>
-  <message key="xmlui.Submission.CollectionViewer.link1">Envia un nou element a aquesta col·lecció</message>
-  <message key="xmlui.Submission.Navigation.submissions">Enviaments</message>
-  <message key="xmlui.Submission.Submissions.email">adreça electrònica:</message>
-  <message key="xmlui.Submission.Submissions.head">Enviaments i tasques de flux de treball</message>
-  <message key="xmlui.Submission.Submissions.progress_column1">Títol</message>
-  <message key="xmlui.Submission.Submissions.progress_column2">Col·lecció</message>
-  <message key="xmlui.Submission.Submissions.progress_column3">Estat</message>
-  <message key="xmlui.Submission.Submissions.progress_head1">Els enviaments es troben en procés de revisió</message>
-  <message key="xmlui.Submission.Submissions.progress_info1">Aquests són els vostres enviaments conclosos que es troben en procés de revisió per part dels responsables de la col·lecció</message>
-  <message key="xmlui.Submission.Submissions.status_0">Enviat</message>
-  <message key="xmlui.Submission.Submissions.status_1">A l'espera de revisió</message>
-  <message key="xmlui.Submission.Submissions.status_2">Enviament en procés de revisió</message>
-  <message key="xmlui.Submission.Submissions.status_3">A l'espera de revisió par part de l'editor</message>
-  <message key="xmlui.Submission.Submissions.status_4">Enviament en procés de revisió</message>
-  <message key="xmlui.Submission.Submissions.status_5">A l'espera de revisió per part de l'editor final</message>
-  <message key="xmlui.Submission.Submissions.status_6">Enviament en procés d'edició</message>
-  <message key="xmlui.Submission.Submissions.status_7">S'ha arxivat l'enviament</message>
-  <message key="xmlui.Submission.Submissions.status_unknown">Estat desconegut</message>
-  <message key="xmlui.Submission.Submissions.submit_column1">No cap</message>
-  <message key="xmlui.Submission.Submissions.submit_column2">Títol</message>
-  <message key="xmlui.Submission.Submissions.submit_column3">Col·lecció</message>
-  <message key="xmlui.Submission.Submissions.submit_column4">Remitent</message>
-  <message key="xmlui.Submission.Submissions.submit_head1">Enviaments</message>
-  <message key="xmlui.Submission.Submissions.submit_head2">Enviaments no finalitzats</message>
-  <message key="xmlui.Submission.Submissions.submit_head3">Autor/a:</message>
-  <message key="xmlui.Submission.Submissions.submit_head4">Supervisant:</message>
-  <message key="xmlui.Submission.Submissions.submit_info1a">Podeu</message>
-  <message key="xmlui.Submission.Submissions.submit_info1b">iniciar un nou enviament</message>
-  <message key="xmlui.Submission.Submissions.submit_info1c">El procés d'enviament inclou la descripció de l'element i la pujada de fitxer(s) que el comprèn o els comprenen. Cada comunitat o col·lecció pot fixar privilegis d'enviament pròpies.</message>
-  <message key="xmlui.Submission.Submissions.submit_info2a">Aquests són enviaments d'elements incomplets. També podeu</message>
-  <message key="xmlui.Submission.Submissions.submit_info2b">iniciar un altre enviament</message>
-  <message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-  <message key="xmlui.Submission.Submissions.submit_info3">No queda cap enviament incomplet.</message>
-  <message key="xmlui.Submission.Submissions.submit_submit_remove">Elimina els enviaments seleccionats</message>
-  <message key="xmlui.Submission.Submissions.title">Enviaments i flux de treball</message>
-  <message key="xmlui.Submission.Submissions.trail">Enviaments</message>
-  <message key="xmlui.Submission.Submissions.untitled">No cap</message>
-  <message key="xmlui.Submission.Submissions.workflow_column1">No cap</message>
-  <message key="xmlui.Submission.Submissions.workflow_column2">Tasca</message>
-  <message key="xmlui.Submission.Submissions.workflow_column3">Element</message>
-  <message key="xmlui.Submission.Submissions.workflow_column4">Col·lecció</message>
-  <message key="xmlui.Submission.Submissions.workflow_column5">Remitent</message>
-  <message key="xmlui.Submission.Submissions.workflow_head1">Tasques de flux de treball</message>
-  <message key="xmlui.Submission.Submissions.workflow_head2">Tasques vostres</message>
-  <message key="xmlui.Submission.Submissions.workflow_head3">Tasques en la cua</message>
-  <message key="xmlui.Submission.Submissions.workflow_info1">Aquestes tasques són elements que es troben a l'espera d'aprovació abans de ser incorporades al repositori. Hi ha dues cues de tasques; una és per a les tasques que heu decidit acceptar i l'altra és per a les tasques que encara no han sigut triades per ningú.</message>
-  <message key="xmlui.Submission.Submissions.workflow_info2">No s'us ha assignat cap tasca</message>
-  <message key="xmlui.Submission.Submissions.workflow_info3">A la cua no hi ha tasques</message>
-  <message key="xmlui.Submission.Submissions.workflow_submit_return">Torna les tasques seleccionades a la cua</message>
-  <message key="xmlui.Submission.Submissions.workflow_submit_take">Agafa tasques seleccionades</message>
-  <message key="xmlui.Submission.general.default.title">Enviament</message>
-  <message key="xmlui.Submission.general.default.trail">Enviament</message>
-  <message key="xmlui.Submission.general.go_mydspace">Vés a l'inici de El meu DSpace</message>
-  <message key="xmlui.Submission.general.mydspace_home">Inici de El meu DSpace</message>
-  <message key="xmlui.Submission.general.showfull">Mostra registre d'element complet</message>
-  <message key="xmlui.Submission.general.showsimple">Mostra registre d'element parcial</message>
-  <message key="xmlui.Submission.general.submission.complete">Completa l'enviament</message>
-  <message key="xmlui.Submission.general.submission.head">Enviament d'elements</message>
-  <message key="xmlui.Submission.general.submission.next">Següent &gt;</message>
-  <message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
-  <message key="xmlui.Submission.general.submission.save">Desa i ix</message>
-  <message key="xmlui.Submission.general.submission.title">Enviament d'elements</message>
-  <message key="xmlui.Submission.general.submission.trail">Enviament d'elements</message>
-  <message key="xmlui.Submission.general.workflow.head">Enviament d'elements</message>
-  <message key="xmlui.Submission.general.workflow.title">Enviament d'elements</message>
-  <message key="xmlui.Submission.general.workflow.trail">Enviament d'elements</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.head">Llicència Creative Commons</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.info1">Si voleu, podeu afegir una llicència &lt;a href="http://creativecommons.org/"&gt;Creative Commons&lt;/a&gt;</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.license">Llicència</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.no_license">no heu seleccionat cap llicència Creative Commons</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">Elimina aquesta llicència Creative Commons</message>
-  <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Vés al lloc web de Creative Commons per seleccionar una llicència</message>
-  <message key="xmlui.Submission.submit.CompletedStep.go_submission">Vés a la pàgina d'enviaments.</message>
-  <message key="xmlui.Submission.submit.CompletedStep.head">Enviament conclòs</message>
-  <message key="xmlui.Submission.submit.CompletedStep.info1">Ara el vostre enviament seguirà el procés de revisió d'aquesta col·lecció. Quan el vostre enviament haja sigut incorporat a la col·lecció, o si hi ha algun problema amb l'enviament, rebreu una notificació per correu electrònic. També podeu comprovar l'estat del vostre enviament consultant la vostra pàgina d'enviaments.</message>
-  <message key="xmlui.Submission.submit.CompletedStep.submit_again">Envia un altre element</message>
-  <message key="xmlui.Submission.submit.DescribeStep.day">Dia</message>
-  <message key="xmlui.Submission.submit.DescribeStep.first_name_help">Noms) + "",</message>
-  <message key="xmlui.Submission.submit.DescribeStep.head">Descriu element</message>
-  <message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognoms,</message>
-  <message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
-  <message key="xmlui.Submission.submit.DescribeStep.report_no">Informe o article núm.</message>
-  <message key="xmlui.Submission.submit.DescribeStep.required_field">Aquest camp és obligatori</message>
-  <message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la sèrie</message>
-  <message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: tipus de fitxer desconegut</message>
-  <message key="xmlui.Submission.submit.DescribeStep.year">Any</message>
-  <message key="xmlui.Submission.submit.EditFileStep.description">Descripció del fitxer</message>
-  <message key="xmlui.Submission.submit.EditFileStep.description_help">Si voleu, doneu una descripció breu dels continguts, com per exemple "</message>
-  <message key="xmlui.Submission.submit.EditFileStep.file">Fitxer</message>
-  <message key="xmlui.Submission.submit.EditFileStep.format_default">El format no és a la llista</message>
-  <message key="xmlui.Submission.submit.EditFileStep.format_detected">Format detectat</message>
-  <message key="xmlui.Submission.submit.EditFileStep.format_selected">Format seleccionat</message>
-  <message key="xmlui.Submission.submit.EditFileStep.format_user">Un altre format</message>
-  <message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nom de l'aplicació que vau fer servir per crear el fitxer i número de versió (per exemple, "</message>
-  <message key="xmlui.Submission.submit.EditFileStep.head">Edita fitxer</message>
-  <message key="xmlui.Submission.submit.EditFileStep.info1">Seleccioneu el format del fitxer entre les opcions de la llista de sota, com ara "</message>
-  <message key="xmlui.Submission.submit.EditFileStep.info2">Si el format no és a la llista de dalt,&lt;strong&gt;seleccioneu "el format no és a la llista " a dalt &lt;/strong&gt; i descriviu el format del fitxer en la casella de sota.</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.and">i</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data de publicació</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.head">Qüestions inicials</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota important:</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Títols múltiples</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'element té més d'un títol,</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la casella de selecció de dalt no es troba marcada, aleshores el(s) següent(s) títol(s) s'eliminaran de l'element:</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicat</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">L'element s'ha publicat o distribuït públicament abans</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la casella de selecció de dalt no es troba marcada, aleshores s'eliminarà de l'element el següent:</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
-  <message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
-  <message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concessió de llicència</message>
-  <message key="xmlui.Submission.submit.LicenseStep.decision_error">Per concloure l'enviament, heu de concedir aquesta llicència. Si no podeu concedir aquesta llicència en aquest moment, podeu desar el vostre treball i tornar més tard o cancel·lar l'enviament fent clic al botó 'Desa i Ix' de sota.</message>
-  <message key="xmlui.Submission.submit.LicenseStep.decision_label">Llicència de distribució</message>
-  <message key="xmlui.Submission.submit.LicenseStep.head">Llicència de distribució</message>
-  <message key="xmlui.Submission.submit.LicenseStep.info1">&lt;strong&gt;Queda un últim pas:&lt;/strong&gt; Per tal que DSpace reproduïsca, traduïsca i distribuïsca el vostre enviament a tot el món, heu d'acceptar les condicions següents.</message>
-  <message key="xmlui.Submission.submit.LicenseStep.info2">Concediu la llicència de distribució estàndard fent clic a "Concedisc la llicència"; a continuació, feu clic a "Conclou enviament".</message>
-  <message key="xmlui.Submission.submit.LicenseStep.info3">Si teniu dubtes al voltant de la llicència, poseu-vos en contacte amb els administradors del sistema.</message>
-  <message key="xmlui.Submission.submit.RemovedStep.go_submission">Vés a la pàgina d'enviaments</message>
-  <message key="xmlui.Submission.submit.RemovedStep.head">Enviament cancel·lat</message>
-  <message key="xmlui.Submission.submit.RemovedStep.info1">Heu cancel·lat el vostre enviament i l'element incomplet ha sigut eliminat del sistema.</message>
-  <message key="xmlui.Submission.submit.ResumeStep.submit_resume">Reinicia</message>
-  <message key="xmlui.Submission.submit.ReviewStep.head">Revisa enviament</message>
-  <message key="xmlui.Submission.submit.ReviewStep.head1">Qüestions inicials</message>
-  <message key="xmlui.Submission.submit.ReviewStep.head2">Descriu pàgina {0}</message>
-  <message key="xmlui.Submission.submit.ReviewStep.head3">Fitxers penjats</message>
-  <message key="xmlui.Submission.submit.ReviewStep.known">conegut</message>
-  <message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Títols múltiples</message>
-  <message key="xmlui.Submission.submit.ReviewStep.no">No</message>
-  <message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-  <message key="xmlui.Submission.submit.ReviewStep.published_before">Publicat abans de</message>
-  <message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregeix el següent</message>
-  <message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Afegeix o elimina fitxer</message>
-  <message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
-  <message key="xmlui.Submission.submit.ReviewStep.unknown">desconegut</message>
-  <message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
-  <message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Voleu desar o cancel·lar l'enviament?</message>
-  <message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voleu cancel·lar l'enviament, o voleu continuar treballant amb ell més endavant? Podeu tornar al procés d'enviament si heu fet clic a Ix per error.</message>
-  <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continua amb l'enviament</message>
-  <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Cancel·la l'enviament</message>
-  <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Desa'l, treballaré amb ell més endavant</message>
-  <message key="xmlui.Submission.submit.SelectCollection.collection">Col·lecció</message>
-  <message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccioneu una col·lecció...</message>
-  <message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccioneu la col·lecció a la qual desitgeu enviar un element.</message>
-  <message key="xmlui.Submission.submit.SelectCollection.head">Seleccioneu una col·lecció</message>
-  <message key="xmlui.Submission.submit.UploadStep.checksum">Comprovació de fitxers</message>
-  <message key="xmlui.Submission.submit.UploadStep.column0">Primari</message>
-  <message key="xmlui.Submission.submit.UploadStep.column1">No cap</message>
-  <message key="xmlui.Submission.submit.UploadStep.column2">Fitxer</message>
-  <message key="xmlui.Submission.submit.UploadStep.column3">Grandària</message>
-  <message key="xmlui.Submission.submit.UploadStep.column4">Descripció</message>
-  <message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-  <message key="xmlui.Submission.submit.UploadStep.column6">No cap</message>
-  <message key="xmlui.Submission.submit.UploadStep.description">Descripció del fitxer</message>
-  <message key="xmlui.Submission.submit.UploadStep.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "</message>
-  <message key="xmlui.Submission.submit.UploadStep.file">Fitxer</message>
-  <message key="xmlui.Submission.submit.UploadStep.file_error">L'element ha de estar compost per almenys un fitxer</message>
-  <message key="xmlui.Submission.submit.UploadStep.file_help">Per favor, introduïu la ruta completa del fitxer del vostre ordinador que correspon al vostre element. Si feu clic a "Visualitza...", una nova finestra us permetrà seleccionar el fitxer del vostre ordinador.</message>
-  <message key="xmlui.Submission.submit.UploadStep.head">Penja fitxer(s)</message>
-  <message key="xmlui.Submission.submit.UploadStep.head2">Fitxers penjats</message>
-  <message key="xmlui.Submission.submit.UploadStep.known">(Conegut)</message>
-  <message key="xmlui.Submission.submit.UploadStep.submit_edit">Edita</message>
-  <message key="xmlui.Submission.submit.UploadStep.submit_remove">Elimina fitxer seleccionats</message>
-  <message key="xmlui.Submission.submit.UploadStep.submit_upload">Penja fitxer i afegeix-ne un altre</message>
-  <message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
-  <message key="xmlui.Submission.submit.UploadStep.unknown_format">format desconegut</message>
-  <message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconegut</message>
-  <message key="xmlui.Submission.submit.UploadStep.unsupported">(Incompatible)</message>
-  <message key="xmlui.Submission.submit.progressbar.complete">Completa</message>
-  <message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-  <message key="xmlui.Submission.submit.progressbar.describe">Descriu</message>
-  <message key="xmlui.Submission.submit.progressbar.initial-questions">Qüestions inicials</message>
-  <message key="xmlui.Submission.submit.progressbar.license">Llicència</message>
-  <message key="xmlui.Submission.submit.progressbar.upload">Penja</message>
-  <message key="xmlui.Submission.submit.progressbar.verify">Revisa</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si heu revisat l'element i resulta adequat per incorporar-lo a la col·lecció, seleccioneu "Aprova".</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprova element</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Una vegada hàgeu editat l'element, utilitzeu aquesta opció per assignar l'element al fitxer.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Assigneu a fitxer</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Seleccioneu aquesta opció per canviar les metadades de l'element.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edita metadades</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accions que podeu dur a terme pel que fa a aquesta tasca:</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixa aquesta tasca en la cua perquè la trie algú altre.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Deixa la tasca</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si heu revisat l'element i creieu que &lt;strong&gt;no&lt;/strong&gt; és adequat per ser incorporat a la col·lecció, seleccioneu "Rebutja". Després s'us demanarà que escriviu un missatge que explique perquè no és adequat i si la persona que fa l'enviament hauria de canviar alguna cosa i tornar-lo a enviar.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rebutja element.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Torna la tasca a la cua perquè un altre usuari puga dur a terme la tasca.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Torna la tasca a la cua.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Assigneu-vos aquesta tasca.</message>
-  <message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Tria la tasca</message>
-  <message key="xmlui.Submission.workflow.RejectTaskStep.info1">En la casella de sota, doneu una raó per la qual rebutgeu l'enviament, i assenyaleu si la persona que ha fet l'enviament pot resoldre el problema i tornar a enviar l'element modificat.</message>
-  <message key="xmlui.Submission.workflow.RejectTaskStep.reason">Raó</message>
-  <message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El camp Raó és obligatori</message>
-  <message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rebutja element</message>
-  <message key="xmlui.administrative.ControlPanel.activity_anonymous">Anònim {0}</message>
-  <message key="xmlui.administrative.ControlPanel.activity_head">Activitat actual (màxim de {0} pàgines)</message>
-  <message key="xmlui.administrative.ControlPanel.activity_hideself">Ocultar les meues visualitzacions de pàgines</message>
-  <message key="xmlui.administrative.ControlPanel.activity_none">Ningú més ha visualitzat cap pàgina de les últimes {0}.</message>
-  <message key="xmlui.administrative.ControlPanel.activity_showself">Mostra les meues visualitzacions de pàgines</message>
-  <message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
-  <message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adreça IP</message>
-  <message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horària</message>
-  <message key="xmlui.administrative.ControlPanel.activity_sort_url">Pàgina URL</message>
-  <message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuari</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minuts</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minuts</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minuts</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Mantin el temporitzador de compte enrere actual</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte enrere</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_countdown_none">No hi ha temporitzador de compte enrere</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_head">Alertes globals del sistema</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema deixarà d'estar disponible en breu per manteniment regular. Deseu el vostre treball i finalitzeu la sessió.</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_message_label">Missatge d'alerta</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continua permetent sessions autenticades</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restringeix el procés d'autenticació però mantin les sessions actuals</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestiona sessió</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_session_note">No cap</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restringeix el procés d'autenticació i conclou les sessions actuals</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activa</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactiva</message>
-  <message key="xmlui.administrative.ControlPanel.alerts_warning">&lt;strong&gt;Avís per a sistemes amb balanç de càrrega&lt;/strong&gt;: les alertes globals del sistema només són efectives per al node on es troba activat. Cal que us assegureu que cada node del conjunt rep l'ordre d'activar alerta.</message>
-  <message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
-  <message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre màxim de connexions DB en la cua</message>
-  <message key="xmlui.administrative.ControlPanel.db_maxidle">Màxim de connexions inactives</message>
-  <message key="xmlui.administrative.ControlPanel.db_maxwait">Temps màxim d'espera de la connexió DB</message>
-  <message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de dades</message>
-  <message key="xmlui.administrative.ControlPanel.db_url">URL de la base de dades</message>
-  <message key="xmlui.administrative.ControlPanel.dspace_dir">Directori d'instal·lació de DSpace</message>
-  <message key="xmlui.administrative.ControlPanel.dspace_head">Configuració de DSpace</message>
-  <message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom de l'amfitrió de DSpace</message>
-  <message key="xmlui.administrative.ControlPanel.dspace_name">Nom del lloc</message>
-  <message key="xmlui.administrative.ControlPanel.dspace_url">URL base de DSpace</message>
-  <message key="xmlui.administrative.ControlPanel.head">Tauler de control</message>
-  <message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-  <message key="xmlui.administrative.ControlPanel.java_head">Java i sistema operatiu</message>
-  <message key="xmlui.administrative.ControlPanel.java_vendor">Venedor de Java Runtime Environment</message>
-  <message key="xmlui.administrative.ControlPanel.java_version">Versió de Java Runtime Environment</message>
-  <message key="xmlui.administrative.ControlPanel.knots_active">Actiu</message>
-  <message key="xmlui.administrative.ControlPanel.knots_column1">Intèrpret</message>
-  <message key="xmlui.administrative.ControlPanel.knots_column2">Últim accés</message>
-  <message key="xmlui.administrative.ControlPanel.knots_column3">Estat</message>
-  <message key="xmlui.administrative.ControlPanel.knots_expired">Superat</message>
-  <message key="xmlui.administrative.ControlPanel.knots_head">Continuacions web</message>
-  <message key="xmlui.administrative.ControlPanel.knots_none">No hi ha continuacions actives</message>
-  <message key="xmlui.administrative.ControlPanel.mail_admin">Correu general d'administració del lloc</message>
-  <message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatari de la informació</message>
-  <message key="xmlui.administrative.ControlPanel.mail_from_address">De l'adreça electrònica</message>
-  <message key="xmlui.administrative.ControlPanel.mail_server">Servidor de correu SMTP</message>
-  <message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
-  <message key="xmlui.administrative.ControlPanel.option_alerts">Alertes globals del sistema</message>
-  <message key="xmlui.administrative.ControlPanel.option_dspace">Configuració de DSpace</message>
-  <message key="xmlui.administrative.ControlPanel.option_java">Informació de Java</message>
-  <message key="xmlui.administrative.ControlPanel.option_knots">Continuacions web</message>
-  <message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operatiu</message>
-  <message key="xmlui.administrative.ControlPanel.os_name">Nom del sistema operatiu</message>
-  <message key="xmlui.administrative.ControlPanel.os_version">Versió del sistema operatiu</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_free">Memòria lliure</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_head">Estadístiques d'execució</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_max">Memòria màxima</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_processors">Processadors disponibles</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_total">Memòria assignada</message>
-  <message key="xmlui.administrative.ControlPanel.runtime_used">Memòria usada</message>
-  <message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-  <message key="xmlui.administrative.ControlPanel.select_panel">Useu les pestanyes de dalt per seleccionar la informació que voleu que es mostre</message>
-  <message key="xmlui.administrative.ControlPanel.title">Tauler de control</message>
-  <message key="xmlui.administrative.ControlPanel.trail">Tauler de control</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">S'ha incorporat l'usuari correctament.</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">No s'ha(n) esborrat l'usuari o usuaris llistat(s) perquè hi ha restriccions que ho impedeixen; vegeu la pàgina de dades de l'usuari per a més informació.</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">S'ha esborrat correctament l'usuari o els usuaris.</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">S'ha editat l'usuari correctament.</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">S'ha enviat un missatge de correu electrònic a l'usuari amb un testimoni que pot utilitzar-se per a triar una nova contrasenya.</message>
-  <message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">S'han esborrat correctament els grups seleccionats.</message>
-  <message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">S'ha editat correctament el grup.</message>
-  <message key="xmlui.administrative.FlowItemUtils.bitstream_added">S'ha penjat correctament el nou document.</message>
-  <message key="xmlui.administrative.FlowItemUtils.bitstream_delete">S'han esborrat els documents seleccionades.</message>
-  <message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error en la pujada del fitxer.</message>
-  <message key="xmlui.administrative.FlowItemUtils.bitstream_updated">S'ha actualitzat el document.</message>
-  <message key="xmlui.administrative.FlowItemUtils.item_reinstated">S'ha reincorporat l'element.</message>
-  <message key="xmlui.administrative.FlowItemUtils.item_withdrawn">S'ha retirat l'element.</message>
-  <message key="xmlui.administrative.FlowItemUtils.metadata_added">S'han afegit noves metadades.</message>
-  <message key="xmlui.administrative.FlowItemUtils.metadata_updated">S'han actualitzat correctament les metadades de l'element.</message>
-  <message key="xmlui.administrative.FlowMapperUtils.map_items">S'han mapat elements correctament.</message>
-  <message key="xmlui.administrative.FlowMapperUtils.unmaped_items">S'han desmapat els elements.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">S'ha incorporat correctament el camp de metadades.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">S'han creat correctament nous esquemes.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">S'ha(n) esborrat correctament el(s) format(s).</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">S'ha(n) esborrat correctament el(s) camp(s).</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">S'ha(n) esborrat correctament l'esquema o els esquemes.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">S'ha desat correctament el format.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">S'ha editat correctament el camp de metadades.</message>
-  <message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">S'ha(n) canviat de lloc correctament el(s) camp(s).</message>
-  <message key="xmlui.administrative.ItemExport.available.head">Arxius d'exportació disponibles per descarregar.</message>
-  <message key="xmlui.administrative.ItemExport.collection.id.error">La col·lecció indicada no és vàlida.</message>
-  <message key="xmlui.administrative.ItemExport.collection.not.found">No s'ha trobat la col·lecció sol·licitada.</message>
-  <message key="xmlui.administrative.ItemExport.collection.success">La col·lecció s'ha exportat correctament. Hauríeu de rebre un correu electrònic quan l'arxiu estiga disponible per descarregar. També podeu usar l'enllaç "Les meues exportacions" per veure una llista dels arxius que teniu disponibles.</message>
-  <message key="xmlui.administrative.ItemExport.community.id.error">El codi de comunitat indicat no és vàlid.</message>
-  <message key="xmlui.administrative.ItemExport.community.not.found">No s'ha trobat la col·lecció sol·licitada.</message>
-  <message key="xmlui.administrative.ItemExport.community.success">La comunitat s'ha exportat correctament. Hauríeu de rebre un correu electrònic quan l'arxiu estiga disponible per descarregar. També podeu usar l'enllaç "Les meues exportacions" per veure una llista dels arxius que teniu disponibles.</message>
-  <message key="xmlui.administrative.ItemExport.export.success">L'element s'ha exportat correctament. Hauríeu de rebre un correu electrònic quan l'arxiu estiga disponible per descarregar. També podeu usar l'enllaç "Les meues exportacions" per veure una llista dels arxius que teniu disponibles.</message>
-  <message key="xmlui.administrative.ItemExport.head">Arxiu d'exportació</message>
-  <message key="xmlui.administrative.ItemExport.item.id.error">El codi d'element indicat no és vàlid.</message>
-  <message key="xmlui.administrative.ItemExport.item.not.found">No s'ha trobat l'element sol·licitat.</message>
-  <message key="xmlui.administrative.Navigation.account_export">Les meues exportacions</message>
-  <message key="xmlui.administrative.Navigation.administrative_access_control">Control d'accés</message>
-  <message key="xmlui.administrative.Navigation.administrative_authorizations">Autoritzacions</message>
-  <message key="xmlui.administrative.Navigation.administrative_control_panel">Tauler de control</message>
-  <message key="xmlui.administrative.Navigation.administrative_format">Format</message>
-  <message key="xmlui.administrative.Navigation.administrative_groups">Grups</message>
-  <message key="xmlui.administrative.Navigation.administrative_head">Administratiu</message>
-  <message key="xmlui.administrative.Navigation.administrative_items">Elements</message>
-  <message key="xmlui.administrative.Navigation.administrative_metadata">Metadades</message>
-  <message key="xmlui.administrative.Navigation.administrative_people">Persones</message>
-  <message key="xmlui.administrative.Navigation.administrative_registries">Registres</message>
-  <message key="xmlui.administrative.Navigation.administrative_withdrawn">Retira elements</message>
-  <message key="xmlui.administrative.Navigation.context_create_collection">Crea col·lecció</message>
-  <message key="xmlui.administrative.Navigation.context_create_community">Crea comunitat</message>
-  <message key="xmlui.administrative.Navigation.context_create_subcommunity">Crea subcomunitat</message>
-  <message key="xmlui.administrative.Navigation.context_edit_collection">Edita col·lecció</message>
-  <message key="xmlui.administrative.Navigation.context_edit_community">Edita comunitat</message>
-  <message key="xmlui.administrative.Navigation.context_edit_item">Edita aquest element</message>
-  <message key="xmlui.administrative.Navigation.context_export_collection">Exporta col·lecció</message>
-  <message key="xmlui.administrative.Navigation.context_export_community">Exporta comunitat</message>
-  <message key="xmlui.administrative.Navigation.context_export_item">Exporta element</message>
-  <message key="xmlui.administrative.Navigation.context_head">Context</message>
-  <message key="xmlui.administrative.Navigation.context_item_mapper">Mapador d'elements</message>
-  <message key="xmlui.administrative.Navigation.statistics">Estadístiques</message>
-  <message key="xmlui.administrative.NotAuthorized.head">Privilegis insuficients</message>
-  <message key="xmlui.administrative.NotAuthorized.para1a">El vostre compte no té els privilegis suficients per dur a terme l'acció sol·licitada. Si penseu que es tracta d'un error o voleu preguntar res sobre els vostres privilegis, contacteu els</message>
-  <message key="xmlui.administrative.NotAuthorized.para1b">administradors del sistema del lloc</message>
-  <message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-  <message key="xmlui.administrative.NotAuthorized.para2">Connecteu-vos com a un usuari diferent</message>
-  <message key="xmlui.administrative.NotAuthorized.title">No autoritzat</message>
-  <message key="xmlui.administrative.NotAuthorized.trail">No autoritzat</message>
-  <message key="xmlui.administrative.SystemwideAlerts.countdown">&lt;strong&gt;D'ací a {0} minuts&lt;/strong&gt;:</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...permetre la possibilitat de realitzar l'acció següent...</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...en totes les col·leccions següents</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Per a tots els grups seleccionats...</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acció</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Col·lecció</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grup</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipus de contingut</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...per a tots els tipus d'objectes següents...</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor avançat de privilegis</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permet afegir comodins a privilegis i buidar privilegis per a tipus de continguts que es troben dins d'alguna col·lecció concreta. AVÍS: si elimineu permisos LLEGITS d'elements, aquests no es podran visualitzar!</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Afegeix privilegis</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Buida privilegis</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor avançat de privilegis</message>
-  <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autoritzacions avançades</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Eina avançada d'autoritzacions</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Feu clic ací per anar a l'eina d'administració de privilegis de comodins d'elements</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoritzacions de l'element</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Cerca un element</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">La identificació que heu facilitat no correspon a cap element.</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoritzacions de comunitats/col·leccions</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Feu clic en una comunitat o col·lecció per editar-ne els privilegis.</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administreu privilegis d'autorització</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Per cercar un element, podeu fer-ho mitjançant handle o identificador intern</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Cerca</message>
-  <message key="xmlui.administrative.authorization.AuthorizationMain.title">Administreu privilegis d'autorització</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">S'eliminaran els privilegis següents:</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acció</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grup</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">Identificació</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmeu que voleu esborrar el privilegi</message>
-  <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edita</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acció</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grup</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">Identificació</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Feu clic ací per afegir nous privilegis.</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilegis de la col·lecció "{0}" ({1},codi: {2})</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegis de la comunitat "{0}" ({1},codi: {2})</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No s'han trobat privilegis per a aquest objecte.</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Afegeix</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Esborra els seleccionats</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edita privilegis</message>
-  <message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Llista de privilegis</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Afegeix un nou privilegi de documents</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Afegeix un nou privilegi de paquets</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Afegeix un nou privilegi d'elements</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilegis de l'element {0} (codi={1})</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Amb aquest editor podeu veure i modificar els privilegis d'un element, a més de modificar els privilegis de components d'elements individuals: paquets i documents. En síntesi, un element és un contenidor de paquets, i els paquets són contenidors de documents. Normalment els contenidors tenen privilegis d'ADDICIÓ/ELIMINACIÓ/LECTURA/ESCRIPTURA, mentre que els documents només tenen privilegis de LECTURA/ESCRIPTURA.</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Veureu que hi ha un paquet i document extra per a cada element que conté el text de llicència per a l'element.</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Document {0} ({1})</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilegis del paquet{0} ({1})</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilegis de l'element</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.title">Privilegis d'edició de l'element</message>
-  <message key="xmlui.administrative.authorization.EditItemPolicies.trail">Llista de privilegis</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No s'ha seleccionat cap acció</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No s'ha seleccionat cap grup</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">Identificació</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nom</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accions per a aquest recurs</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4">No cap</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultats de la cerca</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Seleccioneu l'acció</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Cerca un grup</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edita privilegi {0} per a {1} {2}</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crea nous privilegis per a {0} {1}</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Selecciona un grup</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conjunt</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Cerca</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.title">Edita privilegi</message>
-  <message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edita privilegi</message>
-  <message key="xmlui.administrative.authorization.general.authorize_trail">Autorització</message>
-  <message key="xmlui.administrative.authorization.general.policyList_trail">Llista de privilegis</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crea...</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">La lectura per defecte per als elements i documents entrants està actualment configurada com a anònima.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">En aquesta col·lecció la configuració d'accés és l'establerta per defecte.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Edita els privilegis d'autorització directament.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Els administradors de la col·lecció decideixen qui pot enviar elements a la col·lecció, llevar elements, editar metadades d'elements (després de ser enviats) i afegir (mapar) elements existents d'altres col·leccions a aquesta col·lecció (sempre que es tinga autorització per a la col·lecció en qüestió).</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuaris i grups que poden llegir nous elements enviats a aquesta col·lecció. Els canvis que afecten aquesta funció no són retroactius. Els elements existents en el sistema continuaran sent visibles per aquells que tenen accés de lectura en el moment en què van ser afegits.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Els usuaris i grups que tenen permís per enviar nous elements a aquesta col·lecció.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les persones responsables d'aquesta acció poden acceptar o rebutjar els enviaments rebuts. Tanmateix, no poden editar les metadades de l'enviament.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les persones responsables d'aquesta acció poden editar les metadades dels enviaments rebuts i després acceptar-los o rebutjar-los.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Les persones responsables d'aquesta acció poden editar les metadades dels enviaments rebuts però no poden rebutjar-los.</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradors</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accés de lectura per defecte</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Remitents</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accepta/Rebutja/Acció</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accepta/Rebutja/Edita acció de metadades</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Edita acció de metadades</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edita col·lecció: {0}</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">no cap</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringeix...</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"></message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grup associat</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Funció</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only">No cap</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edita funcions</message>
-  <message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Funcions</message>
-  <message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduïu noves metadades per a una nova col·lecció de {0}</message>
-  <message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crea</message>
-  <message key="xmlui.administrative.collection.CreateCollectionForm.title">Crea col·lecció</message>
-  <message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crea col·lecció</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tots els elements i enviaments incomplets d'aquesta col·lecció que no es troben en altres col·leccions</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contingut d'aquells elements</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Tots els privilegis d'autorització associades</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirmeu que voleu esborrar la col·lecció {0}</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Esteu segurs que voleu esborrar la col·lecció {0}? Açò esborrarà:</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmeu</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmeu que voleu esborrar la funció {0}</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Esteu segurs que voleu esborrar aquesta funció? Es perdran tots els canvis i personalitzacions fetes en el grup {0}, de manera que hauran de crear-se de nou.</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Esteu segurs que voleu esborrar aquesta funció? Esborrar aquest grup donarà accés de LECTURA a tots els usuaris per a tots els elements enviats a aquesta col·lecció a partir d'ara. Tingueu en compte que aquest canvi no és retroactiu. Els elements que hi haja en el sistema continuaran sent restringits per als membres definits per la funció que voleu esborrar.</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmeu que voleu esborrar la funció</message>
-  <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmeu</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Text del copyright (text net)</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Text introductori (HTML)</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla de l'element</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Llicència</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Penja nou logo</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nom</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Origen</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Breu descripció</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novetats (HTML)</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edita col·lecció: {0}</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crea...</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Esborra col·lecció</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Elimina logo</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edita...</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Desa actualitzacions</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only">No cap</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edita metadades de la col·lecció</message>
-  <message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">metadades</message>
-  <message key="xmlui.administrative.collection.general.collection_trail">Col·leccions</message>
-  <message key="xmlui.administrative.collection.general.options_metadata">Edita metadades</message>
-  <message key="xmlui.administrative.collection.general.options_roles">Assigna funcions</message>
-  <message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introduïu metadades per a una nova subcomunitat de {0}</message>
-  <message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Edita metadades per a una nova comunitat de primer nivell</message>
-  <message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crea</message>
-  <message key="xmlui.administrative.community.CreateCommunityForm.title">Crea comunitat</message>
-  <message key="xmlui.administrative.community.CreateCommunityForm.trail">Crea comunitat</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Totes les col·leccions de la comunitat que no es troben en altres comunitats</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tots els elements i enviaments incomplets d'aquesta comunitat que no es troben en altres comunitats</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contingut d'aquests elements</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Totes els privilegis d'autorització associades</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmeu que voleu esborrar {0}</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Esteu segurs que voleu esborrar la comunitat {0}? Açò esborrarà:</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmeu</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edita privilegis d'autorització</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Text del copyright (text net)</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Text introductori (HTML)</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Penja nou logo</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nom</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Breu descripció</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Notícies (HTML)</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edita metadades per a la comunitat{0}</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Esborra comunitat</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Elimina logo</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edita dades de la comunitat</message>
-  <message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">metadades</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Podeu iniciar sessió</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Que l'adreça electrònica està sent usada per un altre usuari. Les adreces electròniques han de ser úniques.</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.error_email">L'adreça electrònica és obligatòria</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L'adreça electrònica ha de ser única</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nom és obligatori</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Els cognoms són obligatoris</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crea un nou usuari</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.head2">Nova informació d'usuari:</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Requereix certificat</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crea usuari</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.title">Afegeix usuari</message>
-  <message key="xmlui.administrative.eperson.AddEPersonForm.trail">Afegeix usuari</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">L'usuari següent serà esborrat:</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Adreça electrònica</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">Identificació</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nom</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirmeu que voleu esborrar l'usuari</message>
-  <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Podeu iniciar sessió</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No es pot esborrar aquest usuari per la següent restricció o restriccions:</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">l'usuari ha enviat un o més elements</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l'usuari té una tasca amb treball pendent de ser atesa</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l'usuari té una restricció sense identificar en el sistema</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l'usuari té un flux de treball d'enviament actiu</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Que l'adreça electrònica està sent usada per un altre usuari. Les adreces electròniques han de ser úniques.</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.error_email">L'adreça electrònica és obligatòria</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L'adreça electrònica ha de ser única</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nom és obligatori</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Els cognoms són obligatoris</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edita usuari</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informació de {0}:</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(via grup: {0})</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Grups d'aquest usuari:</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.member_none">no cap</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Requereix certificat</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.special_help">També podeu eliminar aquest usuari del sistema o restaurar la seua contrasenya. Quan es restaura una contrasenya, l'usuari rep un missatge de correu electrònic que inclou un enllaç especial que pot seguir per tal de triar una nova contrasenya.</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Esborra aquest usuari</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Autentiqueu-vos com a usuari</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restaura contrasenya</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.title">Edita usuari</message>
-  <message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edita usuari</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Visualitza usuaris</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Feu clic ací per visualitzar tots els usuaris.</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crea un nou usuari</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Feu clic ací per afegir un nou usuari.</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accions</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Cerca usuaris</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestió d'usuaris</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">La vostra cerca no ha donat resultats...</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1">No cap</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">Identificació</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nom</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Adreça electrònica</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultats de la cerca</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Els usuaris es localitzen a partir de qualsevol coincidència parcial en l'adreça electrònica o en el nom</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A sota hi ha la llista d'usuaris que coincideixen amb la vostra consulta. Seleccioneu els usuaris que voleu esborrar i feu clic al botó d'esborrar per continuar o feu clic en l'adreça electrònica o en el nom d'una persona per editar-los.</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Esborra usuaris</message>
-  <message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Gestiona usuaris</message>
-  <message key="xmlui.administrative.eperson.general.epeople_trail">Gestiona usuaris</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">Identificació</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nom</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuaris</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grups</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.para">S'esborraran els grups següents:</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirmeu que voleu esborrar grups</message>
-  <message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Elimina membres</message>
-  <message key="xmlui.administrative.group.EditGroupForm.collection_para">Aquest grup està associat amb la col·lecció:</message>
-  <message key="xmlui.administrative.group.EditGroupForm.cycle">Cicle</message>
-  <message key="xmlui.administrative.group.EditGroupForm.epeople_column1">Identificació</message>
-  <message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nom</message>
-  <message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Adreça electrònica</message>
-  <message key="xmlui.administrative.group.EditGroupForm.epeople_column4">No cap</message>
-  <message key="xmlui.administrative.group.EditGroupForm.groups_column1">Identificació</message>
-  <message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nom</message>
-  <message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membres</message>
-  <message key="xmlui.administrative.group.EditGroupForm.groups_column4">Col·lecció</message>
-  <message key="xmlui.administrative.group.EditGroupForm.groups_column5">No cap</message>
-  <message key="xmlui.administrative.group.EditGroupForm.instructions_para">Elimina membres</message>
-  <message key="xmlui.administrative.group.EditGroupForm.label_instructions">Aquest grup està associat a una col·lecció i no se'n pot modificar el nom</message>
-  <message key="xmlui.administrative.group.EditGroupForm.label_name">Canvia el nom del grup:</message>
-  <message key="xmlui.administrative.group.EditGroupForm.label_search">Cerca membres per afegir:</message>
-  <message key="xmlui.administrative.group.EditGroupForm.main_head">Editor del grup: {0} (codi: {1})</message>
-  <message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor del grup: grup nou</message>
-  <message key="xmlui.administrative.group.EditGroupForm.member">Membre</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_column1">Identificació</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_column2">Nom</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_column3">Adreça electrònica</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_column4">No cap</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_group_name">grup: {0}</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_head">Membres</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_none">Aquest grup no té membres.</message>
-  <message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendent]</message>
-  <message key="xmlui.administrative.group.EditGroupForm.no_results">La vostra cerca no ha donat resultats...</message>
-  <message key="xmlui.administrative.group.EditGroupForm.pending">Pendent</message>
-  <message key="xmlui.administrative.group.EditGroupForm.pending_warn">Atenció: els canvis pendents no es desen fins que no feu clic al botó de desar.</message>
-  <message key="xmlui.administrative.group.EditGroupForm.submit_add">Afegeix</message>
-  <message key="xmlui.administrative.group.EditGroupForm.submit_clear">Neteja cerca</message>
-  <message key="xmlui.administrative.group.EditGroupForm.submit_remove">Elimina</message>
-  <message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grups...</message>
-  <message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuaris...</message>
-  <message key="xmlui.administrative.group.EditGroupForm.title">Editor del grup</message>
-  <message key="xmlui.administrative.group.EditGroupForm.trail">Edita grup</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Visualitza els grups</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Feu clic ací per visualitzar tots els grups.</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crea un grup nou</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Feu clic ací per crear un grup nou.</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accions</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Cerca grups</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Visualització</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">visualització</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestió de grups</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.no_results">La vostra cerca no ha donat resultats...</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_column1">No cap</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_column2">Identificació</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nom</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membres</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Col·lecció</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultats de la cerca</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.search_help">Els grups se cerquen per coincidència parcial amb el seu nom</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Esborra grups</message>
-  <message key="xmlui.administrative.group.ManageGroupsMain.title">Gestiona grups</message>
-  <message key="xmlui.administrative.group.general.group_trail">Gestiona grups</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">Llicències Creative Commons</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Llicències</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fitxers de metadades</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fitxers de continguts (per defecte)</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniatures</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Paquet</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripció</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.file_help">Introduïu el nom del fitxer de l'ordinador que corresponga al vostre element. Si feu clic a "Visualitza...", apareixerà una nova finestra on podreu cercar i seleccionar el fitxer que teniu en l'ordinador.</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fitxer</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.head1">Penja un nou document</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Us calen els privilegis d'ADDICIÓ i ESCRIPTURA en almenys un paquet per tal de poder penjar nous documents.</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Penja</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.title">Penja document</message>
-  <message key="xmlui.administrative.item.AddBitstreamForm.trail">Penja document</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.column1">Camp</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.column3">Llengua</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifica element: {0}</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Esteu segurs que aquest element s'hauria d'esborrar del tot? Compte: si feu aquesta acció, l'element no es podrà recuperar.</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Esteu segurs que aquest element s'hauria de tornar a incorporar al fitxer?</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Esteu segurs que aquest element s'hauria de llevar del fitxer?</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Torna a incorporar</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retira</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.title">Confirma</message>
-  <message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirma</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nom</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripció</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Esteu segurs que voleu esborrar aquests documents?</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripció</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxer</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.format_default">El format no és a la llista</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format seleccionat</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.head1">Edita document</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccioneu el format del fitxer entre les opcions de la llista de sota, com ara "</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el format no és a la llista&lt;/strong&gt;, descriviu-lo en la casella que hi ha a continuació de la llista.</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Document primari</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">no</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">sí</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.title">Edita document</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.trail">Edita document</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.user_help">L'aplicació que heu usat per crear el fitxer i el número de versió (per exemple, "</message>
-  <message key="xmlui.administrative.item.EditBitstreamForm.user_label">Un altre format</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label">&lt;strong&gt;Paquet: {0}&lt;/strong&gt;</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.column1">No cap</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nom</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripció</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Visualització</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Documents</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Us cal el privilegi d'ELIMINACIÓ en l'element i en els paquets per tal de poder esborrar nous documents.</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Us calen els privilegis d'ADDICIÓ i ESCRIPTURA en l'element i en els paquets per tal de poder penjar nous documents.</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Penja un nou document</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Esborra documents</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Documents de l'element</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Documents de l'element</message>
-  <message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">visualització</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.column1">Elimina</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nom</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.column4">Llengua</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.head1">Afegeix noves metadades</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.head2">metadades</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Llengua</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nom</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.para1">ADVERTÈNCIA: aquests canvis no es validen de cap manera. Sou responsables d'introduir les dades en el format correcte. Si no esteu segurs de quin és el format, per favor, NO feu canvis.</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Afegeix noves metadades</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadades de l'element</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadades de l'element</message>
-  <message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Autoritzacions de l'element</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Suprimeix del tot l'element</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_id">Identificador intern de l'element</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_in">En col·leccions</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Modificat per última vegada</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_page">Pàgina dels elements</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Torna a incorporar l'element en el repositori</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Element llevat del repositori</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.na">no disponible</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvinguts a la pàgina de gestió de l'element. Des d'ací podeu llevar, tornar a incorporar o esborrar l'element. També podeu actualitzar o a afegir noves metadades / nous documents en altres pestanyes.</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Edita</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Esborra definitivament</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Torna a incorporar...</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Elimina...</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(només administradors del sistema)</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.title">Estat de l'element</message>
-  <message key="xmlui.administrative.item.EditItemStatusForm.trail">Estat de l'element</message>
-  <message key="xmlui.administrative.item.FindItemForm.find">Troba</message>
-  <message key="xmlui.administrative.item.FindItemForm.head1">Cerca element</message>
-  <message key="xmlui.administrative.item.FindItemForm.identifier_error">No ha estat possible resoldre l'identificador</message>
-  <message key="xmlui.administrative.item.FindItemForm.identifier_label">Identificació d'element intern/Handle de l'element</message>
-  <message key="xmlui.administrative.item.FindItemForm.title">Cerca element</message>
-  <message key="xmlui.administrative.item.ViewItem.title">Visualitza element</message>
-  <message key="xmlui.administrative.item.ViewItem.trail">Visualitza element</message>
-  <message key="xmlui.administrative.item.general.item_trail">Elements</message>
-  <message key="xmlui.administrative.item.general.option_bitstreams">Documents de l'element</message>
-  <message key="xmlui.administrative.item.general.option_head">Edita element</message>
-  <message key="xmlui.administrative.item.general.option_metadata">Metadades de l'element</message>
-  <message key="xmlui.administrative.item.general.option_status">Estat de l'element</message>
-  <message key="xmlui.administrative.item.general.option_view">Visualitza element</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.column1">No cap</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.column2">Col·lecció</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor/a</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.column4">Títol</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.head1">Visualitzant elements mapats</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">En aquesta col·lecció us cal el privilegi d'ELIMINACIÓ per poder desmapar elements d'aquesta col·lecció.</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desmapa elements seleccionats</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.title">Visualitza els elements mapats</message>
-  <message key="xmlui.administrative.mapper.BrowseItemForm.trail">Visualitza els elements mapats</message>
-  <message key="xmlui.administrative.mapper.MapperMain.head1">Mapador d'elements - Mapa elements d'altres col·leccions</message>
-  <message key="xmlui.administrative.mapper.MapperMain.no_add">(Requereix el privilegi d'ADDICIÓ de la col·lecció)</message>
-  <message key="xmlui.administrative.mapper.MapperMain.para1">Col·lecció: "&lt;strong&gt;{0}&lt;/strong&gt;"</message>
-  <message key="xmlui.administrative.mapper.MapperMain.para2">Aquesta és l'eina de mapatge d'elements que permet els administradors de col·leccions mapar elements d'altres col·leccions en aquesta. Podeu cercar elements d'altres col·leccions i mapar-les, o visualitzar la llista d'elements actualment mapats.</message>
-  <message key="xmlui.administrative.mapper.MapperMain.search_label">Cerca</message>
-  <message key="xmlui.administrative.mapper.MapperMain.stat_info">&lt;strong&gt;{0} de {1}&lt;/strong&gt; elements d'aquesta col·lecció han sigut mapats d'altres col·leccions</message>
-  <message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadístiques</message>
-  <message key="xmlui.administrative.mapper.MapperMain.submit_browse">Visualitza els elements mapats</message>
-  <message key="xmlui.administrative.mapper.MapperMain.submit_search">Cerca elements</message>
-  <message key="xmlui.administrative.mapper.MapperMain.title">Mapador d'elements</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.column1">No cap</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.column2">Col·lecció</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor/a</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.column4">Títol</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.head1">Cerca coincidència d'elements: "{0}"</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Mapa els elements seleccionats</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.title">Cerca elements</message>
-  <message key="xmlui.administrative.mapper.SearchItemForm.trail">Cerca elements</message>
-  <message key="xmlui.administrative.mapper.general.mapper_trail">Mapador d'elements</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">Identificació</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipus MIME</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nom</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Esteu segurs que voleu esborrar el format? Qualssevol documents d'aquest format que existisquen tornaran a tenir el format de document desconegut.</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Esborra formats del document</message>
-  <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Esborra formats del document</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">Identificació</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nom</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota d'abast</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Esteu</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Si hi ha algun element que conté metadades per a aquests camps, aquesta acció provocarà un error.</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Esborra camps</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Esborra camps</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVÍS:</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">Identificació</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espai de nom</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nom</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmeu que voleu esborrar</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Esteu</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Si hi ha algun element amb metadades dins d'aquest esquema, l'acció provocarà un error.</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Esborra esquema</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Esborra esquema</message>
-  <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVÍS:</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripció</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensions dels fitxers</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions són extensions de fitxers que s'apliquen automàticament per identificar el format dels fitxers carregats. Per a cada format podeu introduir diverses extensions.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nou format de document</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format del document: {0}</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Intern</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Els formats marcats com a interns estan ocults per a l'usuari i s'utilitzen amb finalitats administratives.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipus MIME</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype.help">El tipus MIME associat a aquest format no ha de ser necessàriament únic.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nom</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El camp del nom és obligatori.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nom únic per a aquest format (per exemple, Microsoft Word XP o Microsoft Word 2000)</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Faciliteu metadades descriptives sobre el format del document a sota. Si bé els noms de format han de ser únics, en el cas dels tipus MIME no ho han de ser necessàriament. Podeu tenir entrades de registre de format distintes per a versions diferents de Microsoft Word, encara que el tipus MIME serà el mateix per cadascuna d'elles.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivell de suport</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconegut</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conegut</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Amb suport</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">El nivell de suport que la vostra institució garanteix per a aquest format.</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format del document</message>
-  <message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format del document</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.column1">No cap</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.column2">Identificació</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.column3">Camp</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota d'abast</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.empty">No hi ha camps de metadades</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nom del camp ja es troba en ús; tots els elements i qualificadors han de ser únics.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L'element del camp conté un caràcter incorrecte. L'element NO pot contenir punts, caràcters de subratllat o espais.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'element del camp és obligatori.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L'element del camp és massa llarg, ha de tenir menys de 32 caràcters.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El qualificador del camp conté un caràcter incorrecte. El qualificador NO pot contenir: punts, caràcters de subratllat o espais.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El qualificador del camp és massa llarg, ha de tenir menys de 32 caràcters.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadades: "{0}"</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.head2">Camps de metadades de l'esquema</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.head3">Afegeix nou camp de metadades</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.head4">Actualitza camp: {0}</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.name">Nom del camp</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota d'abast</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes addicionals sobre aquest camp de metadades</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.para1">Aquest és l' esquema de metadades per a "{0}". Podeu afegir nous camps de metadades a aquest esquema o actualitzar els existents. També podeu seleccionar camps per esborrar o desplaçar a un altre esquema.</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Afegeix nou camp de metadades</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Esborra camps</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Desplaça camps a un altre esquema</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Actualitza camp</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadades</message>
-  <message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadades</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.column1">No cap</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.column2">Identificació</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nom</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipus MIME</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivell de suport</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.head">Registre de formats de documents</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.internal">(</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Afegeix un nou format de document</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.para1">Aquesta llista de formats de documents dóna informació sobre formats coneguts i el seu nivell de suport. Podeu editar formats de documents o afegir-ne de nous amb aquesta eina. Els formats marcats com a "interns" es troben ocults per a l'usuari i s'utilitzen amb finalitats administratives.</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Esborra formats</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconegut</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conegut</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Amb suport</message>
-  <message key="xmlui.administrative.registries.FormatRegistryMain.title">Registre de format</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.column1">No cap</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.column2">Identificació</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espai de nom</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nom</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.head1">registre de metadades</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Afegeix un nou esquema</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nom</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Aquest camp és obligatori i no pot incloure espais, punts o caràcters de subratllat.</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notació abreujada per a l'esquema. S'usarà com a prefix d'un nom de camp (per exemple, dc.element.qualifier). El nom ha de tenir menys de 32 caràcters i no pot incloure espais, punts o caràcters de subratllat.</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espai de nom</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Aquest camp és obligatori</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L'espai de nom hauria de ser un lloc URI per al nou esquema.</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registre de metadades manté una llista de tots els camps de metadades disponibles en aquest repositori. Aquests camps poden dividir-se entre múltiples esquemes. No obstant això, DSpace requereix l'esquema Qualified Dublin Core. Podeu ampliar l'esquema Dublin Core amb camps addicionals o afegir nous esquemes al registre.</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Afegeix nou esquema</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Esborra esquema</message>
-  <message key="xmlui.administrative.registries.MetadataRegistryMain.title">registre de metadades</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.column1">Identificació</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.column2">Nom</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota d'abast</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.head1">Desplaça camps de metadades</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.para1">Seleccioneu un esquema de destinació per als camps que voleu desplaçar. Si l'esquema de destinació té camps amb noms idèntics, els camps no s'hi desplaçaran.</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.para2">Desplaça a l'esquema:</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Desplaça camps</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.title">Desplaça camps</message>
-  <message key="xmlui.administrative.registries.MoveMetadataField.trail">Desplaça camps</message>
-  <message key="xmlui.administrative.registries.general.format_registry_trail">Registre de format</message>
-  <message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de metadades</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">El logo de la col·lecció</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Actualment la visualització resum d'una col·lecció no es troba en ús o aplicació. Això pot solucionar-se substituint la plantilla de dri2xhtml anomenada collectionSummaryView</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">El logo de la comunitat</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">La visualització resum d'una comunitat no es troba en ús o aplicació. Això pot solucionar-se substituint la plantilla de dri2xhtml anomenada communitySummaryView.</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.copyright">Copyright i llicència</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elements de Dublin Core</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termes de Dublin Core</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resum</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor/a</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripció</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxers</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Fitxers en aquest element</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Grandària</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Visualització</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualitza/</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hi ha fitxers associats a aquest element.</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-preview">Visualització prèvia</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-subject">Assumpte</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-title">Títol</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.license-text">Els següents fitxers sobre la llicència estan associats a aquest element:</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.news">Notícies</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconegut</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Cap logo</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.no-preview">No hi ha visualització prèvia disponible</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.no-title">Sense títol</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Aquest objecte de DSpace no s'ajusta al perfil METS 1.0 i com a tal no pot renderitzar-se de manera eficaç. Podeu substituir la plantilla que gestiona el cas general en dri2xhtml per a executar la funció requerida o podeu crear una plantilla que concorde amb tots aquells perfils que useu.</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Qualified Dublin Core (QDC) no és aplicable a comunitats i col·leccions de DSpace en aquest moment. Quan useu QDC, hauríeu d'usar la correspondència QDC per a elements de DSpace i o bé DIM o MODS per al tractament de comunitats i col·leccions.</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-  <message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-  <message key="xmlui.dri2xhtml.default.textarea.value"> </message>
-  <message key="xmlui.dri2xhtml.pioneer.author">Autor/a</message>
-  <message key="xmlui.dri2xhtml.pioneer.date">Data</message>
-  <message key="xmlui.dri2xhtml.pioneer.preview">Visualització prèvia</message>
-  <message key="xmlui.dri2xhtml.pioneer.title">Títol</message>
-  <message key="xmlui.dri2xhtml.structural.contact-link">Poseu-vos en contacte amb nosaltres</message>
-  <message key="xmlui.dri2xhtml.structural.feedback-link">Envieu suggeriments</message>
-  <message key="xmlui.dri2xhtml.structural.footer-promotional">No cap</message>
-  <message key="xmlui.dri2xhtml.structural.head-subtitle">Repositori DSpace/Manakin</message>
-  <message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-  <message key="xmlui.dri2xhtml.structural.link_original_license">Llicència original</message>
-  <message key="xmlui.dri2xhtml.structural.login">Connexió</message>
-  <message key="xmlui.dri2xhtml.structural.logout">Desconnexió</message>
-  <message key="xmlui.dri2xhtml.structural.pagination-info">Ara mostrant els elements {0}-{1} d {2}</message>
-  <message key="xmlui.dri2xhtml.structural.pagination-next">Pàgina següent</message>
-  <message key="xmlui.dri2xhtml.structural.pagination-previous">Pàgina anterior</message>
-  <message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
-  <message key="xmlui.dri2xhtml.structural.search">Cerca a DSpace</message>
-  <message key="xmlui.dri2xhtml.structural.search-advanced">Cerca avançada</message>
-  <message key="xmlui.dri2xhtml.structural.search-in-collection">Aquesta col·lecció</message>
-  <message key="xmlui.dri2xhtml.structural.search-in-community">Aquesta comunitat</message>
-  <message key="xmlui.eperson.noAuthMethod.head">No s'ha trobat mètode d'autenticació</message>
-  <message key="xmlui.eperson.noAuthMethod.p1">No s'ha trobat mètode d'autenticació. Per favor, poseu-vos en contacte amb l'administrador del lloc.</message>
-  <message key="xmlui.eperson.shibbLoginFailure.head">L'accés amb Shibboleth ha fallat</message>
-  <message key="xmlui.eperson.shibbLoginFailure.p1">L'autenticació amb Shibboleth no és disponible en aquest moment. Per favor, poseu-vos en contacte amb l'administrador del lloc.</message>
-  <message key="xmlui.feed.general_description">El sistema de repositori digital DSpace captura, emmagatzema, indexa, conserva i distribueix material de recerca digital.</message>
-  <message key="xmlui.feed.logo_title">Imatge del canal</message>
-  <message key="xmlui.feed.untitled">Sense títol</message>
-  <message key="xmlui.general.cancel">Cancel·la</message>
-  <message key="xmlui.general.delete">Esborra</message>
-  <message key="xmlui.general.dspace_home">Inici de DSpace</message>
-  <message key="xmlui.general.go">Vés</message>
-  <message key="xmlui.general.go_home">Vés a l'inici</message>
-  <message key="xmlui.general.next">Següent</message>
-  <message key="xmlui.general.notice.default_head">Avís</message>
-  <message key="xmlui.general.return">Torna</message>
-  <message key="xmlui.general.save">Desa</message>
-  <message key="xmlui.general.search">Cerca</message>
-  <message key="xmlui.general.untitled">Sense títol</message>
-  <message key="xmlui.general.update">Actualitza</message>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+
+	<!--
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
+		   because they are used very frequently.
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
+	<!-- General keys -->
+	<message key="xmlui.general.dspace_home">Inici de DSpace</message>
+	<message key="xmlui.general.search">Cerca</message>
+	<message key="xmlui.general.go">Vés</message>
+	<message key="xmlui.general.go_home">Vés a l'inici</message>
+	<message key="xmlui.general.save">Desa</message>
+	<message key="xmlui.general.cancel">Cancel·la</message>
+	<message key="xmlui.general.return">Torna</message>
+	<message key="xmlui.general.update">Actualitza</message>
+	<message key="xmlui.general.delete">Esborra</message>
+	<message key="xmlui.general.next">Següent</message>
+	<message key="xmlui.general.untitled">Sense títol</message>
+        <message key="xmlui.general.perform">Perform</message>
+        <message key="xmlui.general.queue">Queue</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
+		This is a special component that is not part of any aspect but is added
+		by manakin to all aspect chains.
+		-->
+	<message key="xmlui.PageNotFound.title">Pàgina no trobada</message>
+	<message key="xmlui.PageNotFound.head">Pàgina no trobada</message>
+	<message key="xmlui.PageNotFound.para1">No es pot trobar la pàgina que heu sol·licitat.</message>
+
+
+	<!--
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Only site administrators may assume login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
+	-->
+	<message key="xmlui.feed.general_description">El sistema de repositori digital DSpace captura, emmagatzema, indexa, conserva i distribueix material de recerca digital.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
+	<message key="xmlui.feed.logo_title">Imatge del canal</message>
+	<message key="xmlui.feed.untitled">Sense títol</message>
+
+	<!--
+		Default notice header
+	 	-->
+	<message key="xmlui.general.notice.default_head">Avís</message>
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             ArtifactBrowser Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultats de la cerca en la comunitat {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultats de la cerca en la col·lecció {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultats de la cerca</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">La vostra consulta "{0}" ha produït {1} resultat(s).</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunitats o col·leccions que coincideixen amb la vostra consulta</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Elements que coincideixen amb la vostra consulta</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La cerca no ha donat cap resultat.</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tot DSpace</message>
+
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">títol</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data de publicació</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data d'enviament</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinència</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordena els elements per</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en ordre</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendent</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendent</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultats/pàgina</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Àmbit de la cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiteu la vostra cerca a una comunitat o col·lecció.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunció</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipus de cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor/a</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Títol</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Matèria</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resum</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sèrie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Llengua (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Mot clau</message>
+
+   <!--  some common other possibilities for Advanced Search Fields -->
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Col·laborador/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Autor/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripció</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relació</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipus MIME</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Altres col·laboradors</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Assessor</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departament</message>
+
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Text complet</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introduïu les primeres lletres:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Visualitza els elements que comencen amb aquestes lletres</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Salta a un punt de l'índex:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Seleccioneu el mes)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Seleccioneu l'any)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O introduïu un any:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Visualitza els elements que siguen d'un any determinat.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sorry, there are no results for this browse.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordena per:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Ordre:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultats:</message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autors/Element:</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Tots</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">títol</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data de publicació</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data d'enviament</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendent</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendent</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nom de l'autor/a</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Matèria</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Visualitza {0} per autor {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Visualitza {0} per autor</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Visualitza {0} per matèria {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Visualitza {0} per matèria</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Visualitzant {0} per títol {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Visualitzant {0} per títol</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Visualitzant {0} per data de publicació {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Visualitzant {0} per data de publicació</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Visualitzant {0} per data d'enviament {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Visualitzant {0} per data d'enviament</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Àmbit de la cerca</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tot DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Cerca de text complet:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Visualitza per</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títols</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autors</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Dates</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Enviaments recents</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Llista de comunitats</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Llista de comunitats</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunitats a DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Seleccioneu una comunitat per visualitzar-ne les col·leccions.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Àmbit de la cerca</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Tot DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Cerca de text complet:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Visualitza per</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títols</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autors</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Dates</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunitats dins d'aquesta comunitat</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Col·leccions en aquesta comunitat</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Enviaments recents</message>
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
+	<message key="xmlui.ArtifactBrowser.Contact.title">Poseu-vos en contacte amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Poseu-vos en contacte amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Poseu-vos en contacte amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">Podeu posar-vos en contacte amb {0} administradors a:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulari electrònic</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Informació</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Correu electrònic</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Suggeriments</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Suggeriments</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Suggeriments</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gràcies pels suggeriments sobre el sistema DSpace.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Correu</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Utilitzarem aquesta adreça per respondre als vostres comentaris.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Envieu-nos informació</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Suggeriments</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Suggeriments</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Suggeriments enviats</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Hem rebut els vostres comentaris.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Visualitza element</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Aquest element apareix en la col·lecció o col·leccions següent(s)</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostra el registre parcial de l'element</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostra el registre complet de l'element</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Visualitza</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tot DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunitats i col·leccions</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títols</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autor/a</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Matèries</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Per data de publicació</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Per data d'enviament</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Aquesta col·lecció</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Aquesta comunitat</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Àmbit de la cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Cerca de text complet</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Aquest recurs és restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Aquest recurs és restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Aquesta comunitat és restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Aquesta col·lecció és restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Aquest element és restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Aquest document és restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No teniu permisos suficients per accedir al recurs restringit.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No teniu permisos suficients per accedir a la comunitat restringida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No teniu permisos suficients per accedir a la comunitat restringida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No teniu permisos suficients per accedir a l'element restringit<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No teniu permisos suficients per accedir al document restringit<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">col·lecció</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunitat</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">document</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">element</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurs</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconegut</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
+	<!-- Authentication messages used at the top of the login page:  -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'element és restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">L'element al qual voleu accedir és un element restringit i per veure'l heu de tenir permisos. Identifiqueu-vos a sota per accedir a l'element.</message>
+
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes mensuals</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resum estadístic</message>
+
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">No hi ha informes disponibles</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Ara mateix no hi ha cap informe disponible per a aquest servei. Comproveu si n'hi ha algun més endavant.</message>
+
+    <!-- Authentication messages used for bitstream authentication -->
+	<message key="xmlui.BitstreamReader.auth_header">El fitxer és restringit</message>
+	<message key="xmlui.BitstreamReader.auth_message">El fitxer al qual voleu accedir és un element restringit i per veure'l heu de tenir permisos. Identifiqueu-vos a sota per accedir al fitxer.</message>
+
+	<!-- Export Archive download messages -->
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Aquest arxiu d'exportació és restringit.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">L'arxiu d'exportació al qual tracteu d'accedir és un recurs restringit i per visualitzar-lo calen permisos. Autentiqueu-vos a continuació per accedir l'arxiu d'exportació.</message>
+
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                EPerson Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- General keys used by the EPerson aspect -->
+	<message key="xmlui.EPerson.trail_new_registration">Registre d'usuari nou</message>
+	<message key="xmlui.EPerson.trail_forgot_password">He oblidat la contrasenya</message>
+
+	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
+	<message key="xmlui.EPerson.CannotRegister.title">Registre no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Registre no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">La configuració d'aquest repositori DSpace no permet registrar-vos-hi en aquest context. Poseu-vos en contacte amb &lt;a href="../contact"&gt;administrador&lt;/a&gt;<a href="../contact">site administrator</a> with questions or comments.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
+	<message key="xmlui.EPerson.EditProfile.title_update">Actualitza perfil</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Crea perfil</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Actualitza perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Actualitza perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Crea perfil</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Adreça de correu electrònic</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Nom</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Cognoms</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Telèfon</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Language</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Subscripcions</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Podeu subscriure-us a col·leccions per rebre missatges diaris de correu electrònic sobre nous elements incorporats. Podeu subscriure-us a tantes col·leccions com desitgeu. Una alternativa als missatges diaris de correu electrònic és l'ús de canals RSS disponibles per a totes les col·leccions.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscripcions per correu electrònic</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">(Seleccioneu col·lecció)</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalment, podeu introduir una nova contrasenya en la casella de sota, que haureu de confirmar tornant a escriure-la en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Introduïu una nova contrasenya en la casella de sota i confirmeu-la tornant-la a escriure en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Contrasenya</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Torneu a escriure-la per confirmar-la</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Completa el registre</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Actualitza perfil</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Aquest camp és obligatori</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Trieu una contrasenya d'almenys sis caràcters</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Grups d'autorització als quals pertanyeu</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identifica</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Seguretat</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Comproveu l'adreça electrònica</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crea perfil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Finalitzat</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Comproveu l'adreça electrònica</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restaura contrasenya</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Finalitzat</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Restauració de contrasenya</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Restauració de contrasenya</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">S'ha restaurat la vostra contrasenya.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
+	<message key="xmlui.EPerson.InvalidToken.title">Cadena no vàlida</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Cadena no vàlida</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Cadena no vàlida</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">La URL que heu facilitat no és vàlida. La URL pot haver-se dividit en diverses línies en el vostre client de correu, com per exemple així:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Si és així, copieu la URL completa i enganxeu-la directament en la barra d'adreces del vostre navegador, en comptes de fer simplement clic en l'enllaç. La barra d'adreces hauria de mostrar alguna cosa com ara:</message>
+
+	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
+	<message key="xmlui.EPerson.Navigation.my_account">El meu compte</message>
+	<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
+	<message key="xmlui.EPerson.Navigation.logout">Ix</message>
+	<message key="xmlui.EPerson.Navigation.login">Entra</message>
+	<message key="xmlui.EPerson.Navigation.register">Registre</message>
+
+	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
+	<message key="xmlui.EPerson.PasswordLogin.title">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Autentiqueu-vos a DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">L'adreça electrònica o la contrasenya introduïdes no són vàlides.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Contrasenya</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">Heu oblidat la vostra contrasenya?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Registre com a usuari nou</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Registreu un compte per subscriure'm a col·leccions per a actualitzacions per correu electrònic i enviament de nous elements a DSpace.</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Feu clic ací per registrar-vos.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
+	<message key="xmlui.EPerson.LDAPLogin.title">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Identifiqueu-vos a DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Nom d'usuari</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nom d'usuari o la contrasenya introduïdes no són vàlides.</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Contrasenya</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Identifiqueu-vos</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
+	<message key="xmlui.EPerson.LoginChooser.title">Escolliu un mètode d'accés</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Escolliu nom d'usuari</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Escolliu un mètode d'accés</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Accediu per mitjà de:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth Authentication</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticació amb LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticació amb contrasenya</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Autenticació amb certificat web</message>
+
+	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Les credencials facilitades no són vàlides.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">L'autenticació no ha sigut possible perquè els arguments rebuts són no vàlids.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No s'ha trobat cap usuari amb les credencials facilitades.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">L'autenticació ha fallat</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">L'autenticació ha fallat</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">L'autenticació ha fallat</message>
+
+	<!-- Login xml files -->
+	<message key="xmlui.eperson.noAuthMethod.head">No s'ha trobat mètode d'autenticació</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">No s'ha trobat mètode d'autenticació. Per favor, poseu-vos en contacte amb l'administrador del lloc.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">L'accés amb Shibboleth ha fallat</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">L'autenticació amb Shibboleth no és disponible en aquest moment. Per favor, poseu-vos en contacte amb l'administrador del lloc.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
+	<message key="xmlui.EPerson.ProfileUpdated.title">Perfil actualitzat</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Actualitza perfil</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Perfil actualitzat</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">La informació del vostre perfil ha estat actualitzada.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
+	<message key="xmlui.EPerson.RegistrationFinished.title">El registre ha finalitzat</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">El registre ha finalitzat</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Ara ja us heu registrat per usar el sistema DSpace. Podeu subscriure-us a col·leccions per rebre actualitzacions per correu electrònic sobre nous elements.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
+	<message key="xmlui.EPerson.ResetPassword.title">Restaura contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Restaura contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Introduïu una nova contrasenya en la casella de sota i confirmeu-la tornant-la a escriure en la segona casella. La contrasenya ha de tenir almenys sis caràcters.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Nova contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Torneu a escriure-la per confirmar-la</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Restaura contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Trieu una contrasenya d'almenys 6 caràcters</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
+	<message key="xmlui.EPerson.StartForgotPassword.title">He oblidat la contrasenya</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">He oblidat la contrasenya</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Introduïu l'adreça electrònica que vau facilitar quan vau registrar-vos a DSpace. Us arribarà un missatge a aquesta adreça amb les indicacions que heu de seguir.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduïu la mateixa adreça que vau usar a l'hora de registrar-vos.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Adreça electrònica no trobada</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Envieu informació</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
+	<message key="xmlui.EPerson.StartRegistration.title">Registre com a nou usuari</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Aquesta adreça electrònica ja l'usa algú</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Que l'adreça electrònica ja l'usa algú més. Si voleu restaurar la contrasenya per aquest compte, feu clic al botó de restauració de contrasenya de sota.</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restaura contrasenya per a</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Restaura contrasenya</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Registre com a nou usuari</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Registra un compte per subscriure'm a col·leccions per rebre actualitzacions per correu electrònic i enviar nous elements a DSpace.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Aquesta adreça serà verificada i utilitzada com a nom d'usuari.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">No ha estat possible enviar correu a aquesta adreça.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Registre</message>
+
+	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
+	<message key="xmlui.EPerson.VerifyEmail.title">S'ha enviat una verificació de correu electrònic</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">S'ha enviat una verificació de correu electrònic</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">S'ha enviat un correu electrònic a {0} amb una URL especial i instruccions pertinents.</message>
+
+
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		               Submission Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- general submission aspect messages -->
+	<message key="xmlui.Submission.general.mydspace_home">Inici de El meu DSpace</message>
+	<message key="xmlui.Submission.general.go_mydspace">Vés a l'inici de El meu DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.trail">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.head">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
+	<message key="xmlui.Submission.general.submission.save">Desa i ix</message>
+	<message key="xmlui.Submission.general.submission.next">Següent &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Completa l'enviament</message>
+	<message key="xmlui.Submission.general.workflow.title">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.workflow.trail">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.workflow.head">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.showfull">Mostra registre d'element complet</message>
+	<message key="xmlui.Submission.general.showsimple">Mostra registre d'element parcial</message>
+	<message key="xmlui.Submission.general.default.title">Enviament</message>
+	<message key="xmlui.Submission.general.default.trail">Enviament</message>
+
+	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
+	<message key="xmlui.Submission.CollectionViewer.link1">Envia un nou element a aquesta col·lecció</message>
+
+	<!-- org.dspace.app.xmlui.submission.Navigation -->
+	<message key="xmlui.Submission.Navigation.submissions">Enviaments</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Enviaments i flux de treball</message>
+	<message key="xmlui.Submission.Submissions.trail">Enviaments</message>
+	<message key="xmlui.Submission.Submissions.head">Enviaments i tasques de flux de treball</message>
+	<message key="xmlui.Submission.Submissions.untitled">No cap<i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">adreça electrònica:</message>
+	<!-- Same transformer, workflow section -->
+	<message key="xmlui.Submission.Submissions.workflow_head1">Tasques de flux de treball</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Aquestes tasques són elements que es troben a l'espera d'aprovació abans de ser incorporades al repositori. Hi ha dues cues de tasques; una és per a les tasques que heu decidit acceptar i l'altra és per a les tasques que encara no han sigut triades per ningú.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Tasques vostres</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1">No cap</message>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Tasca</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Element</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Remitent</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Torna les tasques seleccionades a la cua</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">No s'us ha assignat cap tasca</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Tasques en la cua</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Agafa tasques seleccionades</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">A la cua no hi ha tasques</message>
+	<!-- Same transformer, submissions section -->
+	<message key="xmlui.Submission.Submissions.submit_head1">Enviaments</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Podeu</message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">iniciar un nou enviament</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">El procés d'enviament inclou la descripció de l'element i la pujada de fitxer(s) que el comprèn o els comprenen. Cada comunitat o col·lecció pot fixar privilegis d'enviament pròpies.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Enviaments no finalitzats</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Aquests són enviaments d'elements incomplets. També podeu</message>
+	<message key="xmlui.Submission.Submissions.submit_info2b">iniciar un altre enviament</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1">No cap</message>
+	<message key="xmlui.Submission.Submissions.submit_column2">Títol</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Remitent</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Autor/a:</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">No queda cap enviament incomplet.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Supervisant:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Elimina els enviaments seleccionats</message>
+	<!-- Same transformer, inprogress section -->
+	<message key="xmlui.Submission.Submissions.progress_head1">Els enviaments es troben en procés de revisió</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Aquests són els vostres enviaments conclosos que es troben en procés de revisió per part dels responsables de la col·lecció</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Títol</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Estat</message>
+	<!-- Same transformer, workflow status -->
+	<message key="xmlui.Submission.Submissions.status_0">Enviat</message>
+	<message key="xmlui.Submission.Submissions.status_1">A l'espera de revisió</message>
+	<message key="xmlui.Submission.Submissions.status_2">Enviament en procés de revisió</message>
+	<message key="xmlui.Submission.Submissions.status_3">A l'espera de revisió par part de l'editor</message>
+	<message key="xmlui.Submission.Submissions.status_4">Enviament en procés de revisió</message>
+	<message key="xmlui.Submission.Submissions.status_5">A l'espera de revisió per part de l'editor final</message>
+	<message key="xmlui.Submission.Submissions.status_6">Enviament en procés d'edició</message>
+	<message key="xmlui.Submission.Submissions.status_7">S'ha arxivat l'enviament</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Estat desconegut</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
+
+	<!-- submission progress bar messages -->
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Qüestions inicials</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Descriu</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Penja</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Revisa</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Llicència</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Completa</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Reinicia</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
+	<message key="xmlui.Submission.submit.SelectCollection.head">Seleccioneu una col·lecció</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Col·lecció</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccioneu la col·lecció a la qual desitgeu enviar un element.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccioneu una col·lecció...</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Voleu desar o cancel·lar l'enviament?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voleu cancel·lar l'enviament, o voleu continuar treballant amb ell més endavant? Podeu tornar al procés d'enviament si heu fet clic a Ix per error.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continua amb l'enviament</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Desa'l, treballaré amb ell més endavant</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Cancel·la l'enviament</message>
+
+
+	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Qüestions inicials</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota important:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and">i</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Títols múltiples</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'element té més d'un títol,<i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la casella de selecció de dalt no es troba marcada, aleshores el(s) següent(s) títol(s) s'eliminaran de l'element:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicat</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">L'element s'ha publicat o distribuït públicament abans</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la casella de selecció de dalt no es troba marcada, aleshores s'eliminarà de l'element el següent:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data de publicació</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
+	<message key="xmlui.Submission.submit.DescribeStep.head">Descriu element</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: tipus de fitxer desconegut</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Aquest camp és obligatori</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognoms,<i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Noms) + "",<i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Any</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Dia</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la sèrie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Informe o article núm.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+	<message key="xmlui.Submission.submit.UploadStep.head">Penja fitxer(s)</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Per favor, introduïu la ruta completa del fitxer del vostre ordinador que correspon al vostre element. Si feu clic a "Visualitza...", una nova finestra us permetrà seleccionar el fitxer del vostre ordinador.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">L'element ha de estar compost per almenys un fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">There was a problem uploading your file.  Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only.  Please try again.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Descripció del fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Penja fitxer i afegeix-ne un altre</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Fitxers penjats</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Primari</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1">No cap</message>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Grandària</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Descripció</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6">No cap</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconegut</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">format desconegut</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Conegut)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Incompatible)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Edita</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Comprovació de fitxers</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Elimina fitxer seleccionats</message>
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
+	<message key="xmlui.Submission.submit.EditFileStep.head">Edita fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Descripció del fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Si voleu, doneu una descripció breu dels continguts, com per exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccioneu el format del fitxer entre les opcions de la llista de sota, com ara "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Format detectat</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Format seleccionat</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">El format no és a la llista</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Si el format no és a la llista de dalt,&lt;strong&gt;seleccioneu "el format no és a la llista " a dalt &lt;/strong&gt; i descriviu el format del fitxer en la casella de sota.<strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Un altre format</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nom de l'aplicació que vau fer servir per crear el fitxer i número de versió (per exemple, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">Revisa enviament</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">No</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregeix el següent</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Afegeix o elimina fitxer</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Qüestions inicials</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Descriu pàgina {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Fitxers penjats</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Títols múltiples</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicat abans de</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">desconegut</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">conegut</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Llicència Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Si voleu, podeu afegir una llicència &lt;a href="http://creativecommons.org/"&gt;Creative Commons&lt;/a&gt;<a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Vés al lloc web de Creative Commons per seleccionar una llicència</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Llicència</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">no heu seleccionat cap llicència Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
+	<message key="xmlui.Submission.submit.LicenseStep.head">Llicència de distribució</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1">&lt;strong&gt;Queda un últim pas:&lt;/strong&gt; Per tal que DSpace reproduïsca, traduïsca i distribuïsca el vostre enviament a tot el món, heu d'acceptar les condicions següents.<strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Concediu la llicència de distribució estàndard fent clic a "Concedisc la llicència"; a continuació, feu clic a "Conclou enviament".</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Si teniu dubtes al voltant de la llicència, poseu-vos en contacte amb els administradors del sistema.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Llicència de distribució</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concessió de llicència</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Per concloure l'enviament, heu de concedir aquesta llicència. Si no podeu concedir aquesta llicència en aquest moment, podeu desar el vostre treball i tornar més tard o cancel·lar l'enviament fent clic al botó 'Desa i Ix' de sota.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
+	<message key="xmlui.Submission.submit.RemovedStep.head">Enviament cancel·lat</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Heu cancel·lat el vostre enviament i l'element incomplet ha sigut eliminat del sistema.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Vés a la pàgina d'enviaments</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
+	<message key="xmlui.Submission.submit.CompletedStep.head">Enviament conclòs</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Ara el vostre enviament seguirà el procés de revisió d'aquesta col·lecció. Quan el vostre enviament haja sigut incorporat a la col·lecció, o si hi ha algun problema amb l'enviament, rebreu una notificació per correu electrònic. També podeu comprovar l'estat del vostre enviament consultant la vostra pàgina d'enviaments.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Vés a la pàgina d'enviaments.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Envia un altre element</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accions que podeu dur a terme pel que fa a aquesta tasca:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Assigneu-vos aquesta tasca.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Tria la tasca</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixa aquesta tasca en la cua perquè la trie algú altre.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Deixa la tasca</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si heu revisat l'element i resulta adequat per incorporar-lo a la col·lecció, seleccioneu "Aprova".</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprova element</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Una vegada hàgeu editat l'element, utilitzeu aquesta opció per assignar l'element al fitxer.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Assigneu a fitxer</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si heu revisat l'element i creieu que &lt;strong&gt;no&lt;/strong&gt; és adequat per ser incorporat a la col·lecció, seleccioneu "Rebutja". Després s'us demanarà que escriviu un missatge que explique perquè no és adequat i si la persona que fa l'enviament hauria de canviar alguna cosa i tornar-lo a enviar.<strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rebutja element.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Seleccioneu aquesta opció per canviar les metadades de l'element.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edita metadades</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Torna la tasca a la cua perquè un altre usuari puga dur a terme la tasca.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Torna la tasca a la cua.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">En la casella de sota, doneu una raó per la qual rebutgeu l'enviament, i assenyaleu si la persona que ha fet l'enviament pot resoldre el problema i tornar a enviar l'element modificat.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Raó</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El camp Raó és obligatori</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rebutja element</message>
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             Administrative Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">S'ha incorporat l'usuari correctament.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">S'ha editat l'usuari correctament.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">S'ha enviat un missatge de correu electrònic a l'usuari amb un testimoni que pot utilitzar-se per a triar una nova contrasenya.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">S'ha esborrat correctament l'usuari o els usuaris.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">No s'ha(n) esborrat l'usuari o usuaris llistat(s) perquè hi ha restriccions que ho impedeixen; vegeu la pàgina de dades de l'usuari per a més informació.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">S'ha editat correctament el grup.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">S'han esborrat correctament els grups seleccionats.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">S'han creat correctament nous esquemes.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">S'ha(n) esborrat correctament l'esquema o els esquemes.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">S'ha incorporat correctament el camp de metadades.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">S'ha editat correctament el camp de metadades.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">S'ha(n) canviat de lloc correctament el(s) camp(s).</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">S'ha(n) esborrat correctament el(s) camp(s).</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">S'ha desat correctament el format.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">S'ha(n) esborrat correctament el(s) format(s).</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">S'han actualitzat correctament les metadades de l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">S'han afegit noves metadades.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">S'ha retirat l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">S'ha reincorporat l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">The item has been moved.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">The selected destination collection could not be found.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">S'ha penjat correctament el nou document.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error en la pujada del fitxer.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">S'ha actualitzat el document.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">S'han esborrat els documents seleccionades.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">S'han mapat elements correctament.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">S'han desmapat els elements.</message>
+
+	<!-- general items for all of the eperson classes -->
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Gestiona usuaris</message>
+
+	<!-- org.dspace.app.xmlui.administrative.Navigation -->
+	<!-- contextual menu items -->
+	<message key="xmlui.administrative.Navigation.context_head">Context</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Edita aquest element</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Edita col·lecció</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Mapador d'elements</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Edita comunitat</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Crea col·lecció</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crea subcomunitat</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Crea comunitat</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Exporta element</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exporta col·lecció</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exporta comunitat</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Export Metadata</message>
+
+	<!-- Site administrator options -->
+	<message key="xmlui.administrative.Navigation.administrative_head">Administratiu</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Control d'accés</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Persones</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Grups</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Autoritzacions</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Registres</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadades</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Format</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Elements</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Retira elements</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Tauler de control</message>
+    <message key="xmlui.administrative.Navigation.statistics">Estadístiques</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
+
+    <!-- my account items -->
+	<message key="xmlui.administrative.Navigation.account_export">Les meues exportacions</message>
+
+
+	<!-- export item -->
+	<message key="xmlui.administrative.ItemExport.head">Arxiu d'exportació</message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">El codi d'element indicat no és vàlid.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">La col·lecció indicada no és vàlida.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">El codi de comunitat indicat no és vàlid.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">No s'ha trobat l'element sol·licitat.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">No s'ha trobat la col·lecció sol·licitada.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">No s'ha trobat la col·lecció sol·licitada.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">The item was exported successfully.  You should receive an e-mail when the archive is ready for download.  You can also use the 'My Exports' link to view a list of your available archives.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">La col·lecció s'ha exportat correctament. Hauríeu de rebre un correu electrònic quan l'arxiu estiga disponible per descarregar. També podeu usar l'enllaç "Les meues exportacions" per veure una llista dels arxius que teniu disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">La comunitat s'ha exportat correctament. Hauríeu de rebre un correu electrònic quan l'arxiu estiga disponible per descarregar. També podeu usar l'enllaç "Les meues exportacions" per veure una llista dels arxius que teniu disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Arxius d'exportació disponibles per descarregar.</message>
+
+
+
+    <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Gestiona usuaris</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestió d'usuaris</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accions</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crea un nou usuari</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Feu clic ací per afegir un nou usuari.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Visualitza usuaris</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Feu clic ací per visualitzar tots els usuaris.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Cerca usuaris</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Els usuaris es localitzen a partir de qualsevol coincidència parcial en l'adreça electrònica o en el nom</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A sota hi ha la llista d'usuaris que coincideixen amb la vostra consulta. Seleccioneu els usuaris que voleu esborrar i feu clic al botó d'esborrar per continuar o feu clic en l'adreça electrònica o en el nom d'una persona per editar-los.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1">No cap</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">Identificació</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nom</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Adreça electrònica</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Esborra usuaris</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">La vostra cerca no ha donat resultats...</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Afegeix usuari</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Afegeix usuari</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crea un nou usuari</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Que l'adreça electrònica està sent usada per un altre usuari. Les adreces electròniques han de ser úniques.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Nova informació d'usuari:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L'adreça electrònica ha de ser única</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">L'adreça electrònica és obligatòria</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nom és obligatori</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Els cognoms són obligatoris</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Requereix certificat</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Podeu iniciar sessió</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crea usuari</message>
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Edita usuari</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edita usuari</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edita usuari</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Que l'adreça electrònica està sent usada per un altre usuari. Les adreces electròniques han de ser úniques.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informació de {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L'adreça electrònica ha de ser única</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">L'adreça electrònica és obligatòria</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nom és obligatori</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Els cognoms són obligatoris</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Requereix certificat</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Podeu iniciar sessió</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restaura contrasenya</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">També podeu eliminar aquest usuari del sistema o restaurar la seua contrasenya. Quan es restaura una contrasenya, l'usuari rep un missatge de correu electrònic que inclou un enllaç especial que pot seguir per tal de triar una nova contrasenya.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Esborra aquest usuari</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Autentiqueu-vos com a usuari</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No es pot esborrar aquest usuari per la següent restricció o restriccions:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">l'usuari ha enviat un o més elements</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l'usuari té un flux de treball d'enviament actiu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l'usuari té una tasca amb treball pendent de ser atesa</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l'usuari té una restricció sense identificar en el sistema</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Grups d'aquest usuari:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(via grup: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">no cap</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirmeu que voleu esborrar l'usuari</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">L'usuari següent serà esborrat:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">Identificació</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nom</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Adreça electrònica</message>
+
+	<!-- general items for all of the group classes -->
+	<message key="xmlui.administrative.group.general.group_trail">Gestiona grups</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Gestiona grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestió de grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accions</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crea un grup nou</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Feu clic ací per crear un grup nou.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Visualitza els grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Feu clic ací per visualitzar tots els grups.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Cerca grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Els grups se cerquen per coincidència parcial amb el seu nom</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1">No cap</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">Identificació</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nom</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membres</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Col·lecció</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Visualització</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Esborra grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">La vostra cerca no ha donat resultats...</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
+	<message key="xmlui.administrative.group.EditGroupForm.title">Editor del grup</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Edita grup</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor del grup: {0} (codi: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor del grup: grup nou</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Neteja cerca</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Membre</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Cicle</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Pendent</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Atenció: els canvis pendents no es desen fins que no feu clic al botó de desar.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Afegeix</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Elimina</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Aquest grup està associat amb la col·lecció:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">This group is associated with community: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Canvia el nom del grup:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Aquest grup està associat a una col·lecció i no se'n pot modificar el nom</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Cerca membres per afegir:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuaris...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grups...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">La vostra cerca no ha donat resultats...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">Identificació</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nom</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Adreça electrònica</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4">No cap</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">Identificació</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nom</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Col·lecció</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5">No cap</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">visualització</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">Identificació</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nom</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Adreça electrònica</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4">No cap</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grup: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Aquest grup no té membres.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendent]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Elimina membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Elimina membres</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirmeu que voleu esborrar grups</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">S'esborraran els grups següents:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">Identificació</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nom</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuaris</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grups</message>
+
+	<!-- general items for all of the registries classes -->
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Registre de format</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de metadades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Esborra formats del document</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Esborra formats del document</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Esteu segurs que voleu esborrar el format? Qualssevol documents d'aquest format que existisquen tornaran a tenir el format de document desconegut.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">Identificació</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nom</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Esborra camps</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Esborra camps</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Esteu<b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVÍS:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Si hi ha algun element que conté metadades per a aquests camps, aquesta acció provocarà un error.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">Identificació</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nom</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota d'abast</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Esborra esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Esborra esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Esteu<b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVÍS:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Si hi ha algun element amb metadades dins d'aquest esquema, l'acció provocarà un error.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">Identificació</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espai de nom</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nom</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format del document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format del document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nou format de document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format del document: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Faciliteu metadades descriptives sobre el format del document a sota. Si bé els noms de format han de ser únics, en el cas dels tipus MIME no ho han de ser necessàriament. Podeu tenir entrades de registre de format distintes per a versions diferents de Microsoft Word, encara que el tipus MIME serà el mateix per cadascuna d'elles.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nom</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nom únic per a aquest format (per exemple, Microsoft Word XP o Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El camp del nom és obligatori.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">The MIME type associated with this format, does not have to be unique.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripció</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivell de suport</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">El nivell de suport que la vostra institució garanteix per a aquest format.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconegut</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conegut</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Amb suport</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Intern</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Els formats marcats com a interns estan ocults per a l'usuari i s'utilitzen amb finalitats administratives.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensions dels fitxers</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions són extensions de fitxers que s'apliquen automàticament per identificar el format dels fitxers carregats. Per a cada format podeu introduir diverses extensions.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadades: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Aquest és l' esquema de metadades per a "{0}". Podeu afegir nous camps de metadades a aquest esquema o actualitzar els existents. També podeu seleccionar camps per esborrar o desplaçar a un altre esquema.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Camps de metadades de l'esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1">No cap</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">Identificació</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Camp</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota d'abast</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">No hi ha camps de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Esborra camps</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Desplaça camps a un altre esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Afegeix nou camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nom del camp</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota d'abast</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes addicionals sobre aquest camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Afegeix nou camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Actualitza camp: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Actualitza camp</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nom del camp ja es troba en ús; tots els elements i qualificadors han de ser únics.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'element del camp és obligatori.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L'element del camp conté un caràcter incorrecte. L'element NO pot contenir punts, caràcters de subratllat o espais.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L'element del camp és massa llarg, ha de tenir menys de 32 caràcters.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El qualificador del camp és massa llarg, ha de tenir menys de 32 caràcters.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El qualificador del camp conté un caràcter incorrecte. El qualificador NO pot contenir: punts, caràcters de subratllat o espais.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registre de format</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registre de formats de documents</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Aquesta llista de formats de documents dóna informació sobre formats coneguts i el seu nivell de suport. Podeu editar formats de documents o afegir-ne de nous amb aquesta eina. Els formats marcats com a "interns" es troben ocults per a l'usuari i s'utilitzen amb finalitats administratives.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Afegeix un nou format de document</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1">No cap</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">Identificació</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nom</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivell de suport</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconegut</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conegut</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Amb suport</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Esborra formats</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">registre de metadades</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">registre de metadades</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registre de metadades manté una llista de tots els camps de metadades disponibles en aquest repositori. Aquests camps poden dividir-se entre múltiples esquemes. No obstant això, DSpace requereix l'esquema Qualified Dublin Core. Podeu ampliar l'esquema Dublin Core amb camps addicionals o afegir nous esquemes al registre.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1">No cap</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">Identificació</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espai de nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Esborra esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Afegeix un nou esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espai de nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L'espai de nom hauria de ser un lloc URI per al nou esquema.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Aquest camp és obligatori</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notació abreujada per a l'esquema. S'usarà com a prefix d'un nom de camp (per exemple, dc.element.qualifier). El nom ha de tenir menys de 32 caràcters i no pot incloure espais, punts o caràcters de subratllat.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Aquest camp és obligatori i no pot incloure espais, punts o caràcters de subratllat.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Afegeix nou esquema</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Desplaça camps</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Desplaça camps</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Desplaça camps de metadades</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Seleccioneu un esquema de destinació per als camps que voleu desplaçar. Si l'esquema de destinació té camps amb noms idèntics, els camps no s'hi desplaçaran.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">Identificació</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nom</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota d'abast</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Desplaça a l'esquema:</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Desplaça camps</message>
+
+
+
+
+	<!-- general authorization keywords -->
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorització</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Llista de privilegis</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administreu privilegis d'autorització</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administreu privilegis d'autorització</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoritzacions de l'element</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">La identificació que heu facilitat no correspon a cap element.</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Cerca un element</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Per cercar un element, podeu fer-ho mitjançant handle o identificador intern</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Cerca</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Eina avançada d'autoritzacions</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Feu clic ací per anar a l'eina d'administració de privilegis de comodins d'elements</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoritzacions de comunitats/col·leccions</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Feu clic en una comunitat o col·lecció per editar-ne els privilegis.</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edita privilegis</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Llista de privilegis</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilegis de la col·lecció "{0}" ({1},codi: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegis de la comunitat "{0}" ({1},codi: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Feu clic ací per afegir nous privilegis.</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Afegeix</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">Identificació</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acció</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grup</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Esborra els seleccionats</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edita</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Privilegis d'edició de l'element</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Llista de privilegis</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilegis de l'element {0} (codi={1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Amb aquest editor podeu veure i modificar els privilegis d'un element, a més de modificar els privilegis de components d'elements individuals: paquets i documents. En síntesi, un element és un contenidor de paquets, i els paquets són contenidors de documents. Normalment els contenidors tenen privilegis d'ADDICIÓ/ELIMINACIÓ/LECTURA/ESCRIPTURA, mentre que els documents només tenen privilegis de LECTURA/ESCRIPTURA.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Veureu que hi ha un paquet i document extra per a cada element que conté el text de llicència per a l'element.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilegis de l'element</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilegis del paquet{0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Document {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Afegeix un nou privilegi d'elements</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Afegeix un nou privilegi de paquets</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Afegeix un nou privilegi de documents</message>
+
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No s'han trobat privilegis per a aquest objecte.</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Edita privilegi</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edita privilegi</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crea nous privilegis per a {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edita privilegi {0} per a {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No s'ha seleccionat cap grup</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No s'ha seleccionat cap acció</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4">No cap</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">Identificació</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nom</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accions per a aquest recurs</message>
+
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conjunt</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Selecciona un grup</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Cerca un grup</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Cerca</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Seleccioneu l'acció</message>
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor avançat de privilegis</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autoritzacions avançades</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor avançat de privilegis</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permet afegir comodins a privilegis i buidar privilegis per a tipus de continguts que es troben dins d'alguna col·lecció concreta. AVÍS: si elimineu permisos LLEGITS d'elements, aquests no es podran visualitzar!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Per a tots els grups seleccionats...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...permetre la possibilitat de realitzar l'acció següent...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...per a tots els tipus d'objectes següents...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...en totes les col·leccions següents</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grup</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acció</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipus de contingut</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Col·lecció</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Afegeix privilegis</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Buida privilegis</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmeu que voleu esborrar el privilegi</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">S'eliminaran els privilegis següents:</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">Identificació</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acció</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grup</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
+	<!-- general edit item messages -->
+	<message key="xmlui.administrative.item.general.item_trail">Elements</message>
+	<message key="xmlui.administrative.item.general.template_head">Edit Template Item for Collection: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Edita element</message>
+	<message key="xmlui.administrative.item.general.option_status">Estat de l'element</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Documents de l'element</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.general.option_view">Visualitza element</message>
+        <message key="xmlui.administrative.item.general.option_curate">Curate</message>
+        <message key="xmlui.administrative.item.general.option_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Penja document</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Penja document</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Penja un nou document</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Paquet</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fitxers de continguts (per defecte)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fitxers de metadades</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniatures</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Llicències</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fitxer</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Introduïu el nom del fitxer de l'ordinador que corresponga al vostre element. Si feu clic a "Visualitza...", apareixerà una nova finestra on podreu cercar i seleccionar el fitxer que teniu en l'ordinador.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripció</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Penja</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Us calen els privilegis d'ADDICIÓ i ESCRIPTURA en almenys un paquet per tal de poder penjar nous documents.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Esteu segurs que voleu esborrar aquests documents?</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nom</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripció</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifica element: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Esteu segurs que aquest element s'hauria d'esborrar del tot? Compte: si feu aquesta acció, l'element no es podrà recuperar.</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Esteu segurs que aquest element s'hauria de llevar del fitxer?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Esteu segurs que aquest element s'hauria de tornar a incorporar al fitxer?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Camp</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Llengua</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retira</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Torna a incorporar</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Move item: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Collection</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Select the collection you wish to move this item to.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Select a collection...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Move</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Inherit policies</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Inherit the default policies of the destination collection</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Edita document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Edita document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Edita document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxer</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Document primari</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">sí</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">no</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripció</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Si voleu, doneu una descripció breu del fitxer, com per exemple "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccioneu el format del fitxer entre les opcions de la llista de sota, com ara "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format seleccionat</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">El format no és a la llista</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el format no és a la llista&lt;/strong&gt;, descriviu-lo en la casella que hi ha a continuació de la llista.<strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Un altre format</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">L'aplicació que heu usat per crear el fitxer i el número de versió (per exemple, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Documents de l'element</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Documents de l'element</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Documents</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1">No cap</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nom</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripció</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Visualització</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label">&lt;strong&gt;Paquet: {0}&lt;/strong&gt;<strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">visualització</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Penja un nou document</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Esborra documents</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Us calen els privilegis d'ADDICIÓ i ESCRIPTURA en l'element i en els paquets per tal de poder penjar nous documents.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Us cal el privilegi d'ELIMINACIÓ en l'element i en els paquets per tal de poder esborrar nous documents.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Afegeix noves metadades</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nom</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Llengua</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Afegeix noves metadades</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">ADVERTÈNCIA: aquests canvis no es validen de cap manera. Sou responsables d'introduir les dades en el format correcte. Si no esteu segurs de quin és el format, per favor, NO feu canvis.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">metadades</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Elimina</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nom</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Llengua</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Estat de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estat de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvinguts a la pàgina de gestió de l'element. Des d'ací podeu llevar, tornar a incorporar o esborrar l'element. També podeu actualitzar o a afegir noves metadades / nous documents en altres pestanyes.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">Identificador intern de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Modificat per última vegada</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">En col·leccions</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Pàgina dels elements</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Autoritzacions de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Element llevat del repositori</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Torna a incorporar l'element en el repositori</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Move item to another collection</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Suprimeix del tot l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Edita</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Elimina...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Torna a incorporar...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Move...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Esborra definitivament</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">no disponible</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(només administradors del sistema)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(collection administrators only)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(you are not allowed to perform this action)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
+	<message key="xmlui.administrative.item.ViewItem.title">Visualitza element</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Visualitza element</message>
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Task</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
+	<message key="xmlui.administrative.item.FindItemForm.title">Cerca element</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Cerca element</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Identificació d'element intern/Handle de l'element</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">No ha estat possible resoldre l'identificador</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Troba</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">changes</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">No changes were detected</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">New item</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Upload successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Upload failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unknown metadata element in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Number of changes exceeds maximum allowed. Limit changes or alter bulkedit.gui-item-limit in dspace.cfg</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Upload CSV</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Successfully processed</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Changes applied to item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Added: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Removed: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Added to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Removed from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Mapped to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Unmapped from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Add: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Remove: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Add to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Remove from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Map to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Un-map from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Changes pending for item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Apply changes</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Pending changes are listed below for review</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
+
+	<!-- general mapper messages -->
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Mapador d'elements</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
+	<message key="xmlui.administrative.mapper.MapperMain.title">Mapador d'elements</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Mapador d'elements - Mapa elements d'altres col·leccions</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Col·lecció: "&lt;strong&gt;{0}&lt;/strong&gt;"<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Aquesta és l'eina de mapatge d'elements que permet els administradors de col·leccions mapar elements d'altres col·leccions en aquesta. Podeu cercar elements d'altres col·leccions i mapar-les, o visualitzar la llista d'elements actualment mapats.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadístiques</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info">&lt;strong&gt;{0} de {1}&lt;/strong&gt; elements d'aquesta col·lecció han sigut mapats d'altres col·leccions<strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Cerca</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Visualitza els elements mapats</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Requereix el privilegi d'ADDICIÓ de la col·lecció)</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Cerca coincidència d'elements: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Mapa els elements seleccionats</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1">No cap</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Col·lecció</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor/a</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Títol</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Visualitza els elements mapats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Visualitza els elements mapats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Visualitzant elements mapats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desmapa elements seleccionats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1">No cap</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Col·lecció</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor/a</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Títol</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">En aquesta col·lecció us cal el privilegi d'ELIMINACIÓ per poder desmapar elements d'aquesta col·lecció.</message>
+
+	<!-- General tags for collection management -->
+	<message key="xmlui.administrative.collection.general.collection_trail">Col·leccions</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Edita metadades</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Assigna funcions</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edita funcions</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Funcions</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edita col·lecció: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">no cap</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crea...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringeix...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Els administradors de la col·lecció decideixen qui pot enviar elements a la col·lecció, llevar elements, editar metadades d'elements (després de ser enviats) i afegir (mapar) elements existents d'altres col·leccions a aquesta col·lecció (sempre que es tinga autorització per a la col·lecció en qüestió).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les persones responsables d'aquesta acció poden acceptar o rebutjar els enviaments rebuts. Tanmateix, no poden editar les metadades de l'enviament.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les persones responsables d'aquesta acció poden editar les metadades dels enviaments rebuts i després acceptar-los o rebutjar-los.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Les persones responsables d'aquesta acció poden editar les metadades dels enviaments rebuts però no poden rebutjar-los.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Els usuaris i grups que tenen permís per enviar nous elements a aquesta col·lecció.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuaris i grups que poden llegir nous elements enviats a aquesta col·lecció. Els canvis que afecten aquesta funció no són retroactius. Els elements existents en el sistema continuaran sent visibles per aquells que tenen accés de lectura en el moment en què van ser afegits.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">En aquesta col·lecció la configuració d'accés és l'establerta per defecte.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">La lectura per defecte per als elements i documents entrants està actualment configurada com a anònima.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Edita els privilegis d'autorització directament.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Funció</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grup associat</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"/>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradors</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Workflow steps</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accepta/Rebutja/Acció</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accepta/Rebutja/Edita acció de metadades</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Edita acció de metadades</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Remitents</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accés de lectura per defecte</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only">No cap<nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curate Collection: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curate Collection</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Task</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmeu</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirmeu que voleu esborrar la col·lecció {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Esteu segurs que voleu esborrar la col·lecció {0}? Açò esborrarà:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tots els elements i enviaments incomplets d'aquesta col·lecció que no es troben en altres col·leccions</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contingut d'aquells elements</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Tots els privilegis d'autorització associades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmeu que voleu esborrar la funció</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmeu</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmeu que voleu esborrar la funció {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Esteu segurs que voleu esborrar aquesta funció? Esborrar aquest grup donarà accés de LECTURA a tots els usuaris per a tots els elements enviats a aquesta col·lecció a partir d'ara. Tingueu en compte que aquest canvi no és retroactiu. Els elements que hi haja en el sistema continuaran sent restringits per als membres definits per la funció que voleu esborrar.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Esteu segurs que voleu esborrar aquesta funció? Es perdran tots els canvis i personalitzacions fetes en el grup {0}, de manera que hauran de crear-se de nou.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edita metadades de la col·lecció</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">metadades</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edita col·lecció: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nom</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Breu descripció</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Text introductori (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Text del copyright (text net)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novetats (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Llicència</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Origen</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Penja nou logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla de l'element</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crea...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edita...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Elimina logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Esborra col·lecció</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Desa actualitzacions</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only">No cap<nobr>(system administrators only)</nobr></message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crea col·lecció</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crea col·lecció</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduïu noves metadades per a una nova col·lecció de {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crea</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Collection Harvesting Settings</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Content Source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Content source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">This is a standard DSpace collection</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">This collection harvests its content from an external source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Save</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Harvesting Options</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadata Format</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">The url of the target repository's OAI provider service</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">The persistent identifier used by the OAI provider to designate the target collection</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Test Settings</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadata format</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Last Harvest Result</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">This collection has not yet been harvested.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Current harvest status</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Collection ready for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Collection is currently being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Collection is in queue for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Unexpected error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (full replication).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Change Settings</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Import Now</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Reset and Reimport Collection</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Harvest Scheduler Controls</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Actions</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Start Harvester</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Reset Harvest Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Resume</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pause</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Collections set up for harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Active harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Queued harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Internal errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Generator Settings</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE source</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Settings</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Communities</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Edit Metadata</message>
+	<message key="xmlui.administrative.community.general.options_roles">Assign Roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.community.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Edit Community Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edit Community: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">none</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Create...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections.  In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">This community uses custom default access settings. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Default read for incoming items and bitstreams is currently set to Anonymous.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Edit authorization policies directly.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Associated group</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administrators</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curate Community: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curate Community</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Task</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmeu que voleu esborrar</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmeu</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmeu que voleu esborrar {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Esteu segurs que voleu esborrar la comunitat {0}? Açò esborrarà:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Totes les col·leccions de la comunitat que no es troben en altres comunitats</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tots els elements i enviaments incomplets d'aquesta comunitat que no es troben en altres comunitats</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contingut d'aquests elements</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Totes els privilegis d'autorització associades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirm role deletion</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirm</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirm deletion for role {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Are you sure you want to delete this role? All changes and customizations made to the {0} group will be lost and would have to be created anew.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edita dades de la comunitat</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">metadades</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edita metadades per a la comunitat{0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edita privilegis d'autorització</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nom</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Breu descripció</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Text introductori (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Text del copyright (text net)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Notícies (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Penja nou logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Elimina logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Esborra comunitat</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Crea comunitat</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crea comunitat</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introduïu metadades per a una nova subcomunitat de {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Edita metadades per a una nova comunitat de primer nivell</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crea</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
+	<message key="xmlui.administrative.ControlPanel.title">Tauler de control</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Tauler de control</message>
+	<message key="xmlui.administrative.ControlPanel.head">Tauler de control</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Informació de Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Configuració de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertes globals del sistema</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java i sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Versió de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Venedor de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nom del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Versió del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Estadístiques d'execució</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Processadors disponibles</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Memòria màxima</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Memòria assignada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Memòria usada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Memòria lliure</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Configuració de DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Directori d'instal·lació de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">URL base de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom de l'amfitrió de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Nom del lloc</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de dades</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL de la base de dades</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre màxim de connexions DB en la cua</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Temps màxim d'espera de la connexió DB</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Màxim de connexions inactives</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Servidor de correu SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">De l'adreça electrònica</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatari de la informació</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Correu general d'administració del lloc</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertes globals del sistema</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning">&lt;strong&gt;Avís per a sistemes amb balanç de càrrega&lt;/strong&gt;: les alertes globals del sistema només són efectives per al node on es troba activat. Cal que us assegureu que cada node del conjunt rep l'ordre d'activar alerta.<strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Missatge d'alerta</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema deixarà d'estar disponible en breu per manteniment regular. Deseu el vostre treball i finalitzeu la sessió.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte enrere</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">No hi ha temporitzador de compte enrere</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Mantin el temporitzador de compte enrere actual</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestiona sessió</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continua permetent sessions autenticades</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restringeix el procés d'autenticació però mantin les sessions actuals</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restringeix el procés d'autenticació i conclou les sessions actuals</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note">No cap<strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activa</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactiva</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Activitat actual (màxim de {0} pàgines)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">STOP recording anonymous activity.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">START recording anonymous activity.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">STOP recording bot activity.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">START recording bot activity.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horària</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuari</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adreça IP</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">Pàgina URL</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anònim {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Ningú més ha visualitzat cap pàgina de les últimes {0}.</message>
+
+	<message key="xmlui.administrative.ControlPanel.select_panel">Useu les pestanyes de dalt per seleccionar la informació que voleu que es mostre</message>
+
+	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
+	<message key="xmlui.administrative.SystemwideAlerts.countdown">&lt;strong&gt;D'ací a {0} minuts&lt;/strong&gt;:<strong>In {0} minutes</strong>: </message>
+
+	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
+	<message key="xmlui.administrative.NotAuthorized.title">No autoritzat</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">No autoritzat</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Privilegis insuficients</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">El vostre compte no té els privilegis suficients per dur a terme l'acció sol·licitada. Si penseu que es tracta d'un error o voleu preguntar res sobre els vostres privilegis, contacteu els</message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">administradors del sistema del lloc</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Connecteu-vos com a un usuari diferent</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Statistics</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">Total Visits</message>
+    <message key="xmlui.statistics.visits.month">Total Visits Per Month</message>
+    <message key="xmlui.statistics.visits.views">Views</message>
+    <message key="xmlui.statistics.visits.countries">Top country views</message>
+    <message key="xmlui.statistics.visits.cities">Top cities views</message>
+    <message key="xmlui.statistics.visits.bitstreams">File Visits</message>
+    <message key="xmlui.statistics.Navigation.title">Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">Statistics</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
+
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                  dri2xhtml
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+	<!-- structural.xsl -->
+	<message key="xmlui.dri2xhtml.structural.footer-promotional">No cap<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
+		</a>
+		<p>
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
+		</p>
+	</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Poseu-vos en contacte amb nosaltres</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Envieu suggeriments</message>
+
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Repositori DSpace/Manakin</message>
+
+	<message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
+	<message key="xmlui.dri2xhtml.structural.logout">Desconnexió</message>
+	<message key="xmlui.dri2xhtml.structural.login">Connexió</message>
+
+	<message key="xmlui.dri2xhtml.structural.search">Cerca a DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Cerca avançada</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Aquesta comunitat</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">Aquesta col·lecció</message>
+
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Pàgina anterior</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Ara mostrant els elements {0}-{1} d {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Pàgina següent</message>
+
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Llicència original</message>
+
+
+	<!-- DS-METS-1.0-MODS.xsl -->
+	<!-- DS-METS-1.0-DIM.xsl -->
+	<!-- DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">No hi ha visualització prèvia disponible</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sense títol</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconegut</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Aquest objecte de DSpace no s'ajusta al perfil METS 1.0 i com a tal no pot renderitzar-se de manera eficaç. Podeu substituir la plantilla que gestiona el cas general en dri2xhtml per a executar la funció requerida o podeu crear una plantilla que concorde amb tots aquells perfils que useu.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Visualització prèvia</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Títol</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor/a</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resum</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripció</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Assumpte</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Fitxers en aquest element</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxers</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Grandària</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Visualització</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualitza/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hi ha fitxers associats a aquest element.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Els següents fitxers sobre la llicència estan associats a aquest element:</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Actualment la visualització resum d'una col·lecció no es troba en ús o aplicació. Això pot solucionar-se substituint la plantilla de dri2xhtml anomenada collectionSummaryView</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">La visualització resum d'una comunitat no es troba en ús o aplicació. Això pot solucionar-se substituint la plantilla de dri2xhtml anomenada communitySummaryView.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">El logo de la col·lecció</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">El logo de la comunitat</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Cap logo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Notícies</message>
+
+	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
+		DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Qualified Dublin Core (QDC) no és aplicable a comunitats i col·leccions de DSpace en aquest moment. Quan useu QDC, hauríeu d'usar la correspondència QDC per a elements de DSpace i o bé DIM o MODS per al tractament de comunitats i col·leccions.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elements de Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termes de Dublin Core</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
+	<!-- Special pioneer model related text, wherever it might end up -->
+	<message key="xmlui.dri2xhtml.pioneer.preview">Visualització prèvia</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Títol</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Autor/a</message>
+
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+
+  <!--###### File Format MIME Type Mappings ######-->
+
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">MARC record</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Unknown</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">GIF image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">JPEG 2000 image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">JPEG image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">PNG image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">TIFF image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">CSS file</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">CSV file</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Text file</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">RTF file</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">AVI video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime video</message>
+
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Confidence was never recorded for this value</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">No reasonable confidence value was returned from the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">The authority recommends this submission be rejected</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">The authority encountered an internal failure</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">There are no matching answers in the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">There are multiple matching authority values of equal validity</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">Value is singular and valid but has not been seen and accepted by a human so it is still uncertain</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">This authority value has been confirmed as accurate by an interactive user</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Unlock the authority key value for manual editing, or toggle it locked again</message>
+
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">DSpace Value Lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Accept</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Add</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancel</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">See More Results</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Results @1@ to @2@ of @3@ for "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
+
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up Publisher</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non-authority value: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in "Last, First" format</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Last name, e.g. "Smith"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">First name(s) e.g. "Fred"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Name Authority author lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Local value "@1@" (not in Naming Authority)</message>
+
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_ca.xml
+++ b/src/main/webapp/i18n/messages_ca.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ca">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_ca_ES.xml
+++ b/src/main/webapp/i18n/messages_ca_ES.xml
@@ -1,22 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="ca-ES" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
 	<!--
-		The format used by all keys is as follows xmlui.<Aspect>.<Java
-		Class>.<name> There are a few exceptions to this nameing format, 1)
-		Some general keys are in the xmlui.general namespace because they are
-		used very frequently. 2) Some general keys which are specific to a
-		particular aspect may be found at xmlui.<Aspect> without specifiying a
-		particular java class.
-	-->    
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
+		   because they are used very frequently.
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">Pàgina inicial del DSpace</message>
 	<message key="xmlui.general.search">Cerca</message>
@@ -29,15 +25,31 @@
 	<message key="xmlui.general.delete">Suprimeix</message>
 	<message key="xmlui.general.next">Següent</message>
 	<message key="xmlui.general.untitled">Sense títol</message>
+        <message key="xmlui.general.perform">Perform</message>
+        <message key="xmlui.general.queue">Queue</message>
 
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
-		Page not found keys This is a special component that is not part of
-		any aspect but is added by manakin to all aspect chains.
-	-->
+		Page not found keys
+
+		This is a special component that is not part of any aspect but is added
+		by manakin to all aspect chains.
+		-->
 	<message key="xmlui.PageNotFound.title">No s’ha trobat la pàgina</message>
 	<message key="xmlui.PageNotFound.head">No s’ha trobat la pàgina</message>
 	<message key="xmlui.PageNotFound.para1">No es pot trobar la pàgina que heu sol·licitat.</message>
+
+
+	<!--
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Only site administrators may assume login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
 
 
 	<!--
@@ -46,222 +58,258 @@
 	<message key="xmlui.feed.general_description">El sistema de dipòsit digital DSpace captura,
 		emmagatzema, indexa, conserva i distribueix material de recerca
 		digital. </message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">Imatge del canal</message>
 	<message key="xmlui.feed.untitled">Sense títol</message>
 
 	<!--
-                Default notice header
-                -->
+		Default notice header
+	 	-->
 	<message key="xmlui.general.notice.default_head">Avís</message>
-	<!-- 
-		ArtifactBrowser Aspect 
-	-->                
-	
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             ArtifactBrowser Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultats de cerca de comunitat: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultats de cerca de col·lecció: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultats de la cerca</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">La consulta &quot;{0}&quot; ha obtingut {1} resultat(s).</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunitats o col·leccions que coincideixen amb la consulta</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Unitats que coincideixen amb la consulta</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La cerca no ha obtingut resultats.</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tot el DSpace</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">La consulta "{0}" ha obtingut {1} resultat(s).</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunitats o col·leccions que coincideixen amb la consulta</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Unitats que coincideixen amb la consulta</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La cerca no ha obtingut resultats.</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tot el DSpace</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">títol</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data d’edició</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data d’enviament</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">rellevància</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordena els elements per</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order">per ordre</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendent</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendent</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultats/pàgina</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">títol</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data d’edició</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data d’enviament</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">rellevància</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordena els elements per</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">per ordre</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendent</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendent</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultats/pàgina</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Cerca avançada</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Cerca avançada</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Cerca avançada</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Àmbit de cerca</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiteu la cerca a una comunitat o col·lecció.</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunció</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipus de cerca</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Cerca</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Títol</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Matèria</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resum</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sèrie</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Llengua (ISO) </message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Paraula clau</message>
-   
-    <!--  some common other possibilities for Advanced Search Fields -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Col•laborador</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Autor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripció</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relació</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipus Mime</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Un altre col•laborador</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Assessor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departament</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Àmbit de cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiteu la cerca a una comunitat o col·lecció.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunció</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipus de cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Títol</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Matèria</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resum</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sèrie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Llengua (ISO) </message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Paraula clau</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Text complet</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR </message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
-       
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introduïu-ne les primeres lletres:</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Explora els elements que comencen amb aquestes lletres</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Salta a un punt de l&apos;índex:</message>    
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Trieu el mes)</message>  
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Trieu l&apos;any)</message>    
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O escriviu un any: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Explora els elements pertanyents a aquest any.</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Ordena per: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordre: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Resultats: </message><!-- /Page --><!-- /Page -->
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Autors/unitat: </message>
+   <!--  some common other possibilities for Advanced Search Fields -->
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Col•laborador</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Autor</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripció</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relació</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipus Mime</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Un altre col•laborador</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Assessor</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departament</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Tots</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">títol</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data d’edició</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data d’enviament</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendent</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendent</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nom de l&apos;autor</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Tema</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Exploració {0} per autor {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Exploració {0} per autor</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Exploració {0} per tema {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Exploració {0} per tema</message>
-       
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Exploració {0} per títol {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Exploració {0} per títol</message>
-       
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Exploració {0} per data d&apos;edició {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Exploració {0} per data d&apos;edició</message>
-
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Exploració {0} per data d&apos;enviament {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Exploració {0} per data d&apos;enviament</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Text complet</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR </message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
 
 
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Àmbit de cerca</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tot el DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Cerca en aquesta col·lecció:</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Explora per</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títols</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autors</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Dates</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Cerca avançada</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Enviaments recents</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Llista de comunitats</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Llista de comunitats</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunitats del DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Seleccioneu una comunitat per explorar-ne les col·leccions.</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introduïu-ne les primeres lletres:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Explora els elements que comencen amb aquestes lletres</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Salta a un punt de l'índex:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Trieu el mes)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Trieu l'any)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O escriviu un any: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Explora els elements pertanyents a aquest any.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sorry, there are no results for this browse.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Ordena per: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordre: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Resultats: </message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Autors/unitat: </message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Àmbit de cerca</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Tot el DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Cerca en aquesta comunitat i les seves col·leccions:</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Explora per</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títols</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autors</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Dates</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Cerca avançada</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunitats dins d&apos;aquesta comunitat</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Col·leccions d&apos;aquesta comunitat</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Enviaments recents</message>
-       
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-    <message key="xmlui.ArtifactBrowser.Contact.title">Contacteu amb nosaltres</message>
-    <message key="xmlui.ArtifactBrowser.Contact.trail">Contacteu amb nosaltres</message>
-    <message key="xmlui.ArtifactBrowser.Contact.head">Contacteu amb nosaltres</message>
-    <message key="xmlui.ArtifactBrowser.Contact.para1">Podeu contactar amb els administradors de {0} a:</message>
-    <message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulari en línia</message>
-    <message key="xmlui.ArtifactBrowser.Contact.feedback_link">Comentaris</message>
-    <message key="xmlui.ArtifactBrowser.Contact.email">Correu electrònic</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.title">Envieu els vostres comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Envieu els vostres comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.head">Envieu els vostres comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gràcies per enviar-nos els vostres comentaris sobre el sistema DSpace. Agraïm els vostres comentaris!</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.email">La vostra adreça electrònica</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Aquesta adreça s&apos;utilitzarà per fer el seguiment dels vostres comentaris.</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Envia comentaris</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.title">Envieu els vostres comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Envieu els vostres comentaris</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.head">Comentaris enviats</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Hem rebut els vostres comentaris.</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-    <message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Cerca al DSpace</message>
-    <message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Introduïu text al quadre de sota per cercar al DSpace.</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-    <message key="xmlui.ArtifactBrowser.ItemViewer.trail">Visualitza l'element</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Aquest element apareix a les col·leccions següents </message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostra el registre d&apos;unitat simple</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostra el registre d&apos;unitat complet</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-    <message key="xmlui.ArtifactBrowser.Navigation.head_browse">Explora</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tot el DSpace</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunitats i col·leccions</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títols</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autors</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Temes</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Per data d&apos;edició</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Per data d&apos;enviament</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Aquesta col·lecció</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Aquesta comunitat</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.title">Cerca</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Cerca</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.head">Cerca</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Àmbit de cerca</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Cerca de text complet</message>
-       
-    <!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.title">Aquest recurs està restringit</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringit</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Aquest recurs està restringit</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Aquesta comunitat està restringida</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Aquesta col·lecció està restringida</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Aquest element està restringida</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Aquest document està restringit</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No teniu les credencials necessàries per accedir al recurs restringit.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No teniu les credencials necessàries per accedir a la comunitat restringida <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No teniu les credencials necessàries per accedir a la col·lecció restringida <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No teniu les credencials necessàries per accedir a l'element restringit <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No teniu les credencials necessàries per accedir al document restringit <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">col·lecció</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunitat</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">document</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">unitat</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurs</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconegut</message>
-       
-    <!-- Authentication messages used at the top of the login page:  -->
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'element està restringit</message>        
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">L'element al qual intenteu accedir és un element restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir a l'element.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Tots</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">títol</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data d’edició</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data d’enviament</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendent</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendent</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nom de l'autor</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Tema</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Exploració {0} per autor {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Exploració {0} per autor</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Exploració {0} per tema {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Exploració {0} per tema</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Exploració {0} per títol {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Exploració {0} per títol</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Exploració {0} per data d'edició {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Exploració {0} per data d'edició</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Exploració {0} per data d'enviament {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Exploració {0} per data d'enviament</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Àmbit de cerca</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tot el DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Cerca en aquesta col·lecció:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Explora per</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títols</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autors</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Dates</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Enviaments recents</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Llista de comunitats</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Llista de comunitats</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunitats del DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Seleccioneu una comunitat per explorar-ne les col·leccions.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Àmbit de cerca</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Tot el DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Cerca en aquesta comunitat i les seves col·leccions:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Explora per</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títols</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autors</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Dates</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Cerca avançada</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunitats dins d'aquesta comunitat</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Col·leccions d'aquesta comunitat</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Enviaments recents</message>
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
+	<message key="xmlui.ArtifactBrowser.Contact.title">Contacteu amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Contacteu amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Contacteu amb nosaltres</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">Podeu contactar amb els administradors de {0} a:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulari en línia</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Comentaris</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Correu electrònic</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Envieu els vostres comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Envieu els vostres comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Envieu els vostres comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gràcies per enviar-nos els vostres comentaris sobre el sistema DSpace. Agraïm els vostres comentaris!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">La vostra adreça electrònica</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Aquesta adreça s'utilitzarà per fer el seguiment dels vostres comentaris.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Envia comentaris</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Envieu els vostres comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Envieu els vostres comentaris</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Comentaris enviats</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Hem rebut els vostres comentaris.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Visualitza l'element</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Aquest element apareix a les col·leccions següents </message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostra el registre d'unitat simple</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostra el registre d'unitat complet</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Explora</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tot el DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunitats i col·leccions</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títols</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autors</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Temes</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Per data d'edició</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Per data d'enviament</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Aquesta col·lecció</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Aquesta comunitat</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Àmbit de cerca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Cerca de text complet</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Aquest recurs està restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Aquest recurs està restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Aquesta comunitat està restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Aquesta col·lecció està restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Aquest element està restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Aquest document està restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No teniu les credencials necessàries per accedir al recurs restringit.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No teniu les credencials necessàries per accedir a la comunitat restringida <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No teniu les credencials necessàries per accedir a la col·lecció restringida <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No teniu les credencials necessàries per accedir a l'element restringit <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No teniu les credencials necessàries per accedir al document restringit <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">col·lecció</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunitat</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">document</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">unitat</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurs</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconegut</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
+	<!-- Authentication messages used at the top of the login page:  -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'element està restringit</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">L'element al qual intenteu accedir és un element restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir a l'element.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes mensuals</message>
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resum estadístic</message>
@@ -270,1601 +318,2139 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Actualment no hi ha informes disponibles per a aquest servei.  Torneu a consultar-ho més endavant.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-    <message key="xmlui.BitstreamReader.auth_header">El fitxer està restringit</message>      
-    <message key="xmlui.BitstreamReader.auth_message">El fitxer al qual intenteu accedir és un fitxer restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir al fitxer.</message>
-       
-    <!-- Export Archive download messages -->
-    <message key="xmlui.ItemExportDownloadReader.auth_header">L&apos;arxiu d&apos;exportació està restringit.</message>
-    <message key="xmlui.ItemExportDownloadReader.auth_message">L&apos;arxiu d&apos;exportació al qual intenteu accedir és un recurs restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir a l&apos;arxiu d&apos;exportació.</message>
+	<message key="xmlui.BitstreamReader.auth_header">El fitxer està restringit</message>
+	<message key="xmlui.BitstreamReader.auth_message">El fitxer al qual intenteu accedir és un fitxer restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir al fitxer.</message>
 
-    <!-- REQUEST COPY -->
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Sol·liciteu una còpia del document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Sol·liciteu una còpia del document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Sol·liciteu una còpia del document</message>
+	<!-- Export Archive download messages -->
+	<message key="xmlui.ItemExportDownloadReader.auth_header">L'arxiu d'exportació està restringit.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">L'arxiu d'exportació al qual intenteu accedir és un recurs restringit i calen credencials per visualitzar-lo. Inicieu la sessió a sota per accedir a l'arxiu d'exportació.</message>
+
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Sol·liciteu una còpia del document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Sol·liciteu una còpia del document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Sol·liciteu una còpia del document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Introduïu la següent informació per demanar una còpia del document a la persona responsable</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Adreça electrònica</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Aquesta adreça electrònica s'utilitzarà per enviar el document.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">S'ha d'introduir una adreça</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Missatge</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">S'ha d'introduir un missatge</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Fitxers</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Tots els fitxers (d'aquest document) en accés restringit.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Només el fitxer seleccionat.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Nom</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">S'ha d'introduir un nom</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Sol·licita una còpia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Adreça electrònica</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Aquesta adreça electrònica s'utilitzarà per enviar el document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">S'ha d'introduir una adreça</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Missatge</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">S'ha d'introduir un missatge</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Fitxers</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Tots els fitxers (d'aquest document) en accés restringit.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Només el fitxer seleccionat.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Nom</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">S'ha d'introduir un nom</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Sol·licita una còpia</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestSent.title">S'ha enviat la vostra sol·licitud.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">S'ha enviat la vostra sol·licitud.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestSent.head">S'ha enviat la vostra sol·licitud.</message>
-	 <message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">S'ha enviat la vostra sol·licitud a l'autor/a o persona responsable.</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">S'ha enviat la vostra sol·licitud.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">S'ha enviat la vostra sol·licitud.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">S'ha enviat la vostra sol·licitud.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">S'ha enviat la vostra sol·licitud a l'autor/a o persona responsable.</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Sol·licitud de còpia d'un document</message>
-	 <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI SOU L'AUTOR/A (O UN DELS AUTORS) DEL DOCUMENT «{0}» respongueu a la sol·licitud a través dels botons.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Aquest repositori us proposarà una resposta model apropiada que podreu editar.</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI SOU L'AUTOR/A (O UN DELS AUTORS) DEL DOCUMENT «{0}» respongueu a la sol·licitud a través dels botons.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Aquest repositori us proposarà una resposta model apropiada que podreu editar.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Envia la còpia</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">No enviïs la còpia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">No enviïs la còpia</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Aquest és el text que s'enviarà al sol·licitant.</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Missatge</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Assumpte</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Envia</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Enrere</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Aquest és el text que s'enviarà al sol·licitant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Missatge</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Assumpte</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Envia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Enrere</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Sol·licitud de còpia d'un document</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Aquest és el text que s'enviarà al sol·licitant (juntament amb el document).</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Missatge</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Assumpte</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Envia</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Enrere</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Sol·licitud de canvi de permisos</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Sol·licitud de canvi de permisos</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Sol·licitud de canvi de permisos</message>
-	 <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Podeu aprofitar per reconsiderar les restriccions d'accés a aquest document (per evitar haver de respondre a aquestes sol·licituds), si no hi ha cap raó per mantindre'l restringit. Per fer-ho, després d'introduir el vostre nom i adreça electrònica (per autenticar-vos), feu clic al botó «Canvia a accés obert».</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Nom</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Adreça electrònica</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Sol·licitud de còpia d'un document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Aquest és el text que s'enviarà al sol·licitant (juntament amb el document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Missatge</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Assumpte</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Envia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Enrere</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Sol·licitud de canvi de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Sol·licitud de canvi de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Sol·licitud de canvi de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Podeu aprofitar per reconsiderar les restriccions d'accés a aquest document (per evitar haver de respondre a aquestes sol·licituds), si no hi ha cap raó per mantindre'l restringit. Per fer-ho, després d'introduir el vostre nom i adreça electrònica (per autenticar-vos), feu clic al botó «Canvia a accés obert».</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Nom</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Adreça electrònica</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">S'ha d'introduir el nom</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">S'ha d'introduir l'adreça electrònica</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Canvia a accés obert</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">S'ha d'introduir l'adreça electrònica</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Canvia a accés obert</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">S'ha enviat la sol·licitud</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">S'ha enviat la sol·licitud</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">S'ha enviat la vostra sol·licitud de canvi de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">S'ha enviat la vostra sol·licitud a l'administrador</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Gràcies</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
-    <message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">S'ha enviat la sol·licitud</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">S'ha enviat la sol·licitud</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">S'ha enviat la vostra sol·licitud de canvi de permisos</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">S'ha enviat la vostra sol·licitud a l'administrador</message>
-    <message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Gràcies</message>
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
 
- 	<!--
- 	 EPerson Aspect
-	-->
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
 	
-	<!-- General keys used by the EPerson aspect -->  <message key="xmlui.EPerson.trail_new_registration">Registre d&apos;usuari nou</message>
-    <message key="xmlui.EPerson.trail_forgot_password">Heu oblidat la contrasenya</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-    <message key="xmlui.EPerson.CannotRegister.title">Registre no disponible</message>
-    <message key="xmlui.EPerson.CannotRegister.head">Registre no disponible</message>
-    <message key="xmlui.EPerson.CannotRegister.para1">La configuració d&apos;aquest dipòsit del DSpace no permet el registre en aquest context. Poseu-vos en contacte amb <a href="../contact">l&apos;administrador del lloc</a> per enviar-li preguntes o comentaris.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-    <message key="xmlui.EPerson.EditProfile.title_update">Actualitza el perfil</message>
-    <message key="xmlui.EPerson.EditProfile.title_create">Crea un perfil</message>
-    <message key="xmlui.EPerson.EditProfile.trail_update">Actualitza el perfil</message>
-    <message key="xmlui.EPerson.EditProfile.head_update">Actualitza el perfil</message>
-    <message key="xmlui.EPerson.EditProfile.head_create">Crea un perfil</message>
-    <message key="xmlui.EPerson.EditProfile.email_address">Adreça electrònica</message>
-    <message key="xmlui.EPerson.EditProfile.first_name">Nom</message>
-    <message key="xmlui.EPerson.EditProfile.last_name">Cognoms</message>
-    <message key="xmlui.EPerson.EditProfile.telephone">Telèfon de contacte</message>
-    <message key="xmlui.EPerson.EditProfile.subscriptions">Subscripcions</message>
-    <message key="xmlui.EPerson.EditProfile.subscriptions_help">Us podeu subscriure a col·leccions per rebre alertes diàries per correu electrònic dels elements nous que s&apos;afegeixin. Podeu subscriure-us a tantes col·leccions com vulgueu. Una altra alternativa a les alertes diàries per correu electrònic es utilitzar les fonts RSS que hi ha disponibles per a les col·leccions.</message>
-    <message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscripcions per correu electrònic</message>
-    <message key="xmlui.EPerson.EditProfile.select_collection">( Seleccioneu la col·lecció )</message>
-    <message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalment, podeu introduir una contrasenya nova al quadre de sota i confirmar-la tornant-la a escriure al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
-    <message key="xmlui.EPerson.EditProfile.create_password_instructions">Introduïu una contrasenya al quadre de sota i confirmeu-la tornant-la a escriure al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
-    <message key="xmlui.EPerson.EditProfile.password">Contrasenya</message>
-    <message key="xmlui.EPerson.EditProfile.confirm_password">Torneu-la a escriure per confirmar-la</message>
-    <message key="xmlui.EPerson.EditProfile.submit_update">Completa el registre</message>
-    <message key="xmlui.EPerson.EditProfile.submit_create">Actualitza el perfil</message>
-    <message key="xmlui.EPerson.EditProfile.error_required">Aquest camp és necessari</message>
-    <message key="xmlui.EPerson.EditProfile.error_invalid_password">Trieu una contrasenya de com a mínim 6 caràcters</message>
-    <message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
-    <message key="xmlui.EPerson.EditProfile.head_auth">Grups d&apos;autorització als quals pertanyeu</message>
-    <message key="xmlui.EPerson.EditProfile.head_identify">Identifiqueu-vos</message>
-    <message key="xmlui.EPerson.EditProfile.head_security">Seguretat</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-    <message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifica l&apos;adreça electrònica</message>
-    <message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crea un perfil</message>
-    <message key="xmlui.EPerson.EPersonUtils.register_finished">Finalitzat</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifica l&apos;adreça electrònica</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restableix la contrasenya</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_finished">Finalitzat</message>
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    <!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-    <message key="xmlui.EPerson.ForgotPasswordFinished.title">Contrasenya restablerta</message>
-    <message key="xmlui.EPerson.ForgotPasswordFinished.head">Contrasenya restablerta</message>
-    <message key="xmlui.EPerson.ForgotPasswordFinished.para1">S&apos;ha restablert la contrasenya.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-    <message key="xmlui.EPerson.InvalidToken.title">Testimoni no vàlid</message>
-    <message key="xmlui.EPerson.InvalidToken.trail">Testimoni no vàlid</message>
-    <message key="xmlui.EPerson.InvalidToken.head">Testimoni no vàlid</message>
-    <message key="xmlui.EPerson.InvalidToken.para1">L&apos;adreça URL que heu indicat no és vàlida. Pot ser que l&apos;adreça URL hagi quedat partida en diverses línies al client de correu electrònic, com aquí: </message>
-    <message key="xmlui.EPerson.InvalidToken.para2">Si és així, copieu i enganxeu tota l&apos;adreça URL directament a la barra d&apos;adreces del navegador, en lloc de fer clic a l&apos;enllaç.  La barra d&apos;adreça hauria d&apos;assemblar-se a aquesta:</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-    <message key="xmlui.EPerson.Navigation.my_account">El meu compte</message>
-    <message key="xmlui.EPerson.Navigation.profile">Perfil</message>
-    <message key="xmlui.EPerson.Navigation.logout">Finalitza la sessió</message>
-    <message key="xmlui.EPerson.Navigation.login">Inicia la sessió</message>
-    <message key="xmlui.EPerson.Navigation.register">Registre</message>
+		                EPerson Aspect
 
-    <!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-    <message key="xmlui.EPerson.PasswordLogin.title">Registreu-vos</message>
-    <message key="xmlui.EPerson.PasswordLogin.trail">Registreu-vos</message>
-    <message key="xmlui.EPerson.PasswordLogin.head1">Registreu-vos al DSpace</message>
-    <message key="xmlui.EPerson.PasswordLogin.email_address">Adreça electrònica</message>
-    <message key="xmlui.EPerson.PasswordLogin.error_bad_login">L&apos;adreça electrònica i/o la contrasenya que heu indicat no són vàlides.</message>
-    <message key="xmlui.EPerson.PasswordLogin.password">Contrasenya</message>
-    <message key="xmlui.EPerson.PasswordLogin.forgot_link"> Heu oblidat la contrasenya?</message>
-    <message key="xmlui.EPerson.PasswordLogin.submit">Registreu-vos</message>
-    <message key="xmlui.EPerson.PasswordLogin.head2">Registre d&apos;usuari nou</message>
-    <message key="xmlui.EPerson.PasswordLogin.para1">Registreu un compte per subscriviu-vos a col·leccions, per rebre actualitzacions per correu electrònic i enviar elements nous al DSpace. </message>
-    <message key="xmlui.EPerson.PasswordLogin.register_link">Feu clic aquí per registrar-vos.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-    <message key="xmlui.EPerson.LDAPLogin.title">Registreu-vos</message>
-    <message key="xmlui.EPerson.LDAPLogin.trail">Registreu-vos</message>
-    <message key="xmlui.EPerson.LDAPLogin.head1">Registreu-vos al DSpace</message>
-    <message key="xmlui.EPerson.LDAPLogin.username">Nom d&apos;usuari</message>
-    <message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nom d&apos;usuari i/o la contrasenya que heu indicat no són vàlids.</message>
-    <message key="xmlui.EPerson.LDAPLogin.password">Contrasenya</message>
-    <message key="xmlui.EPerson.LDAPLogin.submit">Registreu-vos</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-    <message key="xmlui.EPerson.LoginChooser.title">Trieu un mètode d&apos;inici de sessió</message>
-    <message key="xmlui.EPerson.LoginChooser.trail">Trieu l&apos;inici de sessió</message>
-    <message key="xmlui.EPerson.LoginChooser.head1">Trieu un mètode d&apos;inici de sessió</message>
-    <message key="xmlui.EPerson.LoginChooser.para1">Inici de sessió per:</message>
-    	<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticació Shibboleth</message>
-    <message key="org.dspace.eperson.LDAPAuthentication.title">Autenticació LDAP</message>
-    <message key="org.dspace.eperson.PasswordAuthentication.title">Autenticació per contrasenya</message>
-    <message key="org.dspace.eperson.X509Authentication.title">Autenticació per certificat web</message>
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
-    <!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-    <message key="xmlui.EPerson.FailedAuthentication.BadCreds">Les credencials proporcionades no son vàlides.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.BadArgs">No es pot autenticar perquè s&apos;han rebut arguments no vàlids.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No s&apos;ha trobat cap usuari amb les credencials indicades.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.title">Ha fallat l&apos;autenticació</message>
-    <message key="xmlui.EPerson.FailedAuthentication.trail">L&apos;autenticació ha fallat</message>
-    <message key="xmlui.EPerson.FailedAuthentication.h1">Ha fallat l&apos;autenticació</message>
-       
-    <!-- Login xml files -->
-    <message key="xmlui.eperson.noAuthMethod.head">No s&apos;ha trobat cap mètode d&apos;autenticació</message>
-    <message key="xmlui.eperson.noAuthMethod.p1">No s&apos;ha trobat cap mètode d&apos;autenticació.  Poseu-vos en contacte amb l&apos;administrador del lloc.</message>
-    <message key="xmlui.eperson.shibbLoginFailure.head">Ha fallat l&apos;inici de sessió amb Shibboleth</message>
-    <message key="xmlui.eperson.shibbLoginFailure.p1">L&apos;autenticació Shibboleth no està disponible en aquest moment. Poseu-vos en contacte amb l&apos;administrador del lloc.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-    <message key="xmlui.EPerson.ProfileUpdated.title">Perfil actualitzat</message>
-    <message key="xmlui.EPerson.ProfileUpdated.trail">Actualitza el perfil</message>
-    <message key="xmlui.EPerson.ProfileUpdated.head">Perfil actualitzat</message>
-    <message key="xmlui.EPerson.ProfileUpdated.para1">S&apos;ha actualitzat la informació del vostre perfil.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-    <message key="xmlui.EPerson.RegistrationFinished.title">Registre finalitzat</message>
-    <message key="xmlui.EPerson.RegistrationFinished.head">Registre finalitzat</message>
-    <message key="xmlui.EPerson.RegistrationFinished.para1">Ja esteu registrat per utilitzar el sistema.  Us podeu subscriure a col·leccions per rebre actualitzacions per correu electrònic sobre elements nous.</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-    <message key="xmlui.EPerson.ResetPassword.title">Restableix la contrasenya</message>
-    <message key="xmlui.EPerson.ResetPassword.head">Restableix la contrasenya</message>
-    <message key="xmlui.EPerson.ResetPassword.para1">Introduïu una contrasenya nova al quadre de sota i confirmeu-la tornant-la a introduir al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
-    <message key="xmlui.EPerson.ResetPassword.email_address">Adreça electrònica</message>
-    <message key="xmlui.EPerson.ResetPassword.new_password">Contrasenya nova</message>
-    <message key="xmlui.EPerson.ResetPassword.confirm_password">Torneu-la a escriure per confirmar-la</message>
-    <message key="xmlui.EPerson.ResetPassword.submit">Restableix la contrasenya</message>
-    <message key="xmlui.EPerson.ResetPassword.error_invalid_password">Trieu una contrasenya de com a mínim 6 caràcters</message>
-    <message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-    <message key="xmlui.EPerson.StartForgotPassword.title">Heu oblidat la contrasenya</message>
-    <message key="xmlui.EPerson.StartForgotPassword.head">Heu oblidat la contrasenya</message>
-    <message key="xmlui.EPerson.StartForgotPassword.para1">Introduïu l&apos;adreça electrònica que vàreu indicar en registrar-vos. Se us enviarà un missatge amb instruccions a aquesta adreça.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.email_address">Adreça electrònica</message>
-    <message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduïu la mateixa adreça que vàreu utilitzar en registrar-vos.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.error_not_found">No s&apos;ha trobat l&apos;adreça electrònica.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.submit">Envia informació</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-    <message key="xmlui.EPerson.StartRegistration.title">Registre d&apos;usuari nou</message>
-    <message key="xmlui.EPerson.StartRegistration.head1">L&apos;adreça electrònica ja s&apos;utilitza</message>
-    <message key="xmlui.EPerson.StartRegistration.para1">Aquesta adreça electrònica ja s&apos;utilitza en un altre compte. Si voleu restablir la contrasenya d&apos;aquest compte, feu clic al botó de restabliment de contrasenya a sota. </message>
-    <message key="xmlui.EPerson.StartRegistration.reset_password_for">Restableix la contrasenya de</message>
-    <message key="xmlui.EPerson.StartRegistration.submit_reset">Restableix la contrasenya</message>
-    <message key="xmlui.EPerson.StartRegistration.head2">Registre d&apos;usuari nou</message>
-    <message key="xmlui.EPerson.StartRegistration.para2">Registreu un compte per subscriviu-vos a col·leccions, per rebre actualitzacions per correu electrònic i enviar elements nous al DSpace. </message>
-    <message key="xmlui.EPerson.StartRegistration.email_address">Adreça electrònica</message>
-    <message key="xmlui.EPerson.StartRegistration.email_address_help">Aquesta adreça es verificarà i s&apos;utilitzarà com a nom d&apos;inici de sessió.</message>
-    <message key="xmlui.EPerson.StartRegistration.error_bad_email">No es pot enviar el missatge a aquesta adreça.</message>
-    <message key="xmlui.EPerson.StartRegistration.submit_register">Registre</message>
-       
-    <!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-    <message key="xmlui.EPerson.VerifyEmail.title">S&apos;ha enviat el missatge de verificació</message>
-    <message key="xmlui.EPerson.VerifyEmail.head">S&apos;ha enviat el missatge de verificació</message>
-    <message key="xmlui.EPerson.VerifyEmail.para">S&apos;ha enviat un missatge a {0} amb una adreça URL especial i més instruccions. </message>
 
 
-	<!--
-		Submission Aspect
-	-->
-	
+
+
+
+	<!-- General keys used by the EPerson aspect -->
+	<message key="xmlui.EPerson.trail_new_registration">Registre d'usuari nou</message>
+	<message key="xmlui.EPerson.trail_forgot_password">Heu oblidat la contrasenya</message>
+
+	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
+	<message key="xmlui.EPerson.CannotRegister.title">Registre no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Registre no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">La configuració d'aquest dipòsit del DSpace no permet el registre en aquest context. Poseu-vos en contacte amb <a href="../contact">site administrator</a> with questions or comments.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
+	<message key="xmlui.EPerson.EditProfile.title_update">Actualitza el perfil</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Crea un perfil</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Actualitza el perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Actualitza el perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Crea un perfil</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Nom</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Cognoms</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Telèfon de contacte</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Language</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Subscripcions</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Us podeu subscriure a col·leccions per rebre alertes diàries per correu electrònic dels elements nous que s'afegeixin. Podeu subscriure-us a tantes col·leccions com vulgueu. Una altra alternativa a les alertes diàries per correu electrònic es utilitzar les fonts RSS que hi ha disponibles per a les col·leccions.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscripcions per correu electrònic</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">( Seleccioneu la col·lecció )</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalment, podeu introduir una contrasenya nova al quadre de sota i confirmar-la tornant-la a escriure al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Introduïu una contrasenya al quadre de sota i confirmeu-la tornant-la a escriure al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Contrasenya</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Torneu-la a escriure per confirmar-la</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Completa el registre</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Actualitza el perfil</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Aquest camp és necessari</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Trieu una contrasenya de com a mínim 6 caràcters</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Grups d'autorització als quals pertanyeu</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identifiqueu-vos</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Seguretat</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifica l'adreça electrònica</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crea un perfil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Finalitzat</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifica l'adreça electrònica</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restableix la contrasenya</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Finalitzat</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Contrasenya restablerta</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Contrasenya restablerta</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">S'ha restablert la contrasenya.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
+	<message key="xmlui.EPerson.InvalidToken.title">Testimoni no vàlid</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Testimoni no vàlid</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Testimoni no vàlid</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">L'adreça URL que heu indicat no és vàlida. Pot ser que l'adreça URL hagi quedat partida en diverses línies al client de correu electrònic, com aquí: </message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Si és així, copieu i enganxeu tota l'adreça URL directament a la barra d'adreces del navegador, en lloc de fer clic a l'enllaç.  La barra d'adreça hauria d'assemblar-se a aquesta:</message>
+
+	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
+	<message key="xmlui.EPerson.Navigation.my_account">El meu compte</message>
+	<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
+	<message key="xmlui.EPerson.Navigation.logout">Finalitza la sessió</message>
+	<message key="xmlui.EPerson.Navigation.login">Inicia la sessió</message>
+	<message key="xmlui.EPerson.Navigation.register">Registre</message>
+
+	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
+	<message key="xmlui.EPerson.PasswordLogin.title">Registreu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Registreu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Registreu-vos al DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">L'adreça electrònica i/o la contrasenya que heu indicat no són vàlides.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Contrasenya</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link"> Heu oblidat la contrasenya?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Registreu-vos</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Registre d'usuari nou</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Registreu un compte per subscriviu-vos a col·leccions, per rebre actualitzacions per correu electrònic i enviar elements nous al DSpace. </message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Feu clic aquí per registrar-vos.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
+	<message key="xmlui.EPerson.LDAPLogin.title">Registreu-vos</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Registreu-vos</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Registreu-vos al DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Nom d'usuari</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nom d'usuari i/o la contrasenya que heu indicat no són vàlids.</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Contrasenya</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Registreu-vos</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
+	<message key="xmlui.EPerson.LoginChooser.title">Trieu un mètode d'inici de sessió</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Trieu l'inici de sessió</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Trieu un mètode d'inici de sessió</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Inici de sessió per:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticació Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticació LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticació per contrasenya</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Autenticació per certificat web</message>
+
+	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Les credencials proporcionades no son vàlides.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">No es pot autenticar perquè s'han rebut arguments no vàlids.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No s'ha trobat cap usuari amb les credencials indicades.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Ha fallat l'autenticació</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">L'autenticació ha fallat</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Ha fallat l'autenticació</message>
+
+	<!-- Login xml files -->
+	<message key="xmlui.eperson.noAuthMethod.head">No s'ha trobat cap mètode d'autenticació</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">No s'ha trobat cap mètode d'autenticació.  Poseu-vos en contacte amb l'administrador del lloc.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">Ha fallat l'inici de sessió amb Shibboleth</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">L'autenticació Shibboleth no està disponible en aquest moment. Poseu-vos en contacte amb l'administrador del lloc.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
+	<message key="xmlui.EPerson.ProfileUpdated.title">Perfil actualitzat</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Actualitza el perfil</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Perfil actualitzat</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">S'ha actualitzat la informació del vostre perfil.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
+	<message key="xmlui.EPerson.RegistrationFinished.title">Registre finalitzat</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Registre finalitzat</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Ja esteu registrat per utilitzar el sistema.  Us podeu subscriure a col·leccions per rebre actualitzacions per correu electrònic sobre elements nous.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
+	<message key="xmlui.EPerson.ResetPassword.title">Restableix la contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Restableix la contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Introduïu una contrasenya nova al quadre de sota i confirmeu-la tornant-la a introduir al segon quadre.  Ha de tenir com a mínim sis caràcters.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Contrasenya nova</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Torneu-la a escriure per confirmar-la</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Restableix la contrasenya</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Trieu una contrasenya de com a mínim 6 caràcters</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Torneu a escriure la contrasenya per confirmar-la</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
+	<message key="xmlui.EPerson.StartForgotPassword.title">Heu oblidat la contrasenya</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Heu oblidat la contrasenya</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Introduïu l'adreça electrònica que vàreu indicar en registrar-vos. Se us enviarà un missatge amb instruccions a aquesta adreça.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduïu la mateixa adreça que vàreu utilitzar en registrar-vos.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">No s'ha trobat l'adreça electrònica.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Envia informació</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
+	<message key="xmlui.EPerson.StartRegistration.title">Registre d'usuari nou</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">L'adreça electrònica ja s'utilitza</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Aquesta adreça electrònica ja s'utilitza en un altre compte. Si voleu restablir la contrasenya d'aquest compte, feu clic al botó de restabliment de contrasenya a sota. </message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restableix la contrasenya de</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Restableix la contrasenya</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Registre d'usuari nou</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Registreu un compte per subscriviu-vos a col·leccions, per rebre actualitzacions per correu electrònic i enviar elements nous al DSpace. </message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Adreça electrònica</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Aquesta adreça es verificarà i s'utilitzarà com a nom d'inici de sessió.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">No es pot enviar el missatge a aquesta adreça.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Registre</message>
+
+	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
+	<message key="xmlui.EPerson.VerifyEmail.title">S'ha enviat el missatge de verificació</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">S'ha enviat el missatge de verificació</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">S'ha enviat un missatge a {0} amb una adreça URL especial i més instruccions. </message>
+
+
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		               Submission Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
 	<!-- general submission aspect messages -->
-	<message key="xmlui.Submission.general.mydspace_home">Pàgina principal d&apos;El meu DSpace</message>
-    <message key="xmlui.Submission.general.go_mydspace">Vés a la pàgina principal d&apos;El meu DSpace</message>
-    <message key="xmlui.Submission.general.submission.title">Enviament d&apos;elements</message>
-    <message key="xmlui.Submission.general.submission.trail">Enviament d&apos;elements</message>
-    <message key="xmlui.Submission.general.submission.head">Enviament d&apos;elements</message>      
-    <message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
-    <message key="xmlui.Submission.general.submission.save">Desa i surt</message>
-    <message key="xmlui.Submission.general.submission.next">Següent &gt;</message>
-    <message key="xmlui.Submission.general.submission.complete">Completa l&apos;enviament</message>
-    <message key="xmlui.Submission.general.workflow.title">Enviament d&apos;elements</message>
-    <message key="xmlui.Submission.general.workflow.trail">Enviament d&apos;elements</message>
-    <message key="xmlui.Submission.general.workflow.head">Enviament d&apos;elements</message>
-    <message key="xmlui.Submission.general.showfull">Mostra el registre d&apos;element complet</message>
-    <message key="xmlui.Submission.general.showsimple">Mostra el registre d&apos;element simple</message>
-    <message key="xmlui.Submission.general.default.title">Enviament</message>
-    <message key="xmlui.Submission.general.default.trail">Enviament</message>
-       
-    <!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-    <message key="xmlui.Submission.CollectionViewer.link1">Envia un element nou a aquesta col·lecció</message>
-       
-    <!-- org.dspace.app.xmlui.submission.Navigation -->
-    <message key="xmlui.Submission.Navigation.submissions">Enviaments</message>
+	<message key="xmlui.Submission.general.mydspace_home">Pàgina principal d'El meu DSpace</message>
+	<message key="xmlui.Submission.general.go_mydspace">Vés a la pàgina principal d'El meu DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.trail">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.head">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
+	<message key="xmlui.Submission.general.submission.save">Desa i surt</message>
+	<message key="xmlui.Submission.general.submission.next">Següent &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Completa l'enviament</message>
+	<message key="xmlui.Submission.general.workflow.title">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.workflow.trail">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.workflow.head">Enviament d'elements</message>
+	<message key="xmlui.Submission.general.showfull">Mostra el registre d'element complet</message>
+	<message key="xmlui.Submission.general.showsimple">Mostra el registre d'element simple</message>
+	<message key="xmlui.Submission.general.default.title">Enviament</message>
+	<message key="xmlui.Submission.general.default.trail">Enviament</message>
 
-       
-    <!-- org.dspace.app.xmlui.Submission.submissions -->
-    <message key="xmlui.Submission.Submissions.title">Enviaments i flux de treball</message>
-    <message key="xmlui.Submission.Submissions.trail">Enviaments</message>
-    <message key="xmlui.Submission.Submissions.head">Enviaments i tasques de flux de treball</message>
-    <message key="xmlui.Submission.Submissions.untitled"><i>Sense títol</i></message>
-    <message key="xmlui.Submission.Submissions.email">correu electrònic: </message>
-    <!-- Same transformer, workflow section -->
-    <message key="xmlui.Submission.Submissions.workflow_head1">Tasques de flux de treball</message>
-    <message key="xmlui.Submission.Submissions.workflow_info1">Aquestes tasques són elements que estan pendents d&apos;aprovació per afegir-se al dipòsit. Hi ha dues cues de tasques, una per a les que heu triat d&apos;acceptar i una altra per a les tasques que encara no ha assumit ningú. </message>
-    <message key="xmlui.Submission.Submissions.workflow_head2">Les vostres tasques</message>
-    <message key="xmlui.Submission.Submissions.workflow_column1"></message>
-    <message key="xmlui.Submission.Submissions.workflow_column2">Tasca</message>
-    <message key="xmlui.Submission.Submissions.workflow_column3">Element</message>
-    <message key="xmlui.Submission.Submissions.workflow_column4">Col·lecció</message>
-    <message key="xmlui.Submission.Submissions.workflow_column5">Qui ho presenta</message>
-    <message key="xmlui.Submission.Submissions.workflow_submit_return">Torna les tasques seleccionades a la memòria</message>
-    <message key="xmlui.Submission.Submissions.workflow_info2">No teniu cap tasca assignada</message>
-    <message key="xmlui.Submission.Submissions.workflow_head3">Tasques a la memòria</message>
-    <message key="xmlui.Submission.Submissions.workflow_submit_take">Assumeix les tasques seleccionades</message>
-    <message key="xmlui.Submission.Submissions.workflow_info3">No hi ha cap tasca a la memòria</message>
-    <!-- Same transformer, submissions section -->
-    <message key="xmlui.Submission.Submissions.submit_head1">Enviaments</message>
-    <message key="xmlui.Submission.Submissions.submit_info1a">Podeu </message>
-    <message key="xmlui.Submission.Submissions.submit_info1b">iniciar un nou enviament</message>
-    <message key="xmlui.Submission.Submissions.submit_info1c">El procés d&apos;enviament inclou la descripció de l'element i la càrrega dels fitxers que el comprenen.  Cada comunitat o col·lecció pot establir la seva pròpia directiva d&apos;enviaments.</message>
-    <message key="xmlui.Submission.Submissions.submit_head2">Enviaments inacabats</message>
-    <message key="xmlui.Submission.Submissions.submit_info2a">Hi ha enviaments d&apos;elements inacabats. També podeu </message>
-    <message key="xmlui.Submission.Submissions.submit_info2b">iniciar un altre enviament</message>
-    <message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-    <message key="xmlui.Submission.Submissions.submit_column1"></message>
-    <message key="xmlui.Submission.Submissions.submit_column2">Títol</message>
-    <message key="xmlui.Submission.Submissions.submit_column3">Col·lecció</message>
-    <message key="xmlui.Submission.Submissions.submit_column4">Qui ho presenta</message>
-    <message key="xmlui.Submission.Submissions.submit_head3">Autoria:</message>
-    <message key="xmlui.Submission.Submissions.submit_info3">No hi ha cap enviament inacabat.</message>
-    <message key="xmlui.Submission.Submissions.submit_head4">Supervisió:</message>
-    <message key="xmlui.Submission.Submissions.submit_submit_remove">Suprimeix els enviaments seleccionats</message>
-    <!-- Same transformer, inprogress section -->
-    <message key="xmlui.Submission.Submissions.progress_head1">Enviaments en revisió</message>
-    <message key="xmlui.Submission.Submissions.progress_info1">Aquests són els vostres enviaments completats que actualment estan revisant els conservadors de la col·lecció.</message>
-    <message key="xmlui.Submission.Submissions.progress_column1">Títol</message>
-    <message key="xmlui.Submission.Submissions.progress_column2">Col·lecció</message>
-    <message key="xmlui.Submission.Submissions.progress_column3">Estat</message>
-    <!-- Same transformer, workflow status -->
-    <message key="xmlui.Submission.Submissions.status_0">Enviat</message>
-    <message key="xmlui.Submission.Submissions.status_1">Pendent de revisió pel revisor</message>
-    <message key="xmlui.Submission.Submissions.status_2">Enviament en procés de revisió</message>
-    <message key="xmlui.Submission.Submissions.status_3">Pendent de revisió per l&apos;editor</message>
-    <message key="xmlui.Submission.Submissions.status_4">Enviament en edició</message>
-    <message key="xmlui.Submission.Submissions.status_5">Pendent de revisió final per l&apos;editor</message>
-    <message key="xmlui.Submission.Submissions.status_6">Enviament en edició</message>
-    <message key="xmlui.Submission.Submissions.status_7">L&apos;enviament s&apos;ha arxivat</message>
-    <message key="xmlui.Submission.Submissions.status_unknown">Estat desconegut</message>
+	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
+	<message key="xmlui.Submission.CollectionViewer.link1">Envia un element nou a aquesta col·lecció</message>
 
-    <!-- submission progress bar messages -->
-    <message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntes inicials</message>
-    <message key="xmlui.Submission.submit.progressbar.describe">Descripció</message>
+	<!-- org.dspace.app.xmlui.submission.Navigation -->
+	<message key="xmlui.Submission.Navigation.submissions">Enviaments</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Enviaments i flux de treball</message>
+	<message key="xmlui.Submission.Submissions.trail">Enviaments</message>
+	<message key="xmlui.Submission.Submissions.head">Enviaments i tasques de flux de treball</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">correu electrònic: </message>
+	<!-- Same transformer, workflow section -->
+	<message key="xmlui.Submission.Submissions.workflow_head1">Tasques de flux de treball</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Aquestes tasques són elements que estan pendents d'aprovació per afegir-se al dipòsit. Hi ha dues cues de tasques, una per a les que heu triat d'acceptar i una altra per a les tasques que encara no ha assumit ningú. </message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Les vostres tasques</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Tasca</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Element</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Qui ho presenta</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Torna les tasques seleccionades a la memòria</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">No teniu cap tasca assignada</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Tasques a la memòria</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Assumeix les tasques seleccionades</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">No hi ha cap tasca a la memòria</message>
+	<!-- Same transformer, submissions section -->
+	<message key="xmlui.Submission.Submissions.submit_head1">Enviaments</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Podeu </message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">iniciar un nou enviament</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">El procés d'enviament inclou la descripció de l'element i la càrrega dels fitxers que el comprenen.  Cada comunitat o col·lecció pot establir la seva pròpia directiva d'enviaments.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Enviaments inacabats</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Hi ha enviaments d'elements inacabats. També podeu </message>
+	<message key="xmlui.Submission.Submissions.submit_info2b">iniciar un altre enviament</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Títol</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Qui ho presenta</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Autoria:</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">No hi ha cap enviament inacabat.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Supervisió:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Suprimeix els enviaments seleccionats</message>
+	<!-- Same transformer, inprogress section -->
+	<message key="xmlui.Submission.Submissions.progress_head1">Enviaments en revisió</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Aquests són els vostres enviaments completats que actualment estan revisant els conservadors de la col·lecció.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Títol</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Col·lecció</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Estat</message>
+	<!-- Same transformer, workflow status -->
+	<message key="xmlui.Submission.Submissions.status_0">Enviat</message>
+	<message key="xmlui.Submission.Submissions.status_1">Pendent de revisió pel revisor</message>
+	<message key="xmlui.Submission.Submissions.status_2">Enviament en procés de revisió</message>
+	<message key="xmlui.Submission.Submissions.status_3">Pendent de revisió per l'editor</message>
+	<message key="xmlui.Submission.Submissions.status_4">Enviament en edició</message>
+	<message key="xmlui.Submission.Submissions.status_5">Pendent de revisió final per l'editor</message>
+	<message key="xmlui.Submission.Submissions.status_6">Enviament en edició</message>
+	<message key="xmlui.Submission.Submissions.status_7">L'enviament s'ha arxivat</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Estat desconegut</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
+
+	<!-- submission progress bar messages -->
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntes inicials</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Descripció</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
     <message key="xmlui.Submission.submit.progressbar.upload">Puja</message>
-    <message key="xmlui.Submission.submit.progressbar.verify">Revisa</message>
-    <message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Revisa</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
     <message key="xmlui.Submission.submit.progressbar.license">Llicència</message>
-    <message key="xmlui.Submission.submit.progressbar.complete">Complet</message>
-       
-    <!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-    <message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resum</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Complet</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-    <message key="xmlui.Submission.submit.SelectCollection.head">Seleccioneu una col·lecció</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection">Col·lecció</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccioneu la col·lecció a la qual voleu enviar un element.</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccioneu una col·lecció...</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Resum</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Voleu desar o cancel·lar l&apos;enviament?</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voleu suprimir l&apos;enviament o voleu continuar treballant-hi més tard?  Podeu tornar al procés d&apos;enviament si heu fet clic a Surt per accident.</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continua amb l&apos;enviament </message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Desa-ho. Hi treballaré més tard </message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Suprimeix l&apos;enviament</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
+	<message key="xmlui.Submission.submit.SelectCollection.head">Seleccioneu una col·lecció</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Col·lecció</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccioneu la col·lecció a la qual voleu enviar un element.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccioneu una col·lecció...</message>
 
-       
-    <!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntes inicials</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota important: </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.and"> i  </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.separator">, </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Diversos títols</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'element té més d&apos;un títol, <i>p. ex. un títol traduït</i></message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si anul·leu la selecció de la casella de dalt els títols següents se suprimiran de l'element:  </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicat</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">L'element ha estat publicat o distribuit públicament abans</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si anul·leu la selecció de la casella de dalt, se suprimirà el següent de l'element:</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data d&apos;edició</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
-       
-    <!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-    <message key="xmlui.Submission.submit.DescribeStep.head">Descriu l'element</message>
-    <message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: Tipus de camp desconegut</message>
-    <message key="xmlui.Submission.submit.DescribeStep.required_field">Aquest camp és necessari</message>
-    <message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognoms, <i>p. ex. Adrià Acosta</i></message>
-    <message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nom + &quot;,  <i>p. ex. Ferran</i></message>
-    <message key="xmlui.Submission.submit.DescribeStep.year">Any</message>
-    <message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
-    <message key="xmlui.Submission.submit.DescribeStep.day">Dia</message>
-    <message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la sèrie</message>
-    <message key="xmlui.Submission.submit.DescribeStep.report_no">Núm. informe o treball</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Voleu desar o cancel·lar l'enviament?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voleu suprimir l'enviament o voleu continuar treballant-hi més tard?  Podeu tornar al procés d'enviament si heu fet clic a Surt per accident.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continua amb l'enviament </message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Desa-ho. Hi treballaré més tard </message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Suprimeix l'enviament</message>
 
+
+	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntes inicials</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota important: </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and"> i  </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">, </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Diversos títols</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'element té més d'un títol, <i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si anul·leu la selecció de la casella de dalt els títols següents se suprimiran de l'element:  </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicat</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">L'element ha estat publicat o distribuit públicament abans</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si anul·leu la selecció de la casella de dalt, se suprimirà el següent de l'element:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data d'edició</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
+	<message key="xmlui.Submission.submit.DescribeStep.head">Descriu l'element</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: Tipus de camp desconegut</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Aquest camp és necessari</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognoms, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nom + ",  <i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Any</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Dia</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la sèrie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Núm. informe o treball</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-    <message key="xmlui.Submission.submit.UploadStep.head">Puja els fitxers </message>
-    <message key="xmlui.Submission.submit.UploadStep.file">Fitxer</message>
-    <message key="xmlui.Submission.submit.UploadStep.file_help">Introduïu la ruta completa del fitxer de l&apos;ordinador que es correspon amb l'element. Si feu clic a &quot;Explora...&quot; s&apos;obrirà una finestra nova on podreu seleccionar el fitxer de l&apos;ordinador. </message>
-    <message key="xmlui.Submission.submit.UploadStep.file_error">L'element ha de contenir com a mínim un fitxer.</message>
-    <message key="xmlui.Submission.submit.UploadStep.upload_error">Hi ha hagut un problema en carregar el fitxer. O bé el nom del fitxer que heu introduït és incorrecte, hi ha hagut un problema de xarxa que ha impedit que l'arxiu arribi correctament, o s'ha intentat carregar un format de fitxer marcat per a ús intern només del sistema. Torneu-ho a intentar de nou.</message>
-    <message key="xmlui.Submission.submit.UploadStep.description">File Description</message>
-
+	<message key="xmlui.Submission.submit.UploadStep.head">Puja els fitxers </message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Introduïu la ruta completa del fitxer de l'ordinador que es correspon amb l'element. Si feu clic a "Explora..." s'obrirà una finestra nova on podreu seleccionar el fitxer de l'ordinador. </message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">L'element ha de contenir com a mínim un fitxer.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Hi ha hagut un problema en carregar el fitxer. O bé el nom del fitxer que heu introduït és incorrecte, hi ha hagut un problema de xarxa que ha impedit que l'arxiu arribi correctament, o s'ha intentat carregar un format de fitxer marcat per a ús intern només del sistema. Torneu-ho a intentar de nou.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Descripció del fitxer</message>
-    <message key="xmlui.Submission.submit.UploadStep.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple &quot; <i>Article principal</i>&quot; o &quot; <i>Lectures de dades de prova</i>".</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_upload">Puja el fitxer i afegeix-ne un altre</message>
-    <message key="xmlui.Submission.submit.UploadStep.head2">Fitxers pujats</message>
-    <message key="xmlui.Submission.submit.UploadStep.column0">Principal</message>
-    <message key="xmlui.Submission.submit.UploadStep.column1">  </message>
-    <message key="xmlui.Submission.submit.UploadStep.column2">Fitxer</message>
-    <message key="xmlui.Submission.submit.UploadStep.column3">Mida</message>
-    <message key="xmlui.Submission.submit.UploadStep.column4">Descripció</message>
-    <message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadStep.column6"></message>
-    <message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconegut</message>
-    <message key="xmlui.Submission.submit.UploadStep.unknown_format">format desconegut</message>
-    <message key="xmlui.Submission.submit.UploadStep.supported">(Admès)</message>
-    <message key="xmlui.Submission.submit.UploadStep.known">(Conegut)</message>
-    <message key="xmlui.Submission.submit.UploadStep.unsupported">(No admès)</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_edit">Edita</message>
-    <message key="xmlui.Submission.submit.UploadStep.checksum">Suma de comprovació de fitxers:</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_remove">Suprimeix els fitxers seleccionats</message>
-       
-    <!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-    <message key="xmlui.Submission.submit.EditFileStep.head">Edita el fitxer</message>
-    <message key="xmlui.Submission.submit.EditFileStep.file">Fitxer</message>
-    <message key="xmlui.Submission.submit.EditFileStep.description">Descripció del fitxer</message>
-    <message key="xmlui.Submission.submit.EditFileStep.description_help">Opcionalment, inclogueu una descripció breu del contingut;  per exemple, &quot; <i>Article principal</i>&quot; o &quot; <i>Lectures de dades de prova</i>".</message>
-    <message key="xmlui.Submission.submit.EditFileStep.info1">Seleccioneu el format del fitxer a la llista de sota, per exemple &quot; <i>Adobe PDF</i>&quot; o &quot;<i>Paraula</i>." <strong>Si el format no és a la llista</strong>, descriviu-lo al quadre d&apos;entrada de sota la llista.</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_detected">Format detectat</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_selected">Format seleccionat</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_default">Format no llistat</message>
-    <message key="xmlui.Submission.submit.EditFileStep.info2">Si el format no és a la llista de dalt, <strong>seleccioneu &quot;format no llistat&quot; a dalt</strong> i descriviu el format del fitxer al quadre de sota.</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_user">Un altre format</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nom de l&apos;aplicació que heu utilitzat per crear el fitxer, i número de versió (per exemple, &quot; <i>ACMESoft SuperApp versió 1.5 </i>").</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple " <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Puja el fitxer i afegeix-ne un altre</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Fitxers pujats</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Principal</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1">  </message>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Fitxer</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Mida</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Descripció</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconegut</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">format desconegut</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Admès)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Conegut)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(No admès)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Edita</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Suma de comprovació de fitxers:</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Suprimeix els fitxers seleccionats</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-    <message key="xmlui.Submission.submit.ReviewStep.head">Revisa l&apos;enviament</message>
-    <message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
-    <message key="xmlui.Submission.submit.ReviewStep.no">No</message>
-    <message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregiu algun dels següents elements</message>
-    <message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Afegiu o suprimiu un fitxer</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head1">Preguntes inicials</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head2">Descriviu la pàgina {0}</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head3">Fitxers pujats</message>
-    <message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Diversos títols</message>
-    <message key="xmlui.Submission.submit.ReviewStep.published_before">Publicat abans</message>
-    <message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-    <message key="xmlui.Submission.submit.ReviewStep.unknown">desconegut</message>
-    <message key="xmlui.Submission.submit.ReviewStep.known">conegut</message>
-    <message key="xmlui.Submission.submit.ReviewStep.supported">admès</message>
-       
-    <!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-    <message key="xmlui.Submission.submit.CCLicenseStep.head">Llicència de Creative Commons</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.info1">Si voleu, podeu afegir una  <a href="http://creativecommons.org/">llicència </a> Creative Commons al vostre element. <strong>Les llicències de Creative Commons regeixen què poden fer amb la vostra obra les persones que la llegeixen.</strong> Si voleu seleccionar una llicència de Creative Commons feu clic al botó de sota.  Accedireu al lloc web de Creative Commons, on se us oferiran diverses opcions de llicència.   Després de seleccionar una llicència, tornareu a aquesta pàgina. </message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Aneu al lloc web de Creative Commons per seleccionar una llicència</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.license">Llicència</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">Treu aquesta llicència de Creative Commons</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.no_license">no s&apos;ha seleccionat cap llicència de Creative Commons</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-    <message key="xmlui.Submission.submit.LicenseStep.head">Llicència de distribució</message>
-    <message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Falta un darrer pas:</strong> Perquè el DSpace pugui reproduir, traduir i distribuir el vostre material a tot el món, heu d&apos;acceptar les condicions següents. </message>
-    <message key="xmlui.Submission.submit.LicenseStep.info2">Concediu la llicència de distribució estàndard seleccionant &apos;Concedeixo la llicència&apos;;  i fent clic a &apos;Completa l&apos;enviament&apos; tot seguit. </message>
-    <message key="xmlui.Submission.submit.LicenseStep.info3">Si teniu preguntes relacionades amb aquesta llicència, poseu-vos en contacte amb els administradors del sistema.</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_label">Llicència de distribució</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concedeixo la llicència</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_error">Heu de concedir la llicència per completar l&apos;enviament. Si no podeu concedir la llicència en aquest moment, podeu desar el treball i tornar més tard o suprimir l&apos;enviament fent clic al botó &apos;Desa i surt&apos; a sota.</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-    <message key="xmlui.Submission.submit.RemovedStep.head">Enviament suprimit</message>
-    <message key="xmlui.Submission.submit.RemovedStep.info1">S&apos;ha cancel·lat l&apos;enviament i s&apos;ha suprimit l'element incomplet del sistema. </message>
-    <message key="xmlui.Submission.submit.RemovedStep.go_submission">Vés a la pàgina Enviaments</message>  
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-    <message key="xmlui.Submission.submit.CompletedStep.head">Enviament completat</message>
-    <message key="xmlui.Submission.submit.CompletedStep.info1">L&apos;enviament se sotmetrà ara al procés de revisió de la col·lecció. Rebreu una notificació per correu electrònic quan el vostre enviament hagi entrat a la col·lecció o si hi ha cap problema amb l&apos;enviament.  També podeu comprovar l&apos;estat del vostre enviament visitant la pàgina d&apos;enviaments.</message>      
-    <message key="xmlui.Submission.submit.CompletedStep.go_submission">Vés a la pàgina Enviaments</message>
-    <message key="xmlui.Submission.submit.CompletedStep.submit_again">Envia un altre element</message>        
 
-    <!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-    <message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accions que podeu fer en aquesta tasca:</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Assigneu-vos aquesta tasca.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Assumeix la tasca</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixeu aquesta tasca a la memòria perquè l&apos;assumeixi una altra persona.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Abandona la tasca</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si heu revisat l'element i és adequat per incloure&apos;s a la col·lecció, seleccioneu &quot;Aprova&quot;. </message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprova l'element</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Quan hagueu editat l'element, utilitzeu aquesta opció per enviar l'element a l&apos;arxiu. </message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Envia a l&apos;arxiu</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si heu revisat l'element i heu conclòs que <strong>no </strong> és adequat per incloure&apos;s a la col·lecció, seleccioneu &quot;Rebutja&quot;.   Posteriorment se us demanarà que introduïu un missatge indicant per què no és adequat l'element i si qui l&apos;ha presentat ha de canviar alguna cosa i tornar a enviar-la. </message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rebutja l'element</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Seleccioneu aquesta opció per canviar les metadades de l'element.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edita les metadades</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Torneu la tasca a la memòria per tal que un altre usuari pugui fer-la.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Torna la tasca a la memòria</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
+	<message key="xmlui.Submission.submit.EditFileStep.head">Edita el fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Descripció del fitxer</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Opcionalment, inclogueu una descripció breu del contingut;  per exemple, " <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccioneu el format del fitxer a la llista de sota, per exemple " <i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Format detectat</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Format seleccionat</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">Format no llistat</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Si el format no és a la llista de dalt, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Un altre format</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nom de l'aplicació que heu utilitzat per crear el fitxer, i número de versió (per exemple, " <i>ACMESoft SuperApp version 1.5</i>").</message>
 
-    <!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-    <message key="xmlui.Submission.workflow.RejectTaskStep.info1">Introduïu al quadre de sota la raó per la qual rebutgeu l'element presentat, indicant si qui l&apos;ha presentat pot resoldre un problema i tornar a enviar-la. </message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.reason">Raó</message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El camp de raó és necessari</message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rebutja l'element</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
 
-       <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- 
- Administrative Aspect
- 
- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->    <!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->      <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L&apos;usuari s&apos;ha afegit correctament.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">L&apos;usuari s&apos;ha editat correctament.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">S&apos;ha enviat un missatge de correu electrònic a l&apos;usuari amb un testimoni que es pot utilitzar per triar una contrasenya nova.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Els usuaris s&apos;han suprimit correctament. </message>
-    <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Els usuaris de la llista no s&apos;han suprimit perquè hi ha restriccions que impedeixen suprimir-los; vegeu la pàgina de detalls d&apos;e-persona per obtenir més informació. </message>
-    <message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">El grup s&apos;ha editat correctament.</message>
-    <message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Els grups seleccionats s&apos;han suprimit correctament.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">S&apos;ha creat correctament un esquema nou.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Els esquemes s&apos;han suprimit correctament.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">S&apos;ha afegit correctament el camp de metadades.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">S&apos;ha editat correctament el camp de metadades.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">S&apos;han mogut correctament els camps. </message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">S&apos;han suprimit correctament els camps. </message>
-    <message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">S&apos;ha desat correctament el format.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">S&apos;han suprimit correctament els formats. </message>
-    <message key="xmlui.administrative.FlowItemUtils.metadata_updated">S&apos;han actualitzat correctament les metadades de l'element.</message>
-    <message key="xmlui.administrative.FlowItemUtils.metadata_added">S&apos;han afegit metadades noves.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_withdrawn">S&apos;ha retirat l'element.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_reinstated">S&apos;ha restituït l'element.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_added">S&apos;ha pujat correctament el nou document.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error en pujar el fitxer.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_updated">S&apos;ha actualitzat el document.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_delete">S&apos;han suprimit els fluxos de bits seleccionats.</message>
-    <message key="xmlui.administrative.FlowMapperUtils.map_items">S&apos;han assignat correctament els elements.</message>
-    <message key="xmlui.administrative.FlowMapperUtils.unmaped_items">S&apos;ha anul·lat l&apos;assignació dels elements.</message>
-       
-    <!-- general items for all of the eperson classes -->
-    <message key="xmlui.administrative.eperson.general.epeople_trail">Gestiona les e-persones</message>
-   <!-- org.dspace.app.xmlui.administrative.Navigation -->  <!-- contextual menu items -->  <message key="xmlui.administrative.Navigation.context_head">Context</message>
-    <message key="xmlui.administrative.Navigation.context_edit_item">Edita aquest element</message>
-    <message key="xmlui.administrative.Navigation.context_edit_collection">Edita la col·lecció</message>
-    <message key="xmlui.administrative.Navigation.context_item_mapper">Assignador d&apos;elements</message>
-    <message key="xmlui.administrative.Navigation.context_edit_community">Edita la comunitat</message>
-    <message key="xmlui.administrative.Navigation.context_create_collection">Crea una col·lecció</message>
-    <message key="xmlui.administrative.Navigation.context_create_subcommunity">Crea una subcomunitat</message>
-    <message key="xmlui.administrative.Navigation.context_create_community">Crea una comunitat</message>
-    <message key="xmlui.administrative.Navigation.context_export_item">Exporta l'element</message>
-     <message key="xmlui.administrative.Navigation.context_export_collection">Exporta la col·lecció</message>
-     <message key="xmlui.administrative.Navigation.context_export_community">Exporta la comunitat</message>
-       
-    <!-- Site administrator options -->
-    <message key="xmlui.administrative.Navigation.administrative_head">Administratiu</message>
-    <message key="xmlui.administrative.Navigation.administrative_access_control">Control d&apos;accés</message>
-    <message key="xmlui.administrative.Navigation.administrative_people">Persones</message>
-    <message key="xmlui.administrative.Navigation.administrative_groups">Grups</message>
-    <message key="xmlui.administrative.Navigation.administrative_authorizations">Autoritzacions</message>
-    <message key="xmlui.administrative.Navigation.administrative_registries">Registres</message>
-    <message key="xmlui.administrative.Navigation.administrative_metadata">Metadades</message>
-    <message key="xmlui.administrative.Navigation.administrative_format">Format</message>
-    <message key="xmlui.administrative.Navigation.administrative_items">Unitats</message>
-     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Unitats retirades</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">Revisa l'enviament</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">No</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregiu algun dels següents elements</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Afegiu o suprimiu un fitxer</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Preguntes inicials</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Descriviu la pàgina {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Fitxers pujats</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Diversos títols</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicat abans</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">desconegut</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">conegut</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">admès</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Llicència de Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Si voleu, podeu afegir una  <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Aneu al lloc web de Creative Commons per seleccionar una llicència</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Llicència</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">no s'ha seleccionat cap llicència de Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
+	<message key="xmlui.Submission.submit.LicenseStep.head">Llicència de distribució</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Concediu la llicència de distribució estàndard seleccionant 'Concedeixo la llicència';  i fent clic a 'Completa l'enviament' tot seguit. </message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Si teniu preguntes relacionades amb aquesta llicència, poseu-vos en contacte amb els administradors del sistema.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Llicència de distribució</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concedeixo la llicència</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Heu de concedir la llicència per completar l'enviament. Si no podeu concedir la llicència en aquest moment, podeu desar el treball i tornar més tard o suprimir l'enviament fent clic al botó 'Desa i surt' a sota.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
+	<message key="xmlui.Submission.submit.RemovedStep.head">Enviament suprimit</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">S'ha cancel·lat l'enviament i s'ha suprimit l'element incomplet del sistema. </message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Vés a la pàgina Enviaments</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
+	<message key="xmlui.Submission.submit.CompletedStep.head">Enviament completat</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">L'enviament se sotmetrà ara al procés de revisió de la col·lecció. Rebreu una notificació per correu electrònic quan el vostre enviament hagi entrat a la col·lecció o si hi ha cap problema amb l'enviament.  També podeu comprovar l'estat del vostre enviament visitant la pàgina d'enviaments.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Vés a la pàgina Enviaments</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Envia un altre element</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accions que podeu fer en aquesta tasca:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Assigneu-vos aquesta tasca.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Assumeix la tasca</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixeu aquesta tasca a la memòria perquè l'assumeixi una altra persona.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Abandona la tasca</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si heu revisat l'element i és adequat per incloure's a la col·lecció, seleccioneu "Aprova". </message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprova l'element</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Quan hagueu editat l'element, utilitzeu aquesta opció per enviar l'element a l'arxiu. </message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Envia a l'arxiu</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si heu revisat l'element i heu conclòs que <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rebutja l'element</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Seleccioneu aquesta opció per canviar les metadades de l'element.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edita les metadades</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Torneu la tasca a la memòria per tal que un altre usuari pugui fer-la.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Torna la tasca a la memòria</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Introduïu al quadre de sota la raó per la qual rebutgeu l'element presentat, indicant si qui l'ha presentat pot resoldre un problema i tornar a enviar-la. </message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Raó</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El camp de raó és necessari</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rebutja l'element</message>
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             Administrative Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L'usuari s'ha afegit correctament.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">L'usuari s'ha editat correctament.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">S'ha enviat un missatge de correu electrònic a l'usuari amb un testimoni que es pot utilitzar per triar una contrasenya nova.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Els usuaris s'han suprimit correctament. </message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Els usuaris de la llista no s'han suprimit perquè hi ha restriccions que impedeixen suprimir-los; vegeu la pàgina de detalls d'e-persona per obtenir més informació. </message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">El grup s'ha editat correctament.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Els grups seleccionats s'han suprimit correctament.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">S'ha creat correctament un esquema nou.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Els esquemes s'han suprimit correctament.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">S'ha afegit correctament el camp de metadades.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">S'ha editat correctament el camp de metadades.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">S'han mogut correctament els camps. </message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">S'han suprimit correctament els camps. </message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">S'ha desat correctament el format.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">S'han suprimit correctament els formats. </message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">S'han actualitzat correctament les metadades de l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">S'han afegit metadades noves.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">S'ha retirat l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">S'ha restituït l'element.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">The item has been moved.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">The selected destination collection could not be found.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">S'ha pujat correctament el nou document.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error en pujar el fitxer.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">S'ha actualitzat el document.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">S'han suprimit els fluxos de bits seleccionats.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">S'han assignat correctament els elements.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">S'ha anul·lat l'assignació dels elements.</message>
+
+	<!-- general items for all of the eperson classes -->
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Gestiona les e-persones</message>
+
+	<!-- org.dspace.app.xmlui.administrative.Navigation -->
+	<!-- contextual menu items -->
+	<message key="xmlui.administrative.Navigation.context_head">Context</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Edita aquest element</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Edita la col·lecció</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Assignador d'elements</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Edita la comunitat</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Crea una col·lecció</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crea una subcomunitat</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Crea una comunitat</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Exporta l'element</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exporta la col·lecció</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exporta la comunitat</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Export Metadata</message>
+
+	<!-- Site administrator options -->
+	<message key="xmlui.administrative.Navigation.administrative_head">Administratiu</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Control d'accés</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Persones</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Grups</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Autoritzacions</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Registres</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadades</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Format</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Unitats</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Unitats retirades</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Tauler de control</message>
-     <message key="xmlui.administrative.Navigation.statistics">Estadístiques</message>
+    <message key="xmlui.administrative.Navigation.statistics">Estadístiques</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
     <!-- my account items -->
-    <message key="xmlui.administrative.Navigation.account_export">Les meves exportacions</message>
-       
-       
-    <!-- export item -->
-    <message key="xmlui.administrative.ItemExport.head">Arxiu d&apos;exportació</message>
-    <message key="xmlui.administrative.ItemExport.item.id.error">L&apos;id. d&apos;unitat indicat no és vàlid.</message>
-    <message key="xmlui.administrative.ItemExport.collection.id.error">L&apos;id. de col·lecció indicat no és vàlid.</message>
-    <message key="xmlui.administrative.ItemExport.community.id.error">L&apos;id. de comunitat indicat no és vàlid</message>
-    <message key="xmlui.administrative.ItemExport.item.not.found">No s&apos;ha trobat l'element sol·licitat.</message>
-    <message key="xmlui.administrative.ItemExport.collection.not.found">No s&apos;ha trobat la col·lecció sol·licitada.</message>
-    <message key="xmlui.administrative.ItemExport.community.not.found">No s&apos;ha trobat la comunitat sol·licitada.</message>
-    <message key="xmlui.administrative.ItemExport.item.success">L'element s&apos;ha exportat correctament.  Rebreu un missatge de correu electrònic quan l&apos;arxiu estigui a punt per baixar.   També podeu utilitzar l&apos;enllaç &apos;Les meves exportacions&apos; per veure una llista dels arxius disponibles.</message>
-    <message key="xmlui.administrative.ItemExport.collection.success">La col·lecció s&apos;ha exportat correctament.  Rebreu un missatge de correu electrònic quan l&apos;arxiu estigui a punt per baixar.   També podeu utilitzar l&apos;enllaç &apos;Les meves exportacions&apos; per veure una llista dels arxius disponibles.</message>
-    <message key="xmlui.administrative.ItemExport.community.success">La comunitat s&apos;ha exportat correctament.  Rebreu un missatge de correu electrònic quan l&apos;arxiu estigui a punt per baixar.   També podeu utilitzar l&apos;enllaç &apos;Les meves exportacions&apos; per veure una llista dels arxius disponibles.</message>
-    <message key="xmlui.administrative.ItemExport.available.head">Arxius d&apos;exportació disponibles per baixar:</message>
-       
+	<message key="xmlui.administrative.Navigation.account_export">Les meves exportacions</message>
+
+
+	<!-- export item -->
+	<message key="xmlui.administrative.ItemExport.head">Arxiu d'exportació</message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">L'id. d'unitat indicat no és vàlid.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">L'id. de col·lecció indicat no és vàlid.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">L'id. de comunitat indicat no és vàlid</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">No s'ha trobat l'element sol·licitat.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">No s'ha trobat la col·lecció sol·licitada.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">No s'ha trobat la comunitat sol·licitada.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">L'element s'ha exportat correctament.  Rebreu un missatge de correu electrònic quan l'arxiu estigui a punt per baixar.   També podeu utilitzar l'enllaç 'Les meves exportacions' per veure una llista dels arxius disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">La col·lecció s'ha exportat correctament.  Rebreu un missatge de correu electrònic quan l'arxiu estigui a punt per baixar.   També podeu utilitzar l'enllaç 'Les meves exportacions' per veure una llista dels arxius disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">La comunitat s'ha exportat correctament.  Rebreu un missatge de correu electrònic quan l'arxiu estigui a punt per baixar.   També podeu utilitzar l'enllaç 'Les meves exportacions' per veure una llista dels arxius disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Arxius d'exportació disponibles per baixar:</message>
+
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Gestiona les e-persones</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestió d&apos;e-persones</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accions</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crea una e-persona nova</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Feu clic aquí per afegir una e-persona nova.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Explora les e-persones</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Feu clic aquí per explorar totes les e-persones.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Cerca e-persones</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Les e-persones se cerquen per coincidència parcial amb l&apos;adreça electrònica o el nom</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A sota es mostra una llista de les e-persones que coincideixen amb la vostra consulta. Seleccioneu les e-persones que voleu suprimir i feu clic al botó de supressió per continuar o a l&apos;adreça electrònica o el nom d&apos;una e-persona per editar-la.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultats de la cerca</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">Id.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nom </message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Correu electrònic</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Suprimeix e-persones</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">La cerca no ha obtingut resultats...</message>
-               
-               
-    <!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-    <message key="xmlui.administrative.eperson.AddEPersonForm.title">Afegeix una e-persona</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.trail">Afegeix una e-persona</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crea un usuari nou</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Aquesta adreça electrònica la utilitza una altra e-persona. Les adreces electròniques han de ser exclusives.</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informació de l&apos;e-persona nova:</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L&apos;adreça electrònica ha de ser exclusiva</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_email">L&apos;adreça electrònica és necessària</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nom és necessari</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Els cognoms són necessaris</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Requereix certificat</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Pot iniciar sessió</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crea e-persona</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-    <message key="xmlui.administrative.eperson.EditEPersonForm.title">Edita e-persona</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edita e-persona</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edita una e-persona</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Aquesta adreça electrònica la utilitza una altra e-persona. Les adreces electròniques han de ser exclusives.</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informació de {0}:</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L&apos;adreça electrònica ha de ser exclusiva</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_email">L&apos;adreça electrònica és necessària</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nom és necessari</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Els cognoms són necessaris</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Requereix certificat</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Pot iniciar sessió</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restableix la contrasenya</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.special_help">També podeu suprimir per sempre aquesta e-persona del sistema o restablir-ne la contrasenya. En restablir una contrasenya, s&apos;enviarà a l&apos;usuari un missatge de correu electrònic amb un enllaç especial per triar una contrasenya nova.</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Suprimeix e-persona</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Inicia la sessió com a e-persona</message>
-       
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Aquesta e-persona no es pot suprimir per les següents restriccions: </message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">l&apos;e-persona ha enviat un o més elements</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l&apos;e-persona té un flux de treball d&apos;enviament actiu</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l&apos;e-persona té una tasca de flux de treball pendent</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l&apos;e-persona té una restricció sense identificar al sistema</message>
-       
-    <message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Grups dels quals és membre aquesta e-persona:</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(a través del grup:  {0})</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.member_none">cap</message>
-       
-       
-    <!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirma la supressió d&apos;e-persona</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirma la supressió</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirma la supressió</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Se suprimiran les e-persones següents: </message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirma la supressió</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">Id.</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nom </message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Correu electrònic</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Gestiona les e-persones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestió d'e-persones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accions</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crea una e-persona nova</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Feu clic aquí per afegir una e-persona nova.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Explora les e-persones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Feu clic aquí per explorar totes les e-persones.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Cerca e-persones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Les e-persones se cerquen per coincidència parcial amb l'adreça electrònica o el nom</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A sota es mostra una llista de les e-persones que coincideixen amb la vostra consulta. Seleccioneu les e-persones que voleu suprimir i feu clic al botó de supressió per continuar o a l'adreça electrònica o el nom d'una e-persona per editar-la.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">Id.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nom </message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Correu electrònic</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Suprimeix e-persones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">La cerca no ha obtingut resultats...</message>
 
 
-    <!-- general items for all of the group classes -->
-    <message key="xmlui.administrative.group.general.group_trail">Gestiona els grups</message>
+	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Afegeix una e-persona</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Afegeix una e-persona</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crea un usuari nou</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Aquesta adreça electrònica la utilitza una altra e-persona. Les adreces electròniques han de ser exclusives.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informació de l'e-persona nova:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L'adreça electrònica ha de ser exclusiva</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">L'adreça electrònica és necessària</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nom és necessari</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Els cognoms són necessaris</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Requereix certificat</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Pot iniciar sessió</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crea e-persona</message>
 
-    <!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-    <message key="xmlui.administrative.group.ManageGroupsMain.title">Gestiona els grups</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestió del grup</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accions</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crea un grup nou</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Feu clic aquí per afegir un grup nou.</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Explora els grups</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Feu clic aquí per explorar tots els grups.</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Cerqueu grups</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_help">Els grups se cerquen per coincidències parcials del seu nom</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultats de la cerca</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column2">Id.</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nom </message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membres</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Col·lecció</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Visualitza</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Suprimeix grups</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.no_results">La cerca no ha obtingut resultats...</message>
+	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Edita e-persona</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edita e-persona</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edita una e-persona</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Aquesta adreça electrònica la utilitza una altra e-persona. Les adreces electròniques han de ser exclusives.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informació de {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L'adreça electrònica ha de ser exclusiva</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">L'adreça electrònica és necessària</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nom és necessari</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Els cognoms són necessaris</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Requereix certificat</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Pot iniciar sessió</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restableix la contrasenya</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">També podeu suprimir per sempre aquesta e-persona del sistema o restablir-ne la contrasenya. En restablir una contrasenya, s'enviarà a l'usuari un missatge de correu electrònic amb un enllaç especial per triar una contrasenya nova.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Suprimeix e-persona</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Inicia la sessió com a e-persona</message>
 
-    <!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-    <message key="xmlui.administrative.group.EditGroupForm.title">Editor de grups</message>
-    <message key="xmlui.administrative.group.EditGroupForm.trail">Edita el grup</message>
-    <message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grups: {0} (Id.: {1})</message>
-    <message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grups: grup nou</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_clear">Esborra la cerca</message>
-    <message key="xmlui.administrative.group.EditGroupForm.member">Membre</message>
-    <message key="xmlui.administrative.group.EditGroupForm.cycle">Cicle</message>
-    <message key="xmlui.administrative.group.EditGroupForm.pending">Pendent</message>
-    <message key="xmlui.administrative.group.EditGroupForm.pending_warn">Tingueu en compte que els canvis pendents no es desen fins que feu clic al botó de desar. </message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_add">Afegeix</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_remove">Suprimeix</message>
-    <message key="xmlui.administrative.group.EditGroupForm.collection_para">Aquest grup està associat amb la col·lecció: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_name">Canvia el nom del grup: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_instructions">Aquest grup està associat amb una col·lecció concreta i el seu nom no es pot modificar.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_search">Cerca membres per afegir: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_search_people">E-persones...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grups...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.no_results">La cerca no ha obtingut resultats...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column1">Id. </message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nom </message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Correu electrònic</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column1">Id. </message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nom </message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membres</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column4">Col·lecció</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">visualitza</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_head">Membres</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column1">Id.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column2">Nom </message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column3">Correu electrònic</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_group_name">grup: {0}</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_none">Aquest grup no té cap membre.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendent]</message>
-    <message key="xmlui.administrative.group.EditGroupForm.instructions_para">Suprimeix membres</message>
-    <message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Suprimeix membres</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirma la supressió del grup</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirma la supressió</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirma la supressió</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Se suprimiran els grups següents:</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">Id. </message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nom </message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">E-persones</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grups</message>
-       
-    <!-- general items for all of the registries classes -->
-    <message key="xmlui.administrative.registries.general.format_registry_trail">Registre de formats</message>
-    <message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de metadades</message>      
-       
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Suprimeix formats de document</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Suprimeix formats de document</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirma la supressió</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Segur que voleu suprimir el format? Tots els fluxos de bits existents amb aquest format es tornaran al format de document desconegut.</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">Id. </message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipus MIME</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nom </message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Aquesta e-persona no es pot suprimir per les següents restriccions: </message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">l'e-persona ha enviat un o més elements</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l'e-persona té un flux de treball d'enviament actiu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l'e-persona té una tasca de flux de treball pendent</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l'e-persona té una restricció sense identificar al sistema</message>
 
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Suprimeix camps</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Suprimeix camps</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirma la supressió</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Teniu <b>la certesa</b> absoluta que voleu suprimir aquests camps?  Si algun element conté metadades en aquests camps, els camps no es poden suprimir.  Us heu d&apos;assegurar que cap element faci servir aquests camps.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ADVERTIMENT: </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Això ocasionarà un error si hi ha cap element que contingui metadades en aquests camps.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">Id. </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nom </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota d&apos;àmbit</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Suprimeix l&apos;esquema</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Suprimeix l&apos;esquema</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirma la supressió</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Teniu <b>la certesa</b> absoluta que voleu suprimir aquests camps? Si hi ha cap element que contingui metadades als camps inclosos en aquest esquema, l&apos;esquema no es pot suprimir.  Us heu d&apos;assegurar que cap element contingui metadades en aquest esquema.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ADVERTIMENT: </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Això ocasionarà un error si hi ha cap element que contingui metadades dins de l&apos;esquema.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">Id. </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espai de nom</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nom </message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format de document</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format de document</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nou format de document</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format de document: {0}</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Inclogueu metadades descriptives sobre el format de document a sota. Si bé els noms de format han de ser exclusius, els tipus MIME no cal que ho siguin.  Podeu tenir entrades de registre de format diferents per a diferents versions del Microsoft Word, encara que el tipus MIME sigui el mateix per a totes dues. </message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nom </message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Nom exclusiu per a aquest format (p. ex.  Microsoft Word XP o Microsoft Word 2000)</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El camp de nom és necessari.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipus MIME</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Tipus MIME associat amb aquest format, que no cal que sigui exclusiu. </message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripció</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivell de suport</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Nivell de suport que dóna la vostra institució a aquest format.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconegut</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conegut</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Admès</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Intern</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Els formats marcats com a interns són ocults per a l&apos;usuari i s&apos;utilitzen amb finalitats administratives. </message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensions de fitxer</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions son extensions de fitxer que s&apos;utilitzen per identificar automàticament el format dels fitxers pujats. Podeu introduir diverses extensions per a cada format.</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-    <message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadades</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadades</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadades: &quot;{0}&quot;</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.para1">Aquest és l&apos;esquema de metadades per a &quot;{0}&quot;. Podeu afegir camps de metadades nous o actualitzar els existents a l&apos;esquema. Els camps també es poden seleccionar per suprimir-los o moure&apos;ls a un altre esquema. </message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head2">Camps de metadades d&apos;esquema</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column2">Id. </message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column3">Camp</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota d&apos;àmbit</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.empty">No hi ha cap camp de metadades</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Suprimeix camps</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mou els camps a un altre esquema</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head3">Afegeix nou camp de metadades</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.name">Nom del fitxer</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota d&apos;àmbit</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes addicionals sobre aquest camp de metadades.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Afegeix nou camp de metadades</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head4">Actualitza el camp: {0}</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Actualitza el camp</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nom del camp ja s&apos;utilitza; tots els elements i els qualificadors han de ser exclusius. </message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L&apos;element del camp és necessari.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L&apos;element del camp conté un caràcter erroni. L&apos;element NO pot contenir: punts, guions baixos ni espais.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L&apos;element d&apos;aquest camp és massa llarg; ha de tenir menys de 32 caràcters. </message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El qualificador del cap és massa llarg; ha de tenir menys de 32 caràcters. </message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El qualificador del camp conté un caràcter erroni. El qualificador NO pot contenir: punts, guions baixos ni espais.</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
-    <message key="xmlui.administrative.registries.FormatRegistryMain.title">Registre de formats</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.head">Registre de formats de document</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.para1">Aquesta llista de formats de document ofereix informació sobre formats coneguts i el seu nivell de suport. Amb aquesta eina podeu editar o afegir nous formats de document. Els formats marcats com a &apos;interns&apos; són ocults per a l&apos;usuari i s&apos;utilitzen amb finalitats administratives. </message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Afegeix un format de document nou</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column2">Id. </message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nom </message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipus MIME</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivell de suport</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>intern</i>)</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconegut</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conegut</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Suport</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Suprimeix formats</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registre de metadades</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registre de metadades</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registre de metadades manté una llista de tots els camps de metadades que hi ha disponibles per al dipòsit. Aquests camps es poden dividir entre diversos esquemes.  Amb tot, el DSpace requereix l&apos;esquema qualificat Dublin Core. Podeu ampliar l&apos;esquema Dublin Core amb altres camps o afegir nous esquemes al registre.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column2">Id. </message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espai de nom</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nom </message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Suprimeix l&apos;esquema</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Afegeix un esquema nou</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espai de nom</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L&apos;espai de nom ha de ser una ubicació URI establerta per a l&apos;esquema nou.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Aquest camp és necessari.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nom </message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notació abreujada de l&apos;esquema. S&apos;utilitzarà com a prefix del nom d&apos;un camp (p. ex. dc.element.qualificador).  El nom ha de tenir menys de 32 caràcters i no pot incloure espais, punts ni guions baixos. </message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Aquest camp és necessari i ha de tenir menys de 32 caràcters i no pot contenir espais, punts ni guions baixos. </message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Afegeix un esquema nou</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-    <message key="xmlui.administrative.registries.MoveMetadataField.title">Mou camps</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.trail">Mou camps</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.head1">Mou camps de metadades</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.para1">Seleccioneu l&apos;esquema de destinació al qual voleu moure aquests camps. Si l&apos;esquema de destinació ja té camps amb noms idèntics, aquests camps no es mouran.</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column1">Id. </message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column2">Nom </message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota d&apos;àmbit</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.para2">Mou a l&apos;esquema: </message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mou camps</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Grups dels quals és membre aquesta e-persona:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(a través del grup:  {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">cap</message>
 
 
-       
-       
-       
-    <!-- general authorization keywords -->
-    <message key="xmlui.administrative.authorization.general.authorize_trail">Autorització</message>
-    <message key="xmlui.administrative.authorization.general.policyList_trail">Llista de directives</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-    <message key="xmlui.administrative.authorization.AuthorizationMain.title">Administra les directives d&apos;autorització</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administra les directives d&apos;autorització</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoritzacions d&apos;unitat</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">L&apos;id. indicat no s&apos;ha resolt en cap element</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Cerca un element</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Els elements es poden trobar per nansa o per id. intern</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Cerca</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Eina d&apos;autoritzacions avançades</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Feu clic aquí per anar a l&apos;eina d&apos;administració de directives de comodí d&apos;unitat</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoritzacions de comunitat/col·lecció</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Feu clic en una comunitat o col·lecció per editar-ne les directives.</message>
-       
-       
-       
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edita les directives</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Llista de directives</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Directives de la col•lecció &quot;{0}&quot; ({1},id.: {2})</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Directives de la comunitat &quot;{0}&quot; ({1},id.: {2})</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Feu clic aquí per afegir una directiva nova. </message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Afegeix</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">Id. </message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acció</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grup</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Suprimeix seleccionats</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edita</message>
-       
+	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirma la supressió d'e-persona</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirma la supressió</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirma la supressió</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Se suprimiran les e-persones següents: </message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirma la supressió</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">Id.</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nom </message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Correu electrònic</message>
 
-       
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
-    <message key="xmlui.administrative.authorization.EditItemPolicies.title">Edita les directives de l'element</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.trail">Llista de directives</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Directives de l'element {0} (id.={1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Amb aquest editor podeu visualitzar i modificar les directives d&apos;un element i modificar les directives de components individuals d&apos;un element:  conjunts i fluxos de bits. En breu, un element és un contenidor de conjunts i els conjunts són contenidors de fluxos de bits.  Els contenidors normalment tenen directives d&apos; ADDICIÓ/SUPRESSIÓ/LECTURA/ESCRIPTURA, mentre que els fluxos de bits només tenen directives de LECTURA/ESCRIPTURA. </message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Veureu que hi ha un conjunt i un document addicional per a cada element que conté el text de llicència de l'element.</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Directives d&apos;unitat</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Directives del conjunt {0} ({1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Document {0} ({1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Afegeix una nova directiva d&apos;unitat</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Afegeix una nova directiva de conjunt</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Afegeix una nova directiva de document</message>
-       
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No s&apos;ha trobat cap directiva per a aquest objecte.</message>
-       
-       
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
-    <message key="xmlui.administrative.authorization.EditPolicyForm.title">Edita la directiva</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edita la directiva</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crea una directiva nova per a {0} {1}</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edita la directiva {0} de {1} {2}</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No s&apos;ha seleccionat cap grup</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No s&apos;ha seleccionat cap acció</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">Id. </message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nom </message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accions d&apos;aquest recurs</message>
-       
-    <message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Estableix</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultats de la cerca</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Seleccioneu un grup</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Cerca un grup</message>
-     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Cerca</message>
-     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Seleccioneu l&apos;acció</message>
-   
-       
+	<!-- general items for all of the group classes -->
+	<message key="xmlui.administrative.group.general.group_trail">Gestiona els grups</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Gestiona els grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestió del grup</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accions</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crea un grup nou</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Feu clic aquí per afegir un grup nou.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Explora els grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Feu clic aquí per explorar tots els grups.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Cerqueu grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Els grups se cerquen per coincidències parcials del seu nom</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">Id.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nom </message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membres</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Col·lecció</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Visualitza</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Suprimeix grups</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">La cerca no ha obtingut resultats...</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
+	<message key="xmlui.administrative.group.EditGroupForm.title">Editor de grups</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Edita el grup</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grups: {0} (Id.: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grups: grup nou</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Esborra la cerca</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Membre</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Cicle</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Pendent</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Tingueu en compte que els canvis pendents no es desen fins que feu clic al botó de desar. </message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Afegeix</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Suprimeix</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Aquest grup està associat amb la col·lecció: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">This group is associated with community: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Canvia el nom del grup: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Aquest grup està associat amb una col·lecció concreta i el seu nom no es pot modificar.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Cerca membres per afegir: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">E-persones...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grups...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">La cerca no ha obtingut resultats...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">Id. </message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nom </message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Correu electrònic</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">Id. </message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nom </message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Col·lecció</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">visualitza</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">Id.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nom </message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Correu electrònic</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grup: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Aquest grup no té cap membre.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendent]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Suprimeix membres</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Suprimeix membres</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirma la supressió del grup</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirma la supressió</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirma la supressió</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Se suprimiran els grups següents:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">Id. </message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nom </message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">E-persones</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grups</message>
+
+	<!-- general items for all of the registries classes -->
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Registre de formats</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de metadades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Suprimeix formats de document</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Suprimeix formats de document</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirma la supressió</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Segur que voleu suprimir el format? Tots els fluxos de bits existents amb aquest format es tornaran al format de document desconegut.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">Id. </message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nom </message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Suprimeix camps</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Suprimeix camps</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirma la supressió</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Teniu <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ADVERTIMENT: </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Això ocasionarà un error si hi ha cap element que contingui metadades en aquests camps.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">Id. </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nom </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota d'àmbit</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Suprimeix l'esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Suprimeix l'esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirma la supressió</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Teniu <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ADVERTIMENT: </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Això ocasionarà un error si hi ha cap element que contingui metadades dins de l'esquema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">Id. </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espai de nom</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nom </message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format de document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format de document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nou format de document</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format de document: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Inclogueu metadades descriptives sobre el format de document a sota. Si bé els noms de format han de ser exclusius, els tipus MIME no cal que ho siguin.  Podeu tenir entrades de registre de format diferents per a diferents versions del Microsoft Word, encara que el tipus MIME sigui el mateix per a totes dues. </message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nom </message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Nom exclusiu per a aquest format (p. ex.  Microsoft Word XP o Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El camp de nom és necessari.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Tipus MIME associat amb aquest format, que no cal que sigui exclusiu. </message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripció</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivell de suport</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Nivell de suport que dóna la vostra institució a aquest format.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconegut</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conegut</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Admès</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Intern</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Els formats marcats com a interns són ocults per a l'usuari i s'utilitzen amb finalitats administratives. </message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensions de fitxer</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions son extensions de fitxer que s'utilitzen per identificar automàticament el format dels fitxers pujats. Podeu introduir diverses extensions per a cada format.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadades: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Aquest és l'esquema de metadades per a "{0}". Podeu afegir camps de metadades nous o actualitzar els existents a l'esquema. Els camps també es poden seleccionar per suprimir-los o moure'ls a un altre esquema. </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Camps de metadades d'esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">Id. </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Camp</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota d'àmbit</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">No hi ha cap camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Suprimeix camps</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mou els camps a un altre esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Afegeix nou camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nom del fitxer</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota d'àmbit</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes addicionals sobre aquest camp de metadades.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Afegeix nou camp de metadades</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Actualitza el camp: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Actualitza el camp</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nom del camp ja s'utilitza; tots els elements i els qualificadors han de ser exclusius. </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'element del camp és necessari.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L'element del camp conté un caràcter erroni. L'element NO pot contenir: punts, guions baixos ni espais.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L'element d'aquest camp és massa llarg; ha de tenir menys de 32 caràcters. </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El qualificador del cap és massa llarg; ha de tenir menys de 32 caràcters. </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El qualificador del camp conté un caràcter erroni. El qualificador NO pot contenir: punts, guions baixos ni espais.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registre de formats</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registre de formats de document</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Aquesta llista de formats de document ofereix informació sobre formats coneguts i el seu nivell de suport. Amb aquesta eina podeu editar o afegir nous formats de document. Els formats marcats com a 'interns' són ocults per a l'usuari i s'utilitzen amb finalitats administratives. </message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Afegeix un format de document nou</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">Id. </message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nom </message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipus MIME</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivell de suport</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconegut</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conegut</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Suport</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Suprimeix formats</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registre de metadades</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registre de metadades</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registre de metadades manté una llista de tots els camps de metadades que hi ha disponibles per al dipòsit. Aquests camps es poden dividir entre diversos esquemes.  Amb tot, el DSpace requereix l'esquema qualificat Dublin Core. Podeu ampliar l'esquema Dublin Core amb altres camps o afegir nous esquemes al registre.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">Id. </message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espai de nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nom </message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Suprimeix l'esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Afegeix un esquema nou</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espai de nom</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L'espai de nom ha de ser una ubicació URI establerta per a l'esquema nou.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Aquest camp és necessari.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nom </message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notació abreujada de l'esquema. S'utilitzarà com a prefix del nom d'un camp (p. ex. dc.element.qualificador).  El nom ha de tenir menys de 32 caràcters i no pot incloure espais, punts ni guions baixos. </message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Aquest camp és necessari i ha de tenir menys de 32 caràcters i no pot contenir espais, punts ni guions baixos. </message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Afegeix un esquema nou</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Mou camps</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mou camps</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mou camps de metadades</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Seleccioneu l'esquema de destinació al qual voleu moure aquests camps. Si l'esquema de destinació ja té camps amb noms idèntics, aquests camps no es mouran.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">Id. </message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nom </message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota d'àmbit</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mou a l'esquema: </message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mou camps</message>
+
+
+
+
+	<!-- general authorization keywords -->
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorització</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Llista de directives</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administra les directives d'autorització</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administra les directives d'autorització</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoritzacions d'unitat</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">L'id. indicat no s'ha resolt en cap element</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Cerca un element</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Els elements es poden trobar per nansa o per id. intern</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Cerca</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Eina d'autoritzacions avançades</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Feu clic aquí per anar a l'eina d'administració de directives de comodí d'unitat</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoritzacions de comunitat/col·lecció</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Feu clic en una comunitat o col·lecció per editar-ne les directives.</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edita les directives</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Llista de directives</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Directives de la col•lecció "{0}" ({1},id.: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Directives de la comunitat "{0}" ({1},id.: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Feu clic aquí per afegir una directiva nova. </message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Afegeix</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">Id. </message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acció</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grup</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Suprimeix seleccionats</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edita</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Edita les directives de l'element</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Llista de directives</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Directives de l'element {0} (id.={1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Amb aquest editor podeu visualitzar i modificar les directives d'un element i modificar les directives de components individuals d'un element:  conjunts i fluxos de bits. En breu, un element és un contenidor de conjunts i els conjunts són contenidors de fluxos de bits.  Els contenidors normalment tenen directives d' ADDICIÓ/SUPRESSIÓ/LECTURA/ESCRIPTURA, mentre que els fluxos de bits només tenen directives de LECTURA/ESCRIPTURA. </message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Veureu que hi ha un conjunt i un document addicional per a cada element que conté el text de llicència de l'element.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Directives d'unitat</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Directives del conjunt {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Document {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Afegeix una nova directiva d'unitat</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Afegeix una nova directiva de conjunt</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Afegeix una nova directiva de document</message>
+
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No s'ha trobat cap directiva per a aquest objecte.</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Edita la directiva</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edita la directiva</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crea una directiva nova per a {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edita la directiva {0} de {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No s'ha seleccionat cap grup</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No s'ha seleccionat cap acció</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">Id. </message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nom </message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accions d'aquest recurs</message>
+
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Estableix</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultats de la cerca</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Seleccioneu un grup</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Cerca un grup</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Cerca</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Seleccioneu l'acció</message>
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
     <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor de directives avançades</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autoritzacions avançades</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor de directives avançades</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permet afegir comodins a les directives i esborrar directives per a tipus de contingut de col·leccions específiques). ADVERTIMENT - La supressió de permisos de LECTURA dels elements farà que no es puguin visualitzar!</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Per a tots els grups seleccionats...</message>
-     <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...concedeix la capacitat de realitzar l&apos;acció següent...</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...per als tipus d&apos;objecte següents...</message>
-     <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...a les col·leccions següents.</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grup</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acció</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipus de contingut</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Col·lecció</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Afegeix directives</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Esborra directives</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirma la supressió de directiva</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirma la supressió</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirma la supressió</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Se suprimiran les directives següents: </message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">Id. </message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acció</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grup</message>
-       
-    <!-- general edit item messages -->
-    <message key="xmlui.administrative.item.general.item_trail">Unitats</message>
-    <message key="xmlui.administrative.item.general.option_head">Edita l'element</message>
-    <message key="xmlui.administrative.item.general.option_status">Estat de l'element</message>
-    <message key="xmlui.administrative.item.general.option_bitstreams">Fluxos de bits de l'element</message>
-    <message key="xmlui.administrative.item.general.option_metadata">Metadades de l'element</message>
-    <message key="xmlui.administrative.item.general.option_view">Visualitza l'element</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-    <message key="xmlui.administrative.item.AddBitstreamForm.title">Puja document</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.trail">Puja document</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.head1">Puja un document nou</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Conjunt</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fitxers de contingut (per defecte)</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fitxers de metadades</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Visualitzacions en miniatura</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Llicències</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">Llicències de Creative Commons</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fitxer</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.file_help">Introduïu el nom del fitxer del vostre ordinador corresponent a l'element. Si feu clic a &quot;Explora...&quot;, es mostrarà una finestra nova on podreu localitzar i seleccionar el fitxer de l&apos;ordinador. </message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripció</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple &quot; <i>Article principal</i>&quot; o &quot; <i>Lectures de dades de prova</i>".</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Puja</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Necessiteu el privilegi d&apos;ADDICIÓ i ESCRIPTURA en com a mínim un conjunt por poder pujar documents nous.</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirma la supressió</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirma la supressió</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirma les supressions </message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Segur que voleu suprimir aquests documents:</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nom </message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripció</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-    <message key="xmlui.administrative.item.ConfirmItemForm.title">Confirma</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirma</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifica l'element: {0}</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Segur que voleu suprimir completament aquest element? Precaució: si feu aquesta acció, l'element no es podrà recuperar. </message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Segur que voleu retirar aquest element de l&apos;arxiu?</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Segur que voleu restituir l'element a l&apos;arxiu?</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column1">Camp</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column3">Llengua</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retira</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Restitueix</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor de directives avançades</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autoritzacions avançades</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor de directives avançades</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permet afegir comodins a les directives i esborrar directives per a tipus de contingut de col·leccions específiques). ADVERTIMENT - La supressió de permisos de LECTURA dels elements farà que no es puguin visualitzar!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Per a tots els grups seleccionats...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...concedeix la capacitat de realitzar l'acció següent...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...per als tipus d'objecte següents...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...a les col·leccions següents.</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grup</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acció</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipus de contingut</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Col·lecció</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Afegeix directives</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Esborra directives</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-    <message key="xmlui.administrative.item.EditBitstreamForm.title">Edita el document</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.trail">Edita el document</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.head1">Edita el document</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxer</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Document principal</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">sí</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">no</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripció</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple &quot; <i>Article principal</i>&quot; o &quot; <i>Lectures de dades de prova</i>"."</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccioneu el format del fitxer a la llista de sota, per exemple &quot; <i>Adobe PDF</i>&quot; o &quot;<i>Paraula</i>", <b>OR</b>  si el format no és a la llista, descriviu-lo al quadre de sota. </message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format seleccionat</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format no llistat</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el format no és a la llista de dalt, <strong>seleccioneu &quot;format no llistat&quot; a dalt</strong> i descriviu-lo al camp de sota.</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.user_label">Un altre format</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.user_help">Aplicació que heu utilitzat per crear el fitxer, i el número de versió (per exemple, &quot; <i>ACMESoft SuperApp versió 1.5 </i>").</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Documents de l'element</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Documents de l'element</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Documents</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nom </message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripció</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Visualitza</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Conjunt: {0}</strong></message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (principal) </message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">visualitza</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Puja un document nou</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Suprimeix documents</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Necessiteu el privilegi d&apos;ADDICIÓ i ESCRIPTURA a l'element i els conjunts per poder pujar nous documents.</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Necessiteu el privilegi de SUPRESSIÓ a l'element i els conjunts per poder suprimir documents.</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-    <message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadades de l'element</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadades de l'element</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.head1">Afegeix metadades noves</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nom </message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Llengua</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Afegeix metadades noves</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.para1">TINGUEU EN COMPTE QUE: Aquests canvis no es validen de cap manera. Teniu tota la responsabilitat d&apos;introduir les dades en el format correcte. Si teniu dubtes pel que fa al format, NO hi feu cap canvi. </message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadades</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column1">Suprimeix</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nom </message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column4">Llengua</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
-    <message key="xmlui.administrative.item.EditItemStatusForm.title">Estat de l'element</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.trail">Estat de l'element</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvinguda a la pàgina de gestió de l'element. Des d&apos;aquí podeu retirar, restituir o suprimir l'element.  També podeu actualitzar o afegir metadades / documents nous a les altres pestanyes.</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_id">Id. intern de l'element</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Darrera modificació</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_in">A les col·leccions</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_page">Pàgina de l'element</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Autoritzacions de l'element</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Unitat retirada del dipòsit</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Restitueix l'element al dipòsit</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Esborra l'element completament</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Edita les autoritzacions</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retira...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Restitueix...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Suprimeix per sempre</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.na">n/d</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(només administradors del sistema)</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
-    <message key="xmlui.administrative.item.ViewItem.title">Visualitza l'element</message>
-    <message key="xmlui.administrative.item.ViewItem.trail">Visualitza l'element</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
-    <message key="xmlui.administrative.item.FindItemForm.title">Cerca element</message>
-    <message key="xmlui.administrative.item.FindItemForm.head1">Cerca element</message>
-    <message key="xmlui.administrative.item.FindItemForm.identifier_label">Id. intern/nansa de l'element</message>
-    <message key="xmlui.administrative.item.FindItemForm.identifier_error">No es pot resoldre l&apos;identificador.</message>
-    <message key="xmlui.administrative.item.FindItemForm.find">Cerca</message>
-       
-    <!-- general mapper messages -->
-    <message key="xmlui.administrative.mapper.general.mapper_trail">Assignador d&apos;unitats</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
-    <message key="xmlui.administrative.mapper.MapperMain.title">Assignador d&apos;unitats</message>
-    <message key="xmlui.administrative.mapper.MapperMain.head1">Assignador d&apos;unitats - Assigna elements d&apos;altres col·leccions</message>
-    <message key="xmlui.administrative.mapper.MapperMain.para1">Col·lecció: "<strong>{0}</strong>"</message>
-    <message key="xmlui.administrative.mapper.MapperMain.para2">Aquesta és l&apos;eina d&apos;assignació d&apos;unitats que permet als administradors de col·leccions assignar elements d&apos;altres col·leccions en aquesta col·lecció. Podeu cercar elements d&apos;altres col·leccions i assignar-les, o bé explorar la llista d&apos;unitats assignades actualment. </message>
-    <message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadístiques</message>
-    <message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} de {1}</strong> elements d&apos;aquesta col·lecció estan assignats des d&apos;altres col·leccions</message>
-    <message key="xmlui.administrative.mapper.MapperMain.search_label">Cerca</message>
-    <message key="xmlui.administrative.mapper.MapperMain.submit_search">Cerca elements</message>
-    <message key="xmlui.administrative.mapper.MapperMain.submit_browse">Explora els elements assignats</message>
-    <message key="xmlui.administrative.mapper.MapperMain.no_add">(Requereix el privilegi d&apos;ADDICIÓ a la col·lecció)</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
-    <message key="xmlui.administrative.mapper.SearchItemForm.title">Cerca elements</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.trail">Cerca elements</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.head1">Cerca elements que coincideixin amb: &quot;{0}&quot;</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Assigna els elements seleccionats</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column2">Col·lecció</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column4">Títol</message>
-               
-    <!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-    <message key="xmlui.administrative.mapper.BrowseItemForm.title">Explora els elements assignats</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.trail">Explora els elements assignats</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.head1">Exploració d&apos;unitats assignades</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Anul·la l&apos;assignació dels elements seleccionats</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column2">Col·lecció</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column4">Títol</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Necessiteu el privilegi de SUPRESSIÓ en aquesta col·lecció per poder anul·lar l&apos;assignació d&apos;unitats d&apos;aquesta col·lecció.</message>
-       
-    <!-- General tags for collection management -->
-    <message key="xmlui.administrative.collection.general.collection_trail">Col·leccions</message>  
-    <message key="xmlui.administrative.collection.general.options_metadata">Edita les metadades</message>
-    <message key="xmlui.administrative.collection.general.options_roles">Assigna rols</message>    
-       
-       
-    <!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edita els rols de la col·lecció</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rols</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edita la col·lecció: {0}</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">cap</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crea...</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringeix...</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Els administradors de la col·lecció decideixen qui pot enviar elements a la col·lecció, retirar-ne, editar les metadades de l'element (després que s&apos;enviï) i afegir (assignar) elements existents d&apos;altres col·leccions a aquesta (que està sotmès a l&apos;autorització per a aquella col·lecció). </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les persones responsables d&apos;aquest pas poden acceptar o rebutjar els enviaments que entren. No obstant, no poden editar les metadades de l&apos;enviament. </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les persones responsables d&apos;aquest pas poden editar les metadades dels enviaments que entren i acceptar-los o rebutjar-los. </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Las persones responsables d&apos;aquest pas poden editar les metadades dels enviaments que entren, però no podran rebutjar-los. </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">E-persones i grups que tenen permís per enviar elements nous a aquesta col·lecció.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">E-persones i grups que poden llegir els elements nous enviats a aquesta col·lecció. Els canvis en aquest rol no són retroactius.  Els elements existents del sistema les podran seguir visualitzant les persones que hi tenien accés de lectura en el moment que s&apos;hi varen afegir.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Aquesta col·lecció utilitza paràmetres d&apos;accés per defecte personalitzats. </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">La lectura per defecte dels elements i els documents que entren està establert actualment com a Anònima.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Edita les directives d&apos;autorització directament.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grup associat</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradors</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accepta/rebutja el pas</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accepta/rebutja/edita el pas de metadades</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Edita el pas de metadades</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Qui ho presenta</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accés de lectura per defecte</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(només administradors del sistema)</nobr></message>
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirma la supressió de directiva</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirma la supressió</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirma la supressió</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Se suprimiran les directives següents: </message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">Id. </message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acció</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grup</message>
 
 
-    <!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirma la supressió</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirma</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirma la supressió col·lecció {0}</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Segur que voleu suprimir la col•lecció {0}? Amb això se suprimirà:</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tots els elements i els enviaments incomplets d&apos;aquesta col·lecció que no s&apos;incloguin en altres col·leccions</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contingut d&apos;aquells elements</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Totes les directives d&apos;autorització associades</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirma la supressió de rol</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirma</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirma la supressió del rol {0}</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Segur que voleu suprimir aquest rol? La supressió d&apos;aquest grup atorgarà accés de LECTURA a tots els usuaris en totes els elements que s&apos;enviïn a aquesta col·lecció a partir d&apos;ara. Tingueu en compte que aquest canvi no és retroactiu. Els elements existents al sistema estaran restringides als membres definits pel rol que esteu a punt de suprimir.</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Segur que voleu suprimir aquest rol? Els canvis i les personalitzacions que s&apos;han fet al grup {0} es perdran i s&apos;hauran de tornar a crear. </message>
-       
-    <!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edita les metadades de la col·lecció</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadades</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edita la col·lecció: {0}</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nom </message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descripció breu</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Text introductori (HTML)</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Text de copyright (sense format)</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Notícies (HTML) </message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Llicència</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Provinença</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Puja un logotip nou</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logotip actual</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla d&apos;unitat</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crea...</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edita...</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Suprimeix el logotip</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Suprimeix la col·lecció</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Desa les actualitzacions</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(només administradors del sistema)</nobr></message>
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-    <message key="xmlui.administrative.collection.CreateCollectionForm.title">Crea una col·lecció</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crea una col·lecció</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introdueix metadades per a una nova col•lecció de {0}</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crea</message>
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirma la supressió</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirma</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirma la supressió de la comunitat Confirma la supressió de la comunitat {0}</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Segur que s&apos;ha de suprimir la comunitat {0}? Amb això se suprimirà:</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Totes les col·leccions de la comunitat que no s&apos;incloguin en altres comunitats</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tots els elements i els enviaments incomplets a aquesta comunitat que no s&apos;incloguin en altres comunitats</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contingut d&apos;aquells elements</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Totes les directives d&apos;autorització associades</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edita les metadades de la comunitat</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadades</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edita les metadades de la comunitat {0}</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edita les directives d&apos;autorització</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nom </message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descripció breu</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Text introductori (HTML)</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Text de copyright (sense format)</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Notícies (HTML) </message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Puja un logotip nou</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logotip actual</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Suprimeix el logotip</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Suprimeix la comunitat</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-    <message key="xmlui.administrative.community.CreateCommunityForm.title">Crea una comunitat</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.trail">Crea una comunitat</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introduïu les metadades d&apos;una nova subcomunitat per a {0}</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Edita les metadades d&apos;una nova comunitat de nivell superior</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crea</message>
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
 
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
 
-    <!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-    <message key="xmlui.administrative.ControlPanel.title">Tauler de control</message>
-    <message key="xmlui.administrative.ControlPanel.trail">Tauler de control </message>
-    <message key="xmlui.administrative.ControlPanel.head">Tauler de control</message>
-    <message key="xmlui.administrative.ControlPanel.option_java">Informació Java</message>
-    <message key="xmlui.administrative.ControlPanel.option_dspace">Configuració del DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.option_alerts">Alertes a tot el sistema</message>
-    <message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-    <message key="xmlui.administrative.ControlPanel.minutes">{0} m</message>
-    <message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-    <message key="xmlui.administrative.ControlPanel.java_head">Java i sistema operatiu</message>
-    <message key="xmlui.administrative.ControlPanel.java_version">Versió de Java Runtime Environment</message>
-    <message key="xmlui.administrative.ControlPanel.java_vendor">Proveïdor de Java Runtime Environment</message>
-    <message key="xmlui.administrative.ControlPanel.os_name">Nom del sistema operatiu</message>
-    <message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operatiu</message>
-    <message key="xmlui.administrative.ControlPanel.os_version">Versió del sistema operatiu</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_head">Estadístiques de temps d&apos;execució</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_processors">Processadors disponibles</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_max">Memòria màxima</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_total">Memòria assignada</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_used">Memòria utilitzada</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_free">Memòria lliure</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_head">Configuració del DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_dir">Directori d&apos;instal·lació del DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_url">Adreça URL base del DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom d&apos;hoste del DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_name">Nom del lloc</message>
-    <message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de dades</message>
-    <message key="xmlui.administrative.ControlPanel.db_url">Adreça URL de la base de dades</message>
-    <message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre màxim de connexions de base de dades a la memòria</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxwait">Temps d&apos;espera màxim de la base de dades</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxidle">Màxim de connexions inactives</message>
-    <message key="xmlui.administrative.ControlPanel.mail_server">Servidor de correu SMTP</message>
-    <message key="xmlui.administrative.ControlPanel.mail_from_address">Adreça electrònica d&apos;origen</message>
-    <message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatari dels comentaris</message>
-    <message key="xmlui.administrative.ControlPanel.mail_admin">Adreça electrònica general d&apos;administració del lloc</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_head">Alertes a tot el sistema</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Advertiment per a sistemes amb equilibri de càrrega</strong>: Les alertes a tot el sistema només son eficaces per al node on s&apos;activen. Cal que us assegureu que tots els nodes del conjunt rebin l&apos;ordre d&apos;activació de l&apos;alerta.</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_message_label">Missatge d&apos;alerta</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema s&apos;aturarà per al manteniment periòdic. Deseu el treball i finalitzeu la sessió.</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte enrere</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_none">No hi ha cap temporitzador de compte enrere</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minuts</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minuts</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minuts</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Conserva el temporitzador de compte enrere actual</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestiona la sessió</message>  
-    <message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continua permetent sessions autenticades</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restringeix l&apos;autenticació però manté les sessions actuals</message>        
-    <message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restringeix l&apos;autenticació i finalitza les sessions actuals</message>        
-    <message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Nota:</strong> Els administradors del lloc estan exempts de la gestió de sessions.</message>  
-    <message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activa</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactiva</message>
-    <message key="xmlui.administrative.ControlPanel.activity_head">Activitat actual ({0} pàgines màxim)</message>
-    <message key="xmlui.administrative.ControlPanel.stop_anonymous">Aturar la gravació anònima de l&apos;activitat.</message>
-    <message key="xmlui.administrative.ControlPanel.start_anonymous">Iniciar la gravació anònima de l&apos;activitat.</message>
-    <message key="xmlui.administrative.ControlPanel.stop_bot">Aturar la gravació de l&apos;activitat del robot.</message>
-    <message key="xmlui.administrative.ControlPanel.start_bot">Iniciar la gravació de l&apos;activitat del robot.</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_time">Segell horari</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuari</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adreça IP</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_url">Adreça URL de la pàgina</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Usuari-agent</message>
-    <message key="xmlui.administrative.ControlPanel.activity_anonymous">Anònim {0}</message>    
-    <message key="xmlui.administrative.ControlPanel.activity_none">A banda de la vostra, no hi ha hagut cap altra visualització de pàgina a les darreres {0} pàgines.</message>
-       
-    <message key="xmlui.administrative.ControlPanel.select_panel">Utilitzeu les pestanyes de dalt per seleccionar la informació que voleu visualitzar</message>
-       
-    <!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-    <message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>D&apos;aquí a {0} minuts</strong>: </message>
-       
-    <!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-    <message key="xmlui.administrative.NotAuthorized.title">No autoritzat</message>
-    <message key="xmlui.administrative.NotAuthorized.trail">No autoritzat</message>
-    <message key="xmlui.administrative.NotAuthorized.head">Privilegis insuficients</message>
-    <message key="xmlui.administrative.NotAuthorized.para1a">El vostre compte no té suficients privilegis per realitzar l&apos;acció sol·licitada. Si creieu que és un error o teniu algun dubte sobre els vostres privilegis, poseu-vos en contacte amb els  </message>
-    <message key="xmlui.administrative.NotAuthorized.para1b">administradors del sistema del lloc</message>
-    <message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-    <message key="xmlui.administrative.NotAuthorized.para2">Inicieu la sessió com un altre usuari</message>
-           
-           
-    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- 		dri2xhtml
- 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- 	-->
- 	
- 	<!-- structural.xsl -->  
- 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-                <a href="http://di.tamu.edu" id="ds-logo-link">                            
-                        <span id="ds-footer-logo">&#160;</span>
-                </a>
-                <p>
- Aquest lloc web utilitza Manakin, un nou sistema principal (front end) per al DSpace creat a la Universitat de Texas A&amp;M Biblioteques.  La interfície es pot modificar àmpliament amb aspectes Manakin i temes basats en XSL.  Per obtenir més informació, aneu a  <a href="http://di.tamu.edu">http://di.tamu.edu</a> i  <a href="http://dspace.org">http://dspace.org</a>                            
-                </p>
-    </message>
-    <message key="xmlui.dri2xhtml.structural.contact-link">Contacteu amb nosaltres</message>
-    <message key="xmlui.dri2xhtml.structural.feedback-link">Envia comentaris</message>
-       
-    <message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace/Dipòsit Manakin</message>
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
 
-    <message key="xmlui.dri2xhtml.structural.profile">Perfil: </message>
-    <message key="xmlui.dri2xhtml.structural.logout">Finalitza la sessió</message>
-    <message key="xmlui.dri2xhtml.structural.login">Inicia la sessió</message>
+	<!-- general edit item messages -->
+	<message key="xmlui.administrative.item.general.item_trail">Unitats</message>
+	<message key="xmlui.administrative.item.general.template_head">Edit Template Item for Collection: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Edita l'element</message>
+	<message key="xmlui.administrative.item.general.option_status">Estat de l'element</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Fluxos de bits de l'element</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.general.option_view">Visualitza l'element</message>
+        <message key="xmlui.administrative.item.general.option_curate">Curate</message>
+        <message key="xmlui.administrative.item.general.option_queue">Queue</message>
 
+	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Puja document</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Puja document</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Puja un document nou</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Conjunt</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fitxers de contingut (per defecte)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fitxers de metadades</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Visualitzacions en miniatura</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Llicències</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fitxer</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Introduïu el nom del fitxer del vostre ordinador corresponent a l'element. Si feu clic a "Explora...", es mostrarà una finestra nova on podreu localitzar i seleccionar el fitxer de l'ordinador. </message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripció</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple " <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Puja</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Necessiteu el privilegi d'ADDICIÓ i ESCRIPTURA en com a mínim un conjunt por poder pujar documents nous.</message>
 
-    <message key="xmlui.dri2xhtml.structural.search">Cerca al DSpace</message>
-    <message key="xmlui.dri2xhtml.structural.search-advanced">Cerca avançada</message>
-    <message key="xmlui.dri2xhtml.structural.search-in-community">Aquesta comunitat</message>
-    <message key="xmlui.dri2xhtml.structural.search-in-collection">Aquesta col·lecció</message>
-       
-    <message key="xmlui.dri2xhtml.structural.pagination-previous">Pàgina anterior</message>
-    <message key="xmlui.dri2xhtml.structural.pagination-info">Ara es mostren els elements {0}-{1} de {2}</message>
-    <message key="xmlui.dri2xhtml.structural.pagination-next">Pàgina següent</message>
-       
-    <message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-    <message key="xmlui.dri2xhtml.structural.link_original_license">Llicència original </message>
+	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirma la supressió</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirma la supressió</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirma les supressions </message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Segur que voleu suprimir aquests documents:</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nom </message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripció</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
 
-     <!-- DS-METS-1.0-MODS.xsl -->  <!-- DS-METS-1.0-DIM.xsl -->  <!-- DS-METS-1.0-QDC.xsl -->  <message key="xmlui.dri2xhtml.METS-1.0.no-preview">No hi ha cap visualització prèvia disponible</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-title">Sense títol</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconegut</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
- Aquest objecte del DSpace no compleix el perfil METS 1,0 i, per tant, no es pot representar de manera eficaç. Podeu ometre la plantilla que gestiona el cas general a dri2xhtml per realitzar la funció necessària o crear la vostra pròpia plantilla perquè s&apos;ajusti a qualsevol perfil que utilitzeu.   </message>
-   
-    <message key="xmlui.dri2xhtml.METS-1.0.item-preview">Visualització prèvia</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-title">Títol</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Abstract</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripció</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-subject">Tema</message>
-       
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Fitxers d&apos;aquest element</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxers</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Mida</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Visualitza</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualitza/<wbr/>Obre</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hi ha cap fitxer associat amb aquest element.</message>
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifica l'element: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Segur que voleu suprimir completament aquest element? Precaució: si feu aquesta acció, l'element no es podrà recuperar. </message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Segur que voleu retirar aquest element de l'arxiu?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Segur que voleu restituir l'element a l'arxiu?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Camp</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Llengua</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retira</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Restitueix</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-       
-    <message key="xmlui.dri2xhtml.METS-1.0.license-text">Els fitxers de llicència següents estan associats amb aquest element:</message>
-               
-    <message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">	La summaryView (visualització resumida) d&apos;una col·lecció actualment no s&apos;utilitza o implementa.  Això es pot resoldre ometent la plantilla dri2xhtml amb el nom collectionSummaryView.  </message>
-    <message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">	La summaryView d&apos;una comunitat actualment no s&apos;utilitza o implementa.  Això es pot resoldre ometent la plantilla dri2xhtml&apos;s amb el nom communitySummaryView.  </message>
-    <message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logotip de la col·lecció</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logotip de la comunitat</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">No hi ha cap logotip</message>          
-    <message key="xmlui.dri2xhtml.METS-1.0.news">Notícies</message>    
-    <message key="xmlui.dri2xhtml.METS-1.0.copyright">Copyright i llicència</message>                      
-               
-    <!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
-                DS-METS-1.0-QDC.xsl 
-    -->
-    <message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable"> El Qualified Dublin Core (QDC) no és aplicable a les comunitats i col·leccions del DSpace en aquest moment.  Si utilitzeu el QDC, heu d&apos;utilitzar el pas del QDC per a elements del DSpace i DIM o MODS per al processament de comunitats i col·leccions.   </message>
-    <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elements de Dublin Core</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Condicions de Dublin Core</message>
-       
-       
-    <!-- Special pioneer model related text, wherever it might end up -->
-    <message key="xmlui.dri2xhtml.pioneer.preview">Visualització prèvia</message>
-    <message key="xmlui.dri2xhtml.pioneer.date">Data</message>
-    <message key="xmlui.dri2xhtml.pioneer.title">Títol</message>
-    <message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
-       
-    <!-- tag used to handle the empty textarea tag added 09/28/2006 -->
-    <message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Move item: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Collection</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Select the collection you wish to move this item to.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Select a collection...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Move</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Inherit policies</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Inherit the default policies of the destination collection</message>
 
-    <!--###### File Format MIME Type Mappings ######-->
+	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Edita el document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Edita el document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Edita el document</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxer</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Document principal</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">sí</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">no</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripció</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Opcionalment, podeu incloure-hi una descripció breu del fitxer, per exemple " <i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccioneu el format del fitxer a la llista de sota, per exemple " <i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format seleccionat</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format no llistat</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el format no és a la llista de dalt, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Un altre format</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Aplicació que heu utilitzat per crear el fitxer, i el número de versió (per exemple, " <i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
 
-    <!-- Application-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.application/marc">Registre MARC</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Desconegut</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Documents de l'element</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Documents de l'element</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Documents</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nom </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripció</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Visualitza</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (principal) </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">visualitza</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Puja un document nou</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Suprimeix documents</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Necessiteu el privilegi d'ADDICIÓ i ESCRIPTURA a l'element i els conjunts per poder pujar nous documents.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Necessiteu el privilegi de SUPRESSIÓ a l'element i els conjunts per poder suprimir documents.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
 
-    <!-- Audio-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.audio/basic">Àudio bàsic</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadades de l'element</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Afegeix metadades noves</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nom </message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Llengua</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Afegeix metadades noves</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">TINGUEU EN COMPTE QUE: Aquests canvis no es validen de cap manera. Teniu tota la responsabilitat d'introduir les dades en el format correcte. Si teniu dubtes pel que fa al format, NO hi feu cap canvi. </message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadades</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Suprimeix</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nom </message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Llengua</message>
 
-    <!-- Image-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.image/gif">Imatge GIF</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/jp2">Imatge JPEG 2000</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/jpeg">Imatge JPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/png">Imatge PNG</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/tiff">Imatge TIFF</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Imatge BMP</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
-
-    <!-- Text-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.text/css">Arxiu CSS</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/csv">Arxiu CSV</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/plain">Arxiu de text</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/richtext">Arxiu RTF</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
- 
-    <!-- Video-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.video/avi">AVI</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Estat de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estat de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvinguda a la pàgina de gestió de l'element. Des d'aquí podeu retirar, restituir o suprimir l'element.  També podeu actualitzar o afegir metadades / documents nous a les altres pestanyes.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">Id. intern de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Darrera modificació</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">A les col·leccions</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Pàgina de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Autoritzacions de l'element</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Unitat retirada del dipòsit</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Restitueix l'element al dipòsit</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Move item to another collection</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Esborra l'element completament</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Edita les autoritzacions</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retira...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Restitueix...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Move...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Suprimeix per sempre</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/d</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(només administradors del sistema)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(collection administrators only)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(you are not allowed to perform this action)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
 
 
 
+	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
+	<message key="xmlui.administrative.item.ViewItem.title">Visualitza l'element</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Visualitza l'element</message>
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Task</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message>
+	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
+	<message key="xmlui.administrative.item.FindItemForm.title">Cerca element</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Cerca element</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Id. intern/nansa de l'element</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">No es pot resoldre l'identificador.</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Cerca</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Matèria</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Tipus de contingut</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Data d'edició</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Data d'edició</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">changes</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">No changes were detected</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">New item</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Upload successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Upload failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unknown metadata element in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Number of changes exceeds maximum allowed. Limit changes or alter bulkedit.gui-item-limit in dspace.cfg</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Upload CSV</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Successfully processed</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Changes applied to item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Added: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Removed: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Added to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Removed from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Mapped to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Unmapped from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Add: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Remove: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Add to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Remove from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Map to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Un-map from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Changes pending for item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Apply changes</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Pending changes are listed below for review</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
+
+	<!-- general mapper messages -->
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Assignador d'unitats</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
+	<message key="xmlui.administrative.mapper.MapperMain.title">Assignador d'unitats</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Assignador d'unitats - Assigna elements d'altres col·leccions</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Col·lecció: "<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Aquesta és l'eina d'assignació d'unitats que permet als administradors de col·leccions assignar elements d'altres col·leccions en aquesta col·lecció. Podeu cercar elements d'altres col·leccions i assignar-les, o bé explorar la llista d'unitats assignades actualment. </message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadístiques</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Cerca</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Explora els elements assignats</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Requereix el privilegi d'ADDICIÓ a la col·lecció)</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Cerca elements</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Cerca elements que coincideixin amb: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Assigna els elements seleccionats</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Col·lecció</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Títol</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Explora els elements assignats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Explora els elements assignats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Exploració d'unitats assignades</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Anul·la l'assignació dels elements seleccionats</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Col·lecció</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Títol</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Necessiteu el privilegi de SUPRESSIÓ en aquesta col·lecció per poder anul·lar l'assignació d'unitats d'aquesta col·lecció.</message>
+
+	<!-- General tags for collection management -->
+	<message key="xmlui.administrative.collection.general.collection_trail">Col·leccions</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Edita les metadades</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Assigna rols</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edita els rols de la col·lecció</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rols</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edita la col·lecció: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">cap</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crea...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringeix...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Els administradors de la col·lecció decideixen qui pot enviar elements a la col·lecció, retirar-ne, editar les metadades de l'element (després que s'enviï) i afegir (assignar) elements existents d'altres col·leccions a aquesta (que està sotmès a l'autorització per a aquella col·lecció). </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les persones responsables d'aquest pas poden acceptar o rebutjar els enviaments que entren. No obstant, no poden editar les metadades de l'enviament. </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les persones responsables d'aquest pas poden editar les metadades dels enviaments que entren i acceptar-los o rebutjar-los. </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Las persones responsables d'aquest pas poden editar les metadades dels enviaments que entren, però no podran rebutjar-los. </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">E-persones i grups que tenen permís per enviar elements nous a aquesta col·lecció.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">E-persones i grups que poden llegir els elements nous enviats a aquesta col·lecció. Els canvis en aquest rol no són retroactius.  Els elements existents del sistema les podran seguir visualitzant les persones que hi tenien accés de lectura en el moment que s'hi varen afegir.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Aquesta col·lecció utilitza paràmetres d'accés per defecte personalitzats. </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">La lectura per defecte dels elements i els documents que entren està establert actualment com a Anònima.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Edita les directives d'autorització directament.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grup associat</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradors</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Workflow steps</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Accepta/rebutja el pas</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Accepta/rebutja/edita el pas de metadades</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Edita el pas de metadades</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Qui ho presenta</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accés de lectura per defecte</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curate Collection: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curate Collection</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Task</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirma la supressió</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirma</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirma la supressió col·lecció {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Segur que voleu suprimir la col•lecció {0}? Amb això se suprimirà:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tots els elements i els enviaments incomplets d'aquesta col·lecció que no s'incloguin en altres col·leccions</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contingut d'aquells elements</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Totes les directives d'autorització associades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirma la supressió de rol</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirma</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirma la supressió del rol {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Segur que voleu suprimir aquest rol? La supressió d'aquest grup atorgarà accés de LECTURA a tots els usuaris en totes els elements que s'enviïn a aquesta col·lecció a partir d'ara. Tingueu en compte que aquest canvi no és retroactiu. Els elements existents al sistema estaran restringides als membres definits pel rol que esteu a punt de suprimir.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Segur que voleu suprimir aquest rol? Els canvis i les personalitzacions que s'han fet al grup {0} es perdran i s'hauran de tornar a crear. </message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edita les metadades de la col·lecció</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadades</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edita la col·lecció: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nom </message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descripció breu</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Text introductori (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Text de copyright (sense format)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Notícies (HTML) </message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Llicència</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Provinença</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Puja un logotip nou</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logotip actual</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla d'unitat</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crea...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edita...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Suprimeix el logotip</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Suprimeix la col·lecció</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Desa les actualitzacions</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crea una col·lecció</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crea una col·lecció</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introdueix metadades per a una nova col•lecció de {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crea</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Collection Harvesting Settings</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Content Source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Content source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">This is a standard DSpace collection</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">This collection harvests its content from an external source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Save</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Harvesting Options</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadata Format</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">The url of the target repository's OAI provider service</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">The persistent identifier used by the OAI provider to designate the target collection</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Test Settings</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadata format</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Last Harvest Result</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">This collection has not yet been harvested.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Current harvest status</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Collection ready for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Collection is currently being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Collection is in queue for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Unexpected error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (full replication).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Change Settings</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Import Now</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Reset and Reimport Collection</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Harvest Scheduler Controls</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Actions</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Start Harvester</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Reset Harvest Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Resume</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pause</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Collections set up for harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Active harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Queued harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Internal errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Generator Settings</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE source</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Settings</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Communities</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Edit Metadata</message>
+	<message key="xmlui.administrative.community.general.options_roles">Assign Roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.community.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Edit Community Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edit Community: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">none</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Create...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections.  In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">This community uses custom default access settings. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Default read for incoming items and bitstreams is currently set to Anonymous.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Edit authorization policies directly.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Associated group</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administrators</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curate Community: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curate Community</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Task</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirma la supressió</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirma</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirma la supressió de la comunitat Confirma la supressió de la comunitat {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Segur que s'ha de suprimir la comunitat {0}? Amb això se suprimirà:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Totes les col·leccions de la comunitat que no s'incloguin en altres comunitats</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tots els elements i els enviaments incomplets a aquesta comunitat que no s'incloguin en altres comunitats</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contingut d'aquells elements</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Totes les directives d'autorització associades</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirm role deletion</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirm</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirm deletion for role {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Are you sure you want to delete this role? All changes and customizations made to the {0} group will be lost and would have to be created anew.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edita les metadades de la comunitat</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadades</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edita les metadades de la comunitat {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edita les directives d'autorització</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nom </message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descripció breu</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Text introductori (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Text de copyright (sense format)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Notícies (HTML) </message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Puja un logotip nou</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logotip actual</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Suprimeix el logotip</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Suprimeix la comunitat</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Crea una comunitat</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crea una comunitat</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introduïu les metadades d'una nova subcomunitat per a {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Edita les metadades d'una nova comunitat de nivell superior</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crea</message>
 
 
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Enviaments recents</message>
+	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
+	<message key="xmlui.administrative.ControlPanel.title">Tauler de control</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Tauler de control </message>
+	<message key="xmlui.administrative.ControlPanel.head">Tauler de control</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Informació Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Configuració del DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertes a tot el sistema</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} m</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java i sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Versió de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Proveïdor de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nom del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Versió del sistema operatiu</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Estadístiques de temps d'execució</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Processadors disponibles</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Memòria màxima</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Memòria assignada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Memòria utilitzada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Memòria lliure</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Configuració del DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Directori d'instal·lació del DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">Adreça URL base del DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom d'hoste del DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Nom del lloc</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de dades</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">Adreça URL de la base de dades</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre màxim de connexions de base de dades a la memòria</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Temps d'espera màxim de la base de dades</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Màxim de connexions inactives</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Servidor de correu SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Adreça electrònica d'origen</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatari dels comentaris</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Adreça electrònica general d'administració del lloc</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertes a tot el sistema</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Missatge d'alerta</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema s'aturarà per al manteniment periòdic. Deseu el treball i finalitzeu la sessió.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte enrere</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">No hi ha cap temporitzador de compte enrere</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minuts</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Conserva el temporitzador de compte enrere actual</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestiona la sessió</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continua permetent sessions autenticades</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restringeix l'autenticació però manté les sessions actuals</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restringeix l'autenticació i finalitza les sessions actuals</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activa</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactiva</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Activitat actual ({0} pàgines màxim)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">Aturar la gravació anònima de l'activitat.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">Iniciar la gravació anònima de l'activitat.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">Aturar la gravació de l'activitat del robot.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">Iniciar la gravació de l'activitat del robot.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Segell horari</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuari</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adreça IP</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">Adreça URL de la pàgina</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Usuari-agent</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anònim {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">A banda de la vostra, no hi ha hagut cap altra visualització de pàgina a les darreres {0} pàgines.</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Mostra'n més</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Enviaments recents</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Enviaments recents</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Enviaments recents</message>
+	<message key="xmlui.administrative.ControlPanel.select_panel">Utilitzeu les pestanyes de dalt per seleccionar la informació que voleu visualitzar</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Tipus</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Editor</message>
+	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Parent</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Agrupa els resultats per</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Cap</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publicació</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Comunitat</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Col·lecció</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Sèrie</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Exploració per: Autor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Exploració per: Títol</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Exploració per: Matèria</message>
+	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
+	<message key="xmlui.administrative.NotAuthorized.title">No autoritzat</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">No autoritzat</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Privilegis insuficients</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">El vostre compte no té suficients privilegis per realitzar l'acció sol·licitada. Si creieu que és un error o teniu algun dubte sobre els vostres privilegis, poseu-vos en contacte amb els  </message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">administradors del sistema del lloc</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Inicieu la sessió com un altre usuari</message>
         
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Exploració per: Resum</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Exploració per: Sèrie</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Exploració per: Patrocinador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Exploració per: Identificador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Exploració per: Llengua (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Exploració per: Paraula clau</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Exploració per: Nom científic</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Exploració per: Col·laborador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Exploració per: Autor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Exploració per: Matèria</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Exploració per: Descripció</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Exploració per: Relació</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Exploració per: Tipus Mime</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Exploració per: Un altre col·laborador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Exploració per: Assessor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Exploració per: Departament</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Exploració per: Data d'edició</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Títol</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Matèria</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Data d'edició</message>
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Ara es mostren els elements {0}-{1}</message>
+                     Statistics Aspect
 
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Filtre per: Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Filtre per: Matèria</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Matèria</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Matèria</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Data d'edició</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Comença per</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">O introduïu-ne les primeres lletres:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Opcions d'ordenació:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Rellevància</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Títol desc.</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Data d'edició desc.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Títol asc.</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Data d'edició asc.</message>
-
-	 <message key="xmlui.Discovery.AbstractSearch.rpp">Resultats per pàgina:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Afegeix filtre</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Aplica</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Suprimeix</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Filtres nous:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Filtres actuals:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Afegeix filtres</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">No s'han trobat valors per al filtre</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Filtra</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... Mostra'n més</message>
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Statistics</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">Total Visits</message>
+    <message key="xmlui.statistics.visits.month">Total Visits Per Month</message>
+    <message key="xmlui.statistics.visits.views">Views</message>
+    <message key="xmlui.statistics.visits.countries">Top country views</message>
+    <message key="xmlui.statistics.visits.cities">Top cities views</message>
+    <message key="xmlui.statistics.visits.bitstreams">File Visits</message>
+    <message key="xmlui.statistics.Navigation.title">Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">Statistics</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
 
 
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Cerca</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Cerca</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Filtres</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Utilitzeu els filtres per refinar els resultats de la cerca.</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
 
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">Conté</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">És igual a</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">No conté</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">No és igual a</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">No ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Elements relacionats</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Mostrant elements relacionats per títol, autor i matèria.</message>
 
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Mostrant {0} d'un total de {1} resultats per la comunitat: {2}. <span class="searchTime">({3} segons)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_collection">Mostrant {0} d'un total de {1} resultats per la col·lecció: {2}. <span class="searchTime">({3} segons)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Mostrant {0} d'un total de {1} resultats. <span class="searchTime">({2} segons)</span></message>
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
 
-    <message key="xmlui.Discovery.AbstractSearch.head2">Comunitats o col·leccions que coincideixen amb la consulta</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Elements que coincideixen amb la consulta</message>
 
-    <message key="xmlui.Discovery.SimpleSearch.did_you_mean">Volíeu dir: </message>
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                  dri2xhtml
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+	<!-- structural.xsl -->
+	<message key="xmlui.dri2xhtml.structural.footer-promotional">
+                <a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
+		</a>
+		<p>
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
+		</p>
+	</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Contacteu amb nosaltres</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Envia comentaris</message>
+
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace/Dipòsit Manakin</message>
+
+	<message key="xmlui.dri2xhtml.structural.profile">Perfil: </message>
+	<message key="xmlui.dri2xhtml.structural.logout">Finalitza la sessió</message>
+	<message key="xmlui.dri2xhtml.structural.login">Inicia la sessió</message>
+
+	<message key="xmlui.dri2xhtml.structural.search">Cerca al DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Cerca avançada</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Aquesta comunitat</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">Aquesta col·lecció</message>
+
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Pàgina anterior</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Ara es mostren els elements {0}-{1} de {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Pàgina següent</message>
+
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Llicència original </message>
+
+
+	<!-- DS-METS-1.0-MODS.xsl -->
+	<!-- DS-METS-1.0-DIM.xsl -->
+	<!-- DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">No hi ha cap visualització prèvia disponible</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sense títol</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconegut</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
+ Aquest objecte del DSpace no compleix el perfil METS 1,0 i, per tant, no es pot representar de manera eficaç. Podeu ometre la plantilla que gestiona el cas general a dri2xhtml per realitzar la funció necessària o crear la vostra pròpia plantilla perquè s'ajusti a qualsevol perfil que utilitzeu.   </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Visualització prèvia</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Títol</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Abstract</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripció</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Tema</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Fitxers d'aquest element</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxers</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Mida</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Visualitza</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualitza/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hi ha cap fitxer associat amb aquest element.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Els fitxers de llicència següents estan associats amb aquest element:</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">	La summaryView (visualització resumida) d'una col·lecció actualment no s'utilitza o implementa.  Això es pot resoldre ometent la plantilla dri2xhtml amb el nom collectionSummaryView.  </message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">	La summaryView d'una comunitat actualment no s'utilitza o implementa.  Això es pot resoldre ometent la plantilla dri2xhtml's amb el nom communitySummaryView.  </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logotip de la col·lecció</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logotip de la comunitat</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">No hi ha cap logotip</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Notícies</message>
+
+	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
+		DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable"> El Qualified Dublin Core (QDC) no és aplicable a les comunitats i col·leccions del DSpace en aquest moment.  Si utilitzeu el QDC, heu d'utilitzar el pas del QDC per a elements del DSpace i DIM o MODS per al processament de comunitats i col·leccions.   </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elements de Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Condicions de Dublin Core</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
+	<!-- Special pioneer model related text, wherever it might end up -->
+	<message key="xmlui.dri2xhtml.pioneer.preview">Visualització prèvia</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Títol</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
+
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+
+  <!--###### File Format MIME Type Mappings ######-->
+
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">Registre MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Desconegut</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Àudio bàsic</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV</message>
+
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">Imatge GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">Imatge JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">Imatge JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">Imatge PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">Imatge TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Imatge BMP</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">Arxiu CSS</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">Arxiu CSV</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Arxiu de text</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">Arxiu RTF</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime</message>
+
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Confidence was never recorded for this value</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">No reasonable confidence value was returned from the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">The authority recommends this submission be rejected</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">The authority encountered an internal failure</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">There are no matching answers in the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">There are multiple matching authority values of equal validity</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">Value is singular and valid but has not been seen and accepted by a human so it is still uncertain</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">This authority value has been confirmed as accurate by an interactive user</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Unlock the authority key value for manual editing, or toggle it locked again</message>
+
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">DSpace Value Lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Accept</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Add</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancel</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">See More Results</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Results @1@ to @2@ of @3@ for "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
+
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up Publisher</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non-authority value: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in "Last, First" format</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Last name, e.g. "Smith"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">First name(s) e.g. "Fred"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Name Authority author lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Local value "@1@" (not in Naming Authority)</message>
+
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
 
 
     <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadades</message>
@@ -1887,11 +2473,11 @@
     <message key="xmlui.mirage2.page-structure.toggleNavigation">Activa/desactiva la navegació</message>
 
     <message key="xmlui.mirage2.page-structure.heroUnit.title">Quant al repositori</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
 
     <message key="xmlui.mirage2.navigation.rss.feed">Canals de difusió</message>
 
     <message key="xmlui.mirage2.choice-authority-control.loading">Carregant...</message>
 
     <message key="xmlui.mirage2.item-list.thumbnail">Miniatura</message>
-	 
 </catalogue>

--- a/src/main/webapp/i18n/messages_ca_ES.xml
+++ b/src/main/webapp/i18n/messages_ca_ES.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ca-ES">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_cs.xml
+++ b/src/main/webapp/i18n/messages_cs.xml
@@ -1,32 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?> 
-<!--
-    translation: Ivan Masár, 2008-2014.
-    review: Dana Kovářová, 2008-2012.
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
-    Version: $Revision$
-    Date: $Date$
--->
-<catalogue xml:lang="cs" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
+
 		There are a few exceptions to this naming format,
-		1) Some general keys are in the xmlui.general namespace 
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">Domovská stránka DSpace</message>
 	<message key="xmlui.general.search">Hledat</message>
@@ -39,60 +25,60 @@
 	<message key="xmlui.general.delete">Smazat</message>
 	<message key="xmlui.general.next">Další</message>
 	<message key="xmlui.general.untitled">Nepojmenovaný</message>
-	<message key="xmlui.general.perform">Vykonat</message>
-	<message key="xmlui.general.queue">Fronta</message>
-	
+        <message key="xmlui.general.perform">Vykonat</message>
+        <message key="xmlui.general.queue">Fronta</message>
+
         <!-- Keys which are used by exception2dri.xsl on error pages -->
         <message key="xmlui.error.contact_msg">Pokud chcete nahlásit tuto chybu, prosím kontaktujte správce. Pokud je to možné, uveďte prosím podrobnosti o tom, co jste dělali v době, kdy k této chybě došlo.</message>
         <message key="xmlui.error.contact">Kontaktovat správce</message>
         <message key="xmlui.error.show_stack">Zobrazit podrobnosti této chyby</message>
 
-	<!-- 
-		Page not found keys 
-		
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">Stránka nenalezena</message>
 	<message key="xmlui.PageNotFound.head">Stránka nenalezena</message>
 	<message key="xmlui.PageNotFound.para1">Stránka, kterou jste požadovali, nebyla nalezena.</message>
-	
-	
-	<!--
-		The "utils" non-aspect
-	-->
-	<message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Pouze správci stránek se mohou přihlásit pod identitou jiného uživatele.</message>
-	<message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Pouze přihlášení uživatelé, kteří jsou správci, se mohou přihlásit pod identitou jiného uživatele.</message>
-	<message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Není možné se přihlásit pod identitou jiného správce.</message>
 
 
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Pouze správci stránek se mohou přihlásit pod identitou jiného uživatele.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Pouze přihlášení uživatelé, kteří jsou správci, se mohou přihlásit pod identitou jiného uživatele.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Není možné se přihlásit pod identitou jiného správce.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">Digitální repozitář DSpace přijímá, ukládá, indexuje, uchovává a šíří digitální vědeckovýzkumné dokumenty.</message>
-	<message key="xmlui.feed.header">Kanály RSS</message>
+    <message key="xmlui.feed.header">Kanály RSS</message>
 	<message key="xmlui.feed.logo_title">Obrázek kanálu</message>
 	<message key="xmlui.feed.untitled">Nepojmenovaný</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">Oznámení</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Výsledky hledání komunity: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Výsledky hledání kolekce: {0}</message>
@@ -131,7 +117,7 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identifikátor (jakýkoliv)</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Kód jazyka</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Klíčové slovo</message>
-   
+
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Přispěvatel</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Tvůrce</message>
@@ -146,17 +132,17 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">A</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">NEBO</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NE</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Nebo zadejte několik prvních písmen:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Prohlížet záznamy, které začínají těmito písmeny</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Přejít na záznam v rejstříku:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Zvolte měsíc)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Zvolte rok)</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Přejít na záznam v rejstříku:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Zvolte měsíc)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Zvolte rok)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Nebo napište rok:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Prohlížet záznamy z daného roku.</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Tento dotaz nevrátil žádné výsledky.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Tento dotaz nevrátil žádné výsledky.</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Seřadit dle:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Řazení:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Výsledky:</message><!-- /Page -->
@@ -179,17 +165,17 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Prohlížení {0} dle předmětu {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Prohlížení {0} dle předmětu</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Prohlížení {0} dle názvu {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Prohlížení {0} dle názvu</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Procházení {0} dle data publikování {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Procházení dle data publikování</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Procházení {0} dle data zaslání {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Procházení {0} dle data zaslání</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
 	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Stažené záznamy dle názvu</message>
 	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Stažené záznamy dle názvu</message>
@@ -210,7 +196,6 @@
 	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Soukromé záznamy dle data zaslání</message>
 	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Soukromé záznamy dle data zaslání</message>
 
-
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Rozsah vyhledávání</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Vše v DSpace</message>
@@ -221,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datumy</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Rozšířené hledání</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Poslední příspěvky</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Seznam komunit</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Seznam komunit</message>
@@ -240,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Podkomunita v komunitě</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Kolekce v této komunitě</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Poslední příspěvky</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Kontaktujte nás</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Kontaktujte nás</message>
@@ -250,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Online formulář</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Vyjádření názoru</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Vyjádření názoru</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Vyjádření názoru</message>
@@ -260,21 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Na tuto adresu budou zaslány odpovědi na vaše komentáře.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Komentáře</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Vyjádření názoru</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Vyjádření názoru</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Vyjádření názoru</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Vyjádření názoru odesláno</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Vaše poznámky byly přijaty.</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Zobrazit záznam</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Tento záznam se objevuje v následujících kolekcích</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Zobrazit minimální záznam</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Zobrazit celý záznam</message>
-	
-	<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Tento záznam byl vyřazen a není nadále dostupný.</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Tento záznam byl vyřazen a není nadále dostupný.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Procházet</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Vše v DSpace</message>
@@ -286,14 +271,14 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Dle data zaslání</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Tato kolekce</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Tato komunita</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Hledat</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Hledat</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Hledat</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Rozsah vyhledávání</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Plnotextové hledání</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Toto je zdroj s omezeným přístupem</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Omezený přístup</message>
@@ -303,25 +288,25 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Toto je záznam s omezeným přístupem</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Toto je bitový tok s omezeným přístupem</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Nemáte potřebné přístupové oprávnění ke zdroji s omezeným přístupem.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Nemáte potřebná přístupová oprávnění ke komunitě <b>{0}</b> s omezeným přístupem.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Nemáte potřebná přístupová oprávnění ke kolekci <b>{0}</b> s omezeným přístupem.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Nemáte potřebná přístupová oprávnění k záznamu <b>{0}</b> s omezeným přístupem.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Nemáte potřebná přístupová oprávnění k bitovému toku <b>{0}</b> s omezeným přístupem.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Nemáte potřebná přístupová oprávnění ke komunitě <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Nemáte potřebná přístupová oprávnění ke kolekci <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Nemáte potřebná přístupová oprávnění k záznamu <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Nemáte potřebná přístupová oprávnění k bitovému toku <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">kolekce</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">komunita</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">bitový tok</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">záznam</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">zdroj</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">neznámý</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Pokračujte na přihlašovací obrazovku.</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Pokračujte na přihlašovací obrazovku.</message>
+
         <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Tento záznam byl vyřazen</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Vybraný záznam byl vyřazen a není nadále dostupný.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Vybraný záznam je záznam s omezeným přístupem a pro jeho zobrazení musíte mít potřebná oprávnění. Prosím, pro zobrazení tohoto záznamu se přihlaste.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Váš účet nemá potřebná oprávnění pro zobrazení ttohoto záznamu. Jestli máte jakékoliv nejasnosti, obraťte se na správce systému.</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Vybraný záznam byl vyřazen a není nadále dostupný.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Vybraný záznam je záznam s omezeným přístupem a pro jeho zobrazení musíte mít potřebná oprávnění. Prosím, pro zobrazení tohoto záznamu se přihlaste.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Váš účet nemá potřebná oprávnění pro zobrazení ttohoto záznamu. Jestli máte jakékoliv nejasnosti, obraťte se na správce systému.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Toto je záznam s omezeným přístupem</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Toto je záznam s omezeným přístupem</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Záznam, ke kterému se pokoušíte přistupovat, je záznam s omezeným přístupem a jeho zobrazení vyžaduje oprávnění. Prosím, přihlaste se pro získání přístupu k záznamu.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">měsíční sestavy</message>
@@ -331,9 +316,9 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Nyní nejsou pro tuto službu dostupné žádné sestavy. Prosím, vraťte se později.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-	<message key="xmlui.BitstreamReader.auth_header">Toto je soubor s omezeným přístupem</message>	
+	<message key="xmlui.BitstreamReader.auth_header">Toto je soubor s omezeným přístupem</message>
 	<message key="xmlui.BitstreamReader.auth_message">Soubor, ke kterému se pokoušíte přistupovat, je soubor s omezeným přístupem a jeho zobrazení vyžaduje oprávnění. Prosím, přihlaste se pro získání přístupu k souboru.</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Toto je exportní archiv s omezeným přístupem</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Exportní archiv, ke kterému se pokoušíte přistupovat, je zdroj s omezeným přístupem a jeho zobrazení vyžaduje oprávnění. Prosím, přihlaste se pro získání přístupu k exportnímu archivu.</message>
@@ -346,7 +331,7 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Vyžádání kopie dokumentu</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Uživatelé tohoto systému se mohou přihlásit pro zobrazení tohoto dokumentu.</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Přihlásit se</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Pro vyžádání kopie dokumentu od odpovědné osoby vyplňte následující informace.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Pro vyžádání kopie dokumentu od odpovědné osoby vyplňte následující informace.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Vaše emailová adresa</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Tato emailová adresa se použije pro zaslání dokumentu</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Adresu je nutné vyplnit</message>
@@ -371,7 +356,6 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Žádost o kopii dokumentu</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">POKUD JSTE AUTOREM (NEBO JEDNÍM Z AUTORŮ) DOKUMENTU „{0}“, odpovězte na tento požadavek uživatele pomocí tlačítek.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Tento repozitář nabídne vhodnou modelovou odpověď, kterou můžete upravit.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Poslat kopii</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Počáteční odpověď žadateli</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Požádat autora o povolení</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Poslat kopii</message>
@@ -414,7 +398,7 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Váš požadavek na změnu oprávnění byl odeslán</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Váš požadavek byl odeslán správci</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Děkujeme</message>
-	
+
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
     <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Žádost o kopii dokumentu</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Žádost o kopii dokumentu</message>
@@ -444,28 +428,28 @@
     <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Vaše odpověď byla odeslána.</message>
 
 
-
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Registrace nového uživatele</message>
 	<message key="xmlui.EPerson.trail_forgot_password">Zapomenuté heslo</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Registrace není dostupná</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Registrace není dostupná</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Nastavení systému DSpace vám nedovoluje registraci v tomto kontextu. S jakýmikoliv dotazy a komentáři kontaktujte prosím <a href="../contact">správce lokality</a>.</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">Nastavení systému DSpace vám nedovoluje registraci v tomto kontextu. S jakýmikoliv dotazy a komentáři kontaktujte prosím <a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Aktualizovat profil</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">Vytvořit profil</message>
@@ -476,7 +460,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">Jméno</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Příjmení</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">Kontaktní telefon</message>
-	<message key="xmlui.EPerson.EditProfile.Language">Jazyk</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Jazyk</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Odběry</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Můžete se přihlásit k odběru denních oznámení o nových záznamech v kolekcích prostřednictvím e-mailu. Tímto způsobem můžete sledovat libovolný počet kolekcí podle vašeho přání. Jinou alternativou k denním oznámením emailem je použití kanálů RSS, které jsou dostupné pro každou kolekci.</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Odběry emailem</message>
@@ -493,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">Jste členem těchto skupin oprávnění:</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Identifikace</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">Bezpečnost</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Ověření emailu</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Vytvořit profil</message>
@@ -506,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Heslo vygenerováno</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Heslo vygenerováno</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Vaše heslo bylo vygenerováno.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Neplatný token</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Neplatný token</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Neplatný token</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">URL, které jste poskytli, je neplatné. Váš emailový klient mohl rozdělit URL na několik řádků následovně:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">Pokud se tak stalo, měli byste zkopírovat celé URL do adresního řádku vašeho prohlížeče místo kliknutí na něj. Adresní řádek by měl pak obsahovat něco jako:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">Můj účet</message>
 	<message key="xmlui.EPerson.Navigation.profile">Profil</message>
@@ -533,7 +517,7 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">Zaregistrovat nového uživatele</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">Zaregistrujte si účet, abyste se mohli přihlásit k odběru aktualizací kolekcí a zasílat nové záznamy do DSpace.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Zaregistrujte se kliknutím zde.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Přihlášení</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Přihlášení</message>
@@ -542,7 +526,7 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Zadané uživatelské jméno nebo heslo, které jste zadali, nebylo správné.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Heslo</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Přihlášení</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Vyberte si způsob přihlášení</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">Vyberte si přihlašovací jméno</message>
@@ -558,26 +542,26 @@
 	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Nebylo možné ověřit, protože byly přijaty neplatné argumenty.</message>
 	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Uživatel s uvedenými přihlašovacími údaji nebyl nalezen.</message>
 	<message key="xmlui.EPerson.FailedAuthentication.title">Autentifikace se nezdařila</message>
-	<message key="xmlui.EPerson.FailedAuthentication.trail">Nezdařená autentifikace</message>
-	<message key="xmlui.EPerson.FailedAuthentication.h1">Autentifikace se nezdařila</message>
-	
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Nezdařená autentifikace</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Autentifikace se nezdařila</message>
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">Metoda autentifikace nebyla nalezena</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">Nebyla nalezena žádná metoda autentifikace. Prosím kontaktujte správce lokality.</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">Přihlášení prostřednictvím Shibboleth se nezdařilo</message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">Autentifikace Shibboleth není momentálně dostupná. Prosím kontaktujte správce lokality.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">Profil aktualizován</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">Aktualizovat profil</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">Profil aktualizován</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">Informace ve vašem profilu byly aktualizovány.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">Registrace dokončena</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">Registrace dokončena</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">Nyní jste registrováni jako uživatelé systému DSpace. Můžete se přihlásit k odběru kolekcí a příjmu e-mailových zpráv o nových záznamech.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">Vygenerovat heslo</message>
 	<message key="xmlui.EPerson.ResetPassword.head">Vygenerovat heslo</message>
@@ -588,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">Vygenerovat heslo</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Vyberte si heslo dlouhé alespoň 6 znaků</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Pro potvrzení zopakujte vaše heslo</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">Zapomenuté heslo</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">Zapomenuté heslo</message>
@@ -597,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Zadejte stejnou emailovou adresu, kterou jste použili při registraci.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">E-mailová adresa nenalezena.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Odeslat informace</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Registrace nového uživatele</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">Email je již v systému registrován</message>
@@ -610,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">Tato adresa bude ověřena a použita jako vaše přihlašovací jméno.</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Nepodařilo se zaslat email na tuto adresu.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">Zaregistrovat se</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">Registrační e-mail zaslán</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">Registrační e-mail zaslán</message>
@@ -622,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -638,7 +622,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">Přejít na domovskou stránku MyDSpace</message>
 	<message key="xmlui.Submission.general.submission.title">Zaslání záznamu</message>
 	<message key="xmlui.Submission.general.submission.trail">Zaslání záznamu</message>
-	<message key="xmlui.Submission.general.submission.head">Zaslání záznamu</message>	
+	<message key="xmlui.Submission.general.submission.head">Zaslání záznamu</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Předchozí</message>
 	<message key="xmlui.Submission.general.submission.save">Uložit a ukončit</message>
 	<message key="xmlui.Submission.general.submission.next">Další &gt;</message>
@@ -650,19 +634,19 @@
 	<message key="xmlui.Submission.general.showsimple">Zobrazit minimální záznam</message>
 	<message key="xmlui.Submission.general.default.title">Příspěvek</message>
 	<message key="xmlui.Submission.general.default.trail">Příspěvek</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Zaslat do této kolekce nový záznam</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Příspěvky</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Příspěvky a workflow</message>
 	<message key="xmlui.Submission.Submissions.trail">Příspěvky</message>
 	<message key="xmlui.Submission.Submissions.head">Příspěvky a úlohy workflow</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Nepojmenovaný</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">email:</message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Úlohy workflow</message>
@@ -711,27 +695,26 @@
 	<message key="xmlui.Submission.Submissions.status_6">Příspěvek se edituje</message>
 	<message key="xmlui.Submission.Submissions.status_7">Příspěvek archivován</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Neznámý stav</message>
-	<!-- Same transformer, completed submissions section -->
-	<message key="xmlui.Submission.Submissions.completed.head">Archivované příspěvky</message>
-	<message key="xmlui.Submission.Submissions.completed.info">Toto jsou vaše příspěvky, které byly zpracované a přijaté do DSpace.</message>
-	<message key="xmlui.Submission.Submissions.completed.column1">Datum přijetí</message>
-	<message key="xmlui.Submission.Submissions.completed.column2">Název</message>
-	<message key="xmlui.Submission.Submissions.completed.column3">Kolekce</message>
-	<message key="xmlui.Submission.Submissions.completed.limit">Výše jsme uvedli pouze 50 z vašich archivovaných příspěvků.</message>
-	<message key="xmlui.Submission.Submissions.completed.displayall">Zobrazit všechny mé archivované příspěvky</message>
-
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archivované příspěvky</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Toto jsou vaše příspěvky, které byly zpracované a přijaté do DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Datum přijetí</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Název</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Kolekce</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Výše jsme uvedli pouze 50 z vašich archivovaných příspěvků.</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Zobrazit všechny mé archivované příspěvky</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Odpovědi na počáteční otázky</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Popsat</message>
-        <message key="xmlui.Submission.submit.progressbar.access">Přístup</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Nahrát</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Přístup</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Nahrát</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Kontrola</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
 	<message key="xmlui.Submission.submit.progressbar.CClicense">Licence CC</message>
-	<message key="xmlui.Submission.submit.progressbar.license">Licence</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Licence</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Dokončeno</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Pokračovat</message>
 
@@ -748,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Uložit pro pozdější dokončení</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Odstranit záznam</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Odpovědi na počáteční otázky</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Důležitá poznámka:</message>
@@ -757,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Více názvů</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Záznam má více než jeden název, <i>např. přeložený název</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Záznam má více než jeden název, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Je-li zaškrtávací pole nahoře označeno, následující názvy budou ze záznamu odstraněny:</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Zveřejněno</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Dokument byl již dříve publikován</message>
@@ -765,78 +748,76 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Dátum publikování</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Citace zdrojového dokumentu</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Nakladatel</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">Popište záznam</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Chyba: neznámý typ pole</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Toto pole je povinné</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Příjmení, <i>např. Erben</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Křestní jméno (jména), <i>např. Karel Jaromír</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Příjmení, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Křestní jméno (jména), <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Rok</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Měsíc</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Den</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">Jméno řady</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Č. zprávy nebo dokumentu</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Předmětové kategorie</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Předmětové kategorie</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtrovat předměty</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtrovat</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Prosím, čekejte na načítání řízeného slovníku.</message>
-        <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Vyskytl se problém s načtením řízeného slovníku. Zkuste to, prosím, znovu později.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Předmětové kategorie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Předmětové kategorie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtrovat předměty</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtrovat</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Prosím, čekejte na načítání řízeného slovníku.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Vyskytl se problém s načtením řízeného slovníku. Zkuste to, prosím, znovu později.</message>
 
 
-        <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
-        <message key="xmlui.Submission.submit.AccessStep.head">Nastavení přístupu</message>
-        <message key="xmlui.Submission.submit.AccessStep.access_settings">Viditelný skupině vybraných uživatelů (pro skupinu Anonymní není nutno nic vybírat)</message>
-        <message key="xmlui.Submission.submit.AccessStep.open_access">Záznam bude viditelný po jeho přijetí do archivu</message>
-        <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo na přístup do určeného data</message>
-        <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Viditelný/embargo</message>
-        <message key="xmlui.Submission.submit.AccessStep.name">Název</message>
-        <message key="xmlui.Submission.submit.AccessStep.name_help">Krátký, popisní název politiky (do 30 znaků). Může se zobrazit koncovému uživateli. Např. „Pouze pro změstnance“. Nepovinný, ale doporučuje se vyplnit.</message>
-        <message key="xmlui.Submission.submit.AccessStep.description">Popis</message>
-        <message key="xmlui.Submission.submit.AccessStep.reason">Důvod</message>
-        <message key="xmlui.Submission.submit.AccessStep.reason_help">Důvod embarga. Typicky pouze pro interní využití. Nepovinný.</message>
-        <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Potvrďte politiku a přidejte další</message>
-        <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Skupiny</message>
-        <message key="xmlui.Submission.submit.AccessStep.error_format_date">Chyba formátu datumu</message>
-        <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Když je zvoleno embargo, vyžaduje se datum</message>
-        <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Identická politika pro tuto skupinu a tuto operaci již existuje.</message>
-        <message key="xmlui.Submission.submit.AccessStep.table_policies">Seznam politik</message>
-        <message key="xmlui.Submission.submit.AccessStep.policies_help">Politiky uvedené v této sekci mají pripritu před jakýmikoliv výchozími politikami kolekcí, do kterých přidáváte záznam. Pokud si přejete nastavit embargo, ale cílová kolekce umožňuje přístup pro libovolného uživatele, musíte nastavit politiku, která povoluje přístup pro skupinu Anonymous pouze od určitého data dále.</message>
-        <message key="xmlui.Submission.submit.AccessStep.no_policies">Pro tento záznam nebyli nastaveny žádné skupinové politiky.</message>
-        <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
-        <message key="xmlui.Submission.submit.AccessStep.private_settings">Soukromý záznam</message>
-        <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Pokud je volba vybrána, záznam se nebude prohledávat</message>
-        <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Soukromý</message>
-        <message key="xmlui.Submission.submit.AccessStep.column0">Název</message>
-        <message key="xmlui.Submission.submit.AccessStep.column1">Operace</message>
-        <message key="xmlui.Submission.submit.AccessStep.column2">Skupina</message>
-        <message key="xmlui.Submission.submit.AccessStep.column3">Datum začátku</message>
-        <message key="xmlui.Submission.submit.AccessStep.column4">Datum konce</message>
-        <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Upravit</message>
-        <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Odstranit</message>
-        <message key="xmlui.administrative.authorization.AccessStep.label_date_help">První den, od kterého je povolen přístup. Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
-        <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Název: {0}; operace: {1}, skupina: {2}, platí od: {3}, platí do: {4}</message>
-        <message key="xmlui.Submission.submit.AccessStep.review_public_item">Záznam bude možné vyhledat</message>
-        <message key="xmlui.Submission.submit.AccessStep.review_private_item">Záznam nebude možné vyhledat</message>
-
-
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Nastavení přístupu</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Viditelný skupině vybraných uživatelů (pro skupinu Anonymní není nutno nic vybírat)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Záznam bude viditelný po jeho přijetí do archivu</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo na přístup do určeného data</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Viditelný/embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Název</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">Krátký, popisní název politiky (do 30 znaků). Může se zobrazit koncovému uživateli. Např. „Pouze pro změstnance“. Nepovinný, ale doporučuje se vyplnit.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Popis</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Důvod</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">Důvod embarga. Typicky pouze pro interní využití. Nepovinný.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Potvrďte politiku a přidejte další</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Skupiny</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Chyba formátu datumu</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Když je zvoleno embargo, vyžaduje se datum</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Identická politika pro tuto skupinu a tuto operaci již existuje.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Seznam politik</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Politiky uvedené v této sekci mají pripritu před jakýmikoliv výchozími politikami kolekcí, do kterých přidáváte záznam. Pokud si přejete nastavit embargo, ale cílová kolekce umožňuje přístup pro libovolného uživatele, musíte nastavit politiku, která povoluje přístup pro skupinu Anonymous pouze od určitého data dále.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">Pro tento záznam nebyli nastaveny žádné skupinové politiky.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Soukromý záznam</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Pokud je volba vybrána, záznam se nebude prohledávat</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Soukromý</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Název</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Operace</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Skupina</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Datum začátku</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">Datum konce</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Upravit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Odstranit</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">První den, od kterého je povolen přístup. Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Název: {0}; operace: {1}, skupina: {2}, platí od: {3}, platí do: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">Záznam bude možné vyhledat</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">Záznam nebude možné vyhledat</message>
 
 
 
-        <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
-        <message key="xmlui.Submission.submit.EditPolicyStep.head">Upravit politiku</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Upravit politiku</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Nahrat soubory</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Soubor</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Prosím, zadejte plnou cestu k souboru na vašem počítači, která odpovídá vašemu záznamu. Po kliknutí na „Procházet...“ se zobrazí nové okno, které vám umožní vybrat soubor z vašeho počítače.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Záznam musí obsahovat alespoň jeden soubor.</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">Vyskytl se problém při nahrávání vašeho souboru. Buď nebyl správně zadán název souboru nebo nastal problém v síti, který znemožnil korektní uložení vašeho souboru. Další přičinou může být pokus o nahrání souboru ve formátu, který je jen pro interní použití. Prosím, zkuste to znovu.</message>
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Soubor nebyl nahraný, protože to vypadá, že obsahuje virus.</message>
-	<message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Vyskytli se technické potíže při pokusu o kontrolu virů. Prosím, kontaktujte správce systému.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Popis souboru</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Hlavní článek</i>“ nebo „<i>Experimentální hodnoty dat</i>“.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Vyskytli se technické potíže při pokusu o kontrolu virů. Prosím, kontaktujte správce systému.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Popis souboru</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Nahrát soubor a přidat další</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Nahrané soubory</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Primární</message>
@@ -857,51 +838,51 @@
 
 
 
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Nahrané soubory</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Soubor</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Prosím, zadejte plnou cestu k souboru na vašem počítači odpovídajícímu vašemu záznamu. Pokud kliknete na „Procházet...“, nové okno vám umožní vybrat soubor z vašeho počítače.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Záznam musí obsahovat alespoň jeden soubor.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Vyskytl se problém s nahráváním vašeho souboru. Buď jste zadali nesprávný název souboru nebo nastal problém se sítí, který způsobil, že se k nám soubor nedostal, nebo jste se pokusili nahrát formát souboru určený pouze pro vnitřní použití.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Soubor nebyl nahrán, protože pravděpodobně obsahuje virus. Prosím, kontaktujte správce systému.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Vyskytl se technický problém během pokusu o kontrolu přítomnosti virů v souboru. Prosím, kontaktujte správce systému.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Popis souboru</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Nepovinně můžete poskytnout stručný popis souboru, např. „<i>Hlavní článek</i>“ nebo „<i>Data měření experimentu</i>“.</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Nahrát soubor a přidat další</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Nahraných souborů</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primární</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Soubor</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Velikost</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Popis</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formát</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Neznámý</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">neznámý formát</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Podporovaný)</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Známý)</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Nepodporovaný)</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Upravit</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Kontrolní součet souboru:</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Odstranit vybrané soubory</message>
-        <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Politiky</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Nahrané soubory</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Soubor</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Prosím, zadejte plnou cestu k souboru na vašem počítači odpovídajícímu vašemu záznamu. Pokud kliknete na „Procházet...“, nové okno vám umožní vybrat soubor z vašeho počítače.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Záznam musí obsahovat alespoň jeden soubor.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Vyskytl se problém s nahráváním vašeho souboru. Buď jste zadali nesprávný název souboru nebo nastal problém se sítí, který způsobil, že se k nám soubor nedostal, nebo jste se pokusili nahrát formát souboru určený pouze pro vnitřní použití.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Soubor nebyl nahrán, protože pravděpodobně obsahuje virus. Prosím, kontaktujte správce systému.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Vyskytl se technický problém během pokusu o kontrolu přítomnosti virů v souboru. Prosím, kontaktujte správce systému.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Popis souboru</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Nepovinně můžete poskytnout stručný popis souboru, např. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Nahrát soubor a přidat další</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Nahraných souborů</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primární</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Soubor</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Velikost</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Popis</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formát</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Neznámý</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">neznámý formát</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Podporovaný)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Známý)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Nepodporovaný)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Upravit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Kontrolní součet souboru:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Odstranit vybrané soubory</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Politiky</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Editovat soubor</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Soubor</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Popis souboru</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Můžete dodat stručný popis obsahu tohoto souboru. Například „<i>Hlavní článek</i>“ nebo „<i>Experimentální hodnoty dat</i>“.</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Z níže uvedeného seznamu vyberte formát souboru, například „<i>Adobe PDF</i>“ nebo „<i>Microsoft Word</i>“. <strong>Není-li formát v seznamu</strong>, a popište ho v textovém poli pod seznamem.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Můžete dodat stručný popis obsahu tohoto souboru. Například „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Z níže uvedeného seznamu vyberte formát souboru, například „<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Zjištený formát</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Vybraný formát</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formát není v seznamu</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Není-li formát ve výše uvedeném seznamu, <strong>vyberte „Formát není v seznamu“ výše</strong> a popište formát souboru ve spodním poli.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Není-li formát ve výše uvedeném seznamu, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Jiný formát</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Název aplikace, kterou jste použili k vytvoření souboru, a číslo verze (např. „<i>ACMESoft SuperApp verze 1.5</i>“).</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Název aplikace, kterou jste použili k vytvoření souboru, a číslo verze (např. „<i>ACMESoft SuperApp version 1.5</i>").</message>
 
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Upravit přístup k bitovému toku</message>
 
-        <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
-        <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Upravit přístup k bitovému toku</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Zkontrolovat záznam</message>
@@ -918,21 +899,21 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">neznámý</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">známý</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">podporovaný</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Vyskytla se chyba ... {0}</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Licencujte své dílo</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">Jestli si přejete, můžete ke svému dílu připojit licenci <a href="http://creativecommons.org/">Creative Commons</a>. <strong>Licence Creative Commons definují, jak mohou ostatní lidé nakládat s vaším dílem.</strong></message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Pokračovat na výběr licence na webu Creative Commons</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Typ licence</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Vyberte nebo změňte svou licenci ...</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Bez licence Creative Commons</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Pro uložení změn musíte kliknout na tlačítko Další.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Vyskytla se chyba ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Licencujte své dílo</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Jestli si přejete, můžete ke svému dílu připojit licenci <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Pokračovat na výběr licence na webu Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Typ licence</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Vyberte nebo změňte svou licenci ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Bez licence Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Pro uložení změn musíte kliknout na tlačítko Další.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Distribuční licence</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Ještě poslední krok:</strong> Aby mohl DSpace kopírovat, překládat a šířit váš příspěvek celosvětově, musíte souhlasit s následujícími podmínkami.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Udělte standardní distribuční licenci vybráním „Uděluji licenci“ a potom klikněte na „Dokončit příspěvek“.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Pokud máte dotazy týkající se této licence, prosím kontaktujte správce systému.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Distribuční licence</message>
@@ -942,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">Příspěvek odstraněn</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">Vkládání vašeho záznamu bylo zrušeno a nedokončený záznam byl odstraněn ze systému.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Přejít na stránku Příspěvky</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Přejít na stránku Příspěvky</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Vložení příspěvku dokončeno</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">Váš příspěvek nyní projde schvalovacím procesem kolekce, do které jste přispěli. Jakmile bude váš záznam přidán do repozitáře DSpace, obdržíte oznámení e-mailem. Také v případě, že váš záznam nebude přidán do repozitáře, budete informováni e-mailem. Na stránce vašich příspěvků si můžete ověřit, v jaké fázi schvalování se váš záznam nachází.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Přejít na stránku Příspěvky</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Zaslat další záznam</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Vložení příspěvku dokončeno</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Váš příspěvek nyní projde schvalovacím procesem kolekce, do které jste přispěli. Jakmile bude váš záznam přidán do repozitáře DSpace, obdržíte oznámení e-mailem. Také v případě, že váš záznam nebude přidán do repozitáře, budete informováni e-mailem. Na stránce vašich příspěvků si můžete ověřit, v jaké fázi schvalování se váš záznam nachází.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Přejít na stránku Příspěvky</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Zaslat další záznam</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Operace, které můžete na této úloze vykonat:</message>
@@ -960,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Schválit záznam</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Pokud jste již záznam editovali, použijte tuto volbu pro zapsání záznamu do archivu.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Uložit do archivu</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Jestli jste zkontrolovali záznam a je <strong>ne</strong>vhodný na vložení do kolekce, vyberte „Zamítnout“. Do následující zprávy pak vyplňte proč je záznam nevhodný a zda by měl odesílatel něco změnit a záznam znovu odeslat.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Jestli jste zkontrolovali záznam a je <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Zamítnout záznam</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Vyberte tuto volbu pro změnu metadat záznamu.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editovat metadata</message>
@@ -973,22 +954,22 @@
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Pole důvod je povinné</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Zamítnout záznam</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Úloha byla úspěšně dokončena.</message>
-	<message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Úloha nečekaně skončila nebo selhala. Pro další informace prosím kontaktujte vašeho správce systému nebo zkontrolujte protokol systému.</message>
-	<message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Úloha byla úspěšně zařazena do fronty.</message>
-	<message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Úlohu nebylo možné zařadit do fronty. Pro další informace prosím kontaktujte vašeho správce systému nebo zkontrolujte protokol systému.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Uživatel byl úspěšně přidán.</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Úloha byla úspěšně dokončena.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Úloha nečekaně skončila nebo selhala. Pro další informace prosím kontaktujte vašeho správce systému nebo zkontrolujte protokol systému.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Úloha byla úspěšně zařazena do fronty.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Úlohu nebylo možné zařadit do fronty. Pro další informace prosím kontaktujte vašeho správce systému nebo zkontrolujte protokol systému.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Uživatel byl úspěšně přidán.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Uživatel byl úspěšně editován.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Uživateli byla zaslána emailová zpráva obsahující token, který může využít na výběr nového hesla.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Uživatel byl úspěšně smazán.</message>
@@ -1015,10 +996,10 @@
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Vybrané bitové toky byly smazány.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">Záznam byl úspěšně namapován.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Záznam byl úspěšně odmapován.</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Spravovat e-osoby</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Kontext</message>
@@ -1030,10 +1011,10 @@
 	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Vytvořit podkomunitu</message>
 	<message key="xmlui.administrative.Navigation.context_create_community">Vytvořit komunitu</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">Exportovat záznam</message>
-	<message key="xmlui.administrative.Navigation.context_export_collection">Exportovat kolekci</message>
-	<message key="xmlui.administrative.Navigation.context_export_community">Exportovat komunitu</message>
-	<message key="xmlui.administrative.Navigation.context_export_metadata">Exportovat metadata</message>
-	
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exportovat kolekci</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exportovat komunitu</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Exportovat metadata</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Správa</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">Řízení přístupu</message>
@@ -1047,16 +1028,16 @@
 	<message key="xmlui.administrative.Navigation.administrative_items">Záznamy</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Vyřazené záznamy</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Soukromé záznamy</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Ovládací panel</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Ovládací panel</message>
     <message key="xmlui.administrative.Navigation.statistics">Statistiky</message>
     <message key="xmlui.administrative.Navigation.administrative_batch_import">Dávkový import (ZIP)</message>
-	<message key="xmlui.administrative.Navigation.administrative_import_metadata">Importovat metadata</message>
-	<message key="xmlui.administrative.Navigation.administrative_curation">Úlohy správy</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importovat metadata</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Úlohy správy</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Moje exporty</message>
-	
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Exportovat archiv</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">Poskytnuté ID záznamu je neplatné.</message>
@@ -1069,7 +1050,7 @@
 	<message key="xmlui.administrative.ItemExport.collection.success">Kolekce byla úspěšně exportována. Měli byste obdržet e-mail, jakmile bude archiv připraven ke stažení. Můžete také použít odkaz „Moje exporty“ k zobrazení seznamu archivů, které jsou pro vás dostupné.</message>
 	<message key="xmlui.administrative.ItemExport.community.success">Komunita byla úspěšně exportována. Měli byste obdržet e-mail, jakmile bude archiv připraven ke stažení. Můžete také použít odkaz „Moje exporty“ k zobrazení seznamu archivů, které jsou pro vás dostupné.</message>
 	<message key="xmlui.administrative.ItemExport.available.head">Exportní archivy dostupné ke stažení:</message>
-	
+
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
@@ -1090,8 +1071,8 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Smazat e-osobu</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Hledání nepřineslo žádné výsledky...</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Přidat e-osobu</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Přidat e-osobu</message>
@@ -1105,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Požadovat certifikát</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Může se přihlásit</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Vytvořit e-osobu</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editovat e-osobu</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editovat e-osobu</message>
@@ -1122,19 +1103,19 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Můžete trvale ostranit tuto e-osobu ze systému nebo jí vygenerovat nové heslo. Po vygenerování hesla se uživateli odešle e-mail obsahující speciální odkaz, kde si může své heslo změnit.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Smazat e-osobu</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Přihlásit se jako e-osoba</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Tuto e-osobu nelze vymazat z důvodu následujících omezení:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">a</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">e-osoba zaslala jeden nebo více záznamů</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">e-osoba má aktivní proces zasílání příspěvku</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">e-osoba má proces zaslání příspěvku, který čeká na její reakci</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">e-osoba má v systému neidentifikované omezení</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Skupiny, v nichž je tato e-osoba členem:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(prostřednictvím skupiny: {0})</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">žádná</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Potvrdit smazání e-osoby</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Potvrdit smazání</message>
@@ -1203,12 +1184,12 @@
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Jméno</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">skupina: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">skupina: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Tato skupina nemá žádné členy.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[čeká]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Odstranit členy</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Odstranit členy</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Potvrďte smazání skupiny</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Potvrdit smazání</message>
@@ -1218,11 +1199,11 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Jméno</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">E-osoby</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Skupiny</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Registr formátů bitových toků</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registr metadat</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registr metadat</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Smazat formát bitového toku</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Smazat formáty bitového toku</message>
@@ -1236,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Smazat pole</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Smazat pole</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Potvrdit smazání</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Jste si <b>definitivně</b> jistý, že chcete smazat tato pole? Pokud existují záznamy obsahující metadata pro tato pole, pole nebude možné smazat. Musíte se ujistit, že žádné záznamy nepoužívají tato pole.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Jste si <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">UPOZORNĚNÍ:</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">To bude mít za následek chybu, pokud existují záznamy obsahující metadata v těchto polích.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1247,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Smazat schéma</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Smazat schéma</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Potvrdit smazání</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Jste si <b>definitivně</b> jistý, že chcete smazat toto schéma? Pokud existují záznamy obsahující metadata pro pole obsažené v tomto schématu, schéma nebude možné smazat. Musíte se ujistit, že žádné záznamy nepoužívají metadata z tohoto schématu.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Jste si <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">UPOZORNĚNÍ:</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">To bude mít za následek chybu v případě, že existují záznamy s vyplněnou hodnotou v rámci tohoto schématu.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1314,7 +1295,7 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Jméno</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Typ MIME</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Úroveň podpory</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>Interní</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Neznámý</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Známý</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Podpora</message>
@@ -1349,13 +1330,13 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Přesunout do schématu:</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Přesunout pole</message>
 
-	
-	
-	
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorizace</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Seznam politik</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Správa autorizačních politik</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Správa autorizačních politik</message>
@@ -1368,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Nástroj na správu politik zástupných znaků</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Oprávnění komunity/kolekce</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Vyberte komunitu nebo kolekci k editaci jejích politik.</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Editovat politiku</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Seznam politik</message>
@@ -1379,16 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Kliknutím zde přidáte novou politiku.</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Přidat</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-        <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Název</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Název</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Operace</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Skupina</message>
-        <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Datum začátku</message>
-        <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Datum konce</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Datum začátku</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Datum konce</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Smazat vybrané</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editovat</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editovat politiky záznamu</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Seznam politik</message>
@@ -1401,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Přidat novou politiku záznamu</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Přidat novú politiku svazku</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Přidat novou politiku bitového toku</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Pro tento objekt nebyly nalezeny žádné politiky.</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editovat politiku</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editovat politiku</message>
@@ -1416,49 +1397,49 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Jméno</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Operace pro tento zdroj</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Nastavit</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">aktuální</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Výsledky hledání</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Vybrat skupinu</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Hledat skupinu</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Hledat</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Vybrat operaci</message>
-    
-        <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Název</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Popis</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Datum začátku</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Datum konce</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Neplatné datum</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Identická politika pro tuto skupinu a tuto operaci již existuje.</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Datum začátku je vyšší než datum konce</message>
-        <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Hledat</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Vybrat operaci</message>
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Název</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Popis</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Datum začátku</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Datum konce</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Neplatné datum</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Identická politika pro tuto skupinu a tuto operaci již existuje.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Datum začátku je vyšší než datum konce</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Pokročilý správce politik</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Pokročilé autorizace</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Pokročilý správce politik</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Dovoluje použití zástupných znaků a vyčištění politik pro typy obsahu v rámci konkrétních kolekcí. UPOZORNĚNÍ - odstranění práva čtení (READ) ze záznamu ho učiní nezobrazitelným!</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Pro všechny vybrané skupiny...</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...udělit schopnost vykonat následující operaci...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...udělit schopnost vykonat následující operaci...</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...pro všechny následující typy objektů...</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...v následujících kolekcích.</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...v následujících kolekcích.</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Skupina</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Operace</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Typ obsahu</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Kolekce</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Přidat politiky</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Vyčistit politiky</message>
-        <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Akceptovaný formát: yyyy, yyyy-mm, yyyy-mm-dd</message>
 
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Název</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Popis</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Datum začátku</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Datum konce</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Neplatné datum</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Datum začátku je vyšší než datum konce</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Vyberte alespoň jednu skupinu</message>
-        <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Vyberte alespoň jednu kolekci</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Název</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Popis</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Datum začátku</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Datum konce</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Neplatné datum</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Datum začátku je vyšší než datum konce</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Vyberte alespoň jednu skupinu</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Vyberte alespoň jednu kolekci</message>
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Potvrdit smazání politiky</message>
@@ -1512,9 +1493,9 @@
 	<message key="xmlui.administrative.item.general.option_bitstreams">Bitové toky záznamu</message>
 	<message key="xmlui.administrative.item.general.option_metadata">Metadata záznamu</message>
 	<message key="xmlui.administrative.item.general.option_view">Zobrazit záznam</message>
-	<message key="xmlui.administrative.item.general.option_curate">Spravovat</message>
-	<message key="xmlui.administrative.item.general.option_queue">Fronta</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">Spravovat</message>
+        <message key="xmlui.administrative.item.general.option_queue">Fronta</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">Nahrát bitový tok</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Nahrát bitový tok</message>
@@ -1528,10 +1509,10 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Soubor</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Prosím, zadejte název souboru na vašem počítači, který odpovídá vašemu záznamu. Po kliknutí na „Procházet...“ se zobrazí nové okno, které vám umožní vybrat soubor z vašeho počítače.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Popis</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Hlavní článek</i>“ nebo „<i>Experimentální hodnoty dat</i>“.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Nahrát</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Potřebujete oprávnění ADD a WRITE alespoň na jednom svazku, abyste mohli nahrávat nové bitové toky.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Potvrdit smazání</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Potvrďte odstranění</message>
@@ -1540,7 +1521,7 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Jméno</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Popis</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formát</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Potvrzení</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Potvrzení</message>
@@ -1553,10 +1534,10 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Jazyk</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Vyřadit</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Znovu zařadit</message>
-        <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Označit jako soukromý</message>
-        <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Označit jako veřejný</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Označit jako soukromý</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Označit jako veřejný</message>
 
-	<!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
 	<message key="xmlui.administrative.item.MoveItemForm.title">Přesunout</message>
 	<message key="xmlui.administrative.item.MoveItemForm.trail">Přesunout</message>
 	<message key="xmlui.administrative.item.MoveItemForm.head1">Přesunout záznam: {0}</message>
@@ -1564,8 +1545,8 @@
 	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Vyberte kolekci, do které chcete přesunout tento záznam.</message>
 	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Vyberte kolekci...</message>
 	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Přesunout</message>
-	<message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Zdědit politiky</message>
-	<message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Zdědit výchozí politiky cílové kolekce</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Zdědit politiky</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Zdědit výchozí politiky cílové kolekce</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">Editovat bitový tok</message>
@@ -1576,17 +1557,16 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">ano</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">ne</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Popis</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Hlavní článek</i>“ nebo „<i>Experimentální hodnoty dat</i>“.</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Ze seznamu níže vyberte formát souboru, například „<i>Adobe PDF</i>“ nebo „<i>Microsoft Word</i>“, <b>NEBO</b> pokud se formát souboru nenachází v seznamu, popište ho prosím do pole níže.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Můžete poskytnout stručný popis souboru, např. „<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Ze seznamu níže vyberte formát souboru, například „<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Vybraný formát</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formát není v seznamu</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Není-li formát uveden na seznamu výše, <strong>vyberte „Formát není v seznamu“ výše</strong> popište ho v poli níže.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Není-li formát uveden na seznamu výše, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Jiný formát</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Aplikace, kterou jste použili na vytvoření souboru a číslo verze (např. „<i>ACMESoft SuperApp verze 1.5</i>“).</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.name_label">Název souboru</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.name_help">Změna názvu soubory tohoto bitového toku. Tímto se změní zobrazený URL bitového toku, ale staré odkazy budou pořád fungovat dokud se nezmění číslo sekvence.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Aplikace, kterou jste použili na vytvoření souboru a číslo verze (např. „<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Název souboru</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Změna názvu soubory tohoto bitového toku. Tímto se změní zobrazený URL bitového toku, ale staré odkazy budou pořád fungovat dokud se nezmění číslo sekvence.</message>
 
-	
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Bitové toky záznamu</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Bitové toky záznamu</message>
@@ -1598,7 +1578,7 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Zobrazit</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Pořadí</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Svazek: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(primární)</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">zobrazit</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Nahrát nový bitový tok</message>
@@ -1609,7 +1589,7 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Předchozí:</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Přesunout výš</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Přesunout níž</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadata záznamu</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadata záznamu</message>
@@ -1648,20 +1628,22 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(jen pro správce systému)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(jen pro správce kolekce)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(nemáte oprávnění vykonat tuto operaci)</message>
-        <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Označit záznam jako soukromý</message>
-        <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Označit záznam jako veřejný</message>
-        <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Označit jako soukromý...</message>
-        <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Označit jako veřejný...</message>
-	
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Označit záznam jako soukromý</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Označit záznam jako veřejný</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Označit jako soukromý...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Označit jako veřejný...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Zobrazit záznam</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Zobrazit záznam</message>
-	<!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-	<message key="xmlui.administrative.item.CurateItemForm.main_head">Spravovat záznam: {0}</message>
-	<message key="xmlui.administrative.item.CurateItemForm.title">Spravovat záznam</message>
-	<message key="xmlui.administrative.item.CurateItemForm.trail">Kurátor</message>
-	<message key="xmlui.administrative.item.CurateItemForm.label_name">Úloha</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Spravovat záznam: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Spravovat záznam</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Kurátor</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Úloha</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Najít záznam</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Najít záznam</message>
@@ -1669,66 +1651,66 @@
 	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Nepodařilo se přeložit identifikátor.</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">Najít</message>
 
-	<!-- org.dspace.app.xmlui.administrative.metadataimport -->
-	<message key="xmlui.administrative.metadataimport.general.title">Importovat Metadata</message>
-	<message key="xmlui.administrative.metadataimport.general.head1">Importovat Metadata</message>
-	<message key="xmlui.administrative.metadataimport.general.trail">Importovat Metadata</message>
-	<message key="xmlui.administrative.metadataimport.general.changes">změn</message>
-	<message key="xmlui.administrative.metadataimport.general.no_changes">Nebyly zjištěny změny</message>
-	<message key="xmlui.administrative.metadataimport.general.new_item">Nový záznam</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_successful">Nahrání přeběhlo úspěšně</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_failed">Nahrání selhalo</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_badschema">Neznámé schéma metadat v hlavičce</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_badelement">Neznámý element metadat v hlavičce</message>
-	<message key="xmlui.administrative.metadataimport.flow.import_successful">Import přeběhl úspěšně</message>
-	<message key="xmlui.administrative.metadataimport.flow.import_failed">Import selhal</message>
-	<message key="xmlui.administrative.metadataimport.flow.over_limit">Počet změn překročil povolené maximum. Omezte změny nebo změňte bulkedit.gui-item-limit v dspace.cfg</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Importovat Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Importovat Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Importovat Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">změn</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Nebyly zjištěny změny</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Nový záznam</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Nahrání přeběhlo úspěšně</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Nahrání selhalo</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Neznámé schéma metadat v hlavičce</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Neznámý element metadat v hlavičce</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import přeběhl úspěšně</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import selhal</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Počet změn překročil povolené maximum. Omezte změny nebo změňte bulkedit.gui-item-limit v dspace.cfg</message>
 
-	<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-	<message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Nahrát CSV</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Nahrát CSV</message>
 
-	<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Úspěšně zpracováno</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Změny byly aplikovány v záznamu</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Přidané: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Odstraněné: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Přidané do vlastnící kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Odstraněné z vlastnící kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Namapované do kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Odmapované z kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Záznam smazán</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Záznam vyřazen</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Záznam znovu zařazen</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Úspěšně zpracováno</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Změny byly aplikovány v záznamu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Přidané: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Odstraněné: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Přidané do vlastnící kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Odstraněné z vlastnící kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Namapované do kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Odmapované z kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Záznam smazán</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Záznam vyřazen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Záznam znovu zařazen</message>
 
-	<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Přidat: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Odstranit: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Přidat do vlastnící kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">odstranit z vlastnící kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Namapovat do kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Odmapovat z kolekce</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Čekající změny záznamu</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Použít změny</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Změny záznamu čekající na kontrolu jsou uvedeny níže</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Smazat záznam</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Vyřadit záznam</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Znovu zařadit záznam</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Přidat: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Odstranit: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Přidat do vlastnící kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">odstranit z vlastnící kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Namapovat do kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Odmapovat z kolekce</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Čekající změny záznamu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Použít změny</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Změny záznamu čekající na kontrolu jsou uvedeny níže</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Smazat záznam</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Vyřadit záznam</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Znovu zařadit záznam</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Mapování záznamů</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Mapování záznamů</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Mapování záznamů - Namapuje záznamy z jiných kolekcí</message>
-	<message key="xmlui.administrative.mapper.MapperMain.para1">Kolekce: „<strong>{0}</strong>“</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Kolekce: „<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Toto je nástroj na mapování záznamů, který umožňuje správcům kolekce mapovat záznamy z jiných kolekcí do této kolekce. Můžete hledat záznamy z jiných kolekcí a mapovat je nebo procházet seznam aktuálně mapovaných záznamů.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statistiky</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} z {1}</strong> záznamů v této kolekci je mapovaných z jiných kolekcí</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Hledat</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Hledat záznamy</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Procházet mapované záznamy</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">(vyžaduje oprávnění ADD do kolekce)</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Hledat záznamy</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Hledat záznamy</message>
@@ -1738,7 +1720,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Kolekce</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Název</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Procházet mapované záznamy</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Procházet mapované záznamy</message>
@@ -1749,14 +1731,14 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Název</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">K odmapování záznamů z této kolekce potřebujete oprávnění REMOVE pro tuto kolekci.</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">Kolekce</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Editovat metadata</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Přidělit role</message>	
-	<message key="xmlui.administrative.collection.general.options_curate">Spravovat</message>
-	<message key="xmlui.administrative.collection.general.options_queue">Fronta</message>
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">Kolekce</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Editovat metadata</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Přidělit role</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Spravovat</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Fronta</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editovat role kolekce</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Role</message>
@@ -1783,16 +1765,16 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Krok editace metadat</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Přispěvatelé</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Výchozí přístup pro čtení</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(jen pro správce systému)</nobr></message>
-        <message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Skupina na úrovni repozitáře, pouze správci systému)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(nemáte oprávnění ke konfiguraci)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
-	<!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-	<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Spravovat kolekci: {0}</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.title">Spravovat kolekci</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.trail">Kurátor</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Úloha</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Spravovat kolekci: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Spravovat kolekci</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Kurátor</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Úloha</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Potvrdit smazání</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Potvrzení</message>
@@ -1801,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Všechny záznamy a nekompletní zadání v této kolekci, které nejsou obsaženy v jiných kolekcích</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Obsah těchto záznamů</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Všechny související autorizační politiky</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Potvrdit smazání role</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Potvrzení</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Potvrdit smazání role {0}</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Jste si jistý, že chcete smazat tuto roli? Smazání této skupiny přidělí přístup READ všem uživatelům pro všechny záznamy zaslané do kolekce od tohoto okamžiku. Prosím, pamatujte, že tato změna není retroaktivní. Stávající záznamy v systému budou stále omezeny na členy definované rolí, kterou se chystáte smazat.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Jste si jistý, že chcete smazat tuto roli? Všechny dosud provedené změny a úpravy skupiny {0} budou ztraceny a bylo by je třeba vytvořit od začátku.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editace metadat kolekce</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadata</message>
@@ -1828,7 +1810,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Odstranit logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Smazat kolekci</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Uložit aktualizace</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(jen pro správce systému)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Vytvořit kolekci</message>
@@ -1899,14 +1881,14 @@
 	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Nastavení generátoru</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Zdroj ORE</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Nastavení sklízení</message>   
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Nastavení sklízení</message>
 
 	<!-- General tags for community management -->
 	<message key="xmlui.administrative.community.general.community_trail">Komunity</message>
 	<message key="xmlui.administrative.community.general.options_metadata">Upravit metadata</message>
 	<message key="xmlui.administrative.community.general.options_roles">Přidělit role</message>
-	<message key="xmlui.administrative.community.general.options_curate">Spravovat</message>
-	<message key="xmlui.administrative.community.general.options_queue">Fronta</message>
+        <message key="xmlui.administrative.community.general.options_curate">Spravovat</message>
+        <message key="xmlui.administrative.community.general.options_queue">Fronta</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
 	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Upravit role komunity</message>
@@ -1922,19 +1904,19 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Přidružená skupina</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Správci</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(pouze správci systému)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
-	<!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-	<message key="xmlui.administrative.community.CurateCommunityForm.main_head">Spravovat komunitu: {0}</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.title">Spravovat komunitu</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.trail">Spravovat</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.label_name">Úloha</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Spravovat komunitu: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Spravovat komunitu</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Spravovat</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Úloha</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Potvrdit smazání</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Potvrzení</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Potvrďte smazání komunity {0}</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Jste si jistý, že chcete smazat komunitu <strong>{0}</strong>? Tím se smaže:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Jste si jistý, že chcete smazat komunitu </message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Všechny kolekce v komunitě, které nejsou obsaženy v jiných komunitách</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Všechny záznamy a nekompletní příspěvky v této komunitě, které nejsou obsaženy v jiných komunitách</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Obsah těchto záznamů</message>
@@ -1960,7 +1942,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Aktuální logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Odstranit logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Smazat komunitu</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Vytvořit komunitu</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Vytvořit komunitu</message>
@@ -1991,16 +1973,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Alokovaná paměť</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Využitá paměť</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Volná paměť</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_head">Info o Cocoon</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_version">Verze Cocoon</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Adresář vyrovnávací paměti Cocoon</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Pracovní adresář Cocoon</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Velikost hlavní vyrovnávací paměti ({0})</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Okamžitě vymazat vyrovnávací paměť)</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Velikost perzistentní vyrovnávací paměti ({0})</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Velikost přechodné vyrovnávací paměti ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Info o Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Verze Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Adresář vyrovnávací paměti Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Pracovní adresář Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Velikost hlavní vyrovnávací paměti ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Okamžitě vymazat vyrovnávací paměť)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Velikost perzistentní vyrovnávací paměti ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Velikost přechodné vyrovnávací paměti ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">Nastavení DSpace</message>
-	<message key="xmlui.administrative.ControlPanel.dspace_version">Verze DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Verze DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">Instalační adresář DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">Základ URL DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Název serveru DSpace</message>
@@ -2016,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Příjemce komentáře</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Obecný e-mail správce lokality</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Celosystémové upozornění</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Upozornění pro systémy s load balancingem</strong>: Celosystémová upozornění jsou účinná jen pro uzel, na kterém byla aktivována. Musíte se ujistit, že každý uzel v sadě dostane příkaz activate alert.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Správa s upozorněním</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Systém bude vypnut z důvodu pravidelné údržby. Prosím, uložte svou práci a odhlaste se</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Odpočet</message>
@@ -2026,11 +2008,11 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minut</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hodina</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Ponechat aktuální odpočet</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Spravovat relaci</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Nadále povolovat ověřené relace</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Omezit ověřování, ale ponechat aktuální relace</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Omezit ověřování a ukončit aktuální relace</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Poznámka:</strong> Spravců lokality se netýká správa relací.</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Spravovat relaci</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Nadále povolovat ověřené relace</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Omezit ověřování, ale ponechat aktuální relace</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Omezit ověřování a ukončit aktuální relace</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktivovat</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Deaktivovat</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Aktuální aktivita (maximálně {0} stránek)</message>
@@ -2043,14 +2025,14 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP adresa</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">Stránka URL</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-Agent</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymní {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymní {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Nebyly zaznamenány žádná zobrazení stránek.</message>
-	
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">Vyberte informace, které chcete zobrazit pomocí záložek výše</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Za {0} minut</strong>:</message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Bez oprávnění</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">Nemá oprávnění</message>
@@ -2059,83 +2041,83 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">správci systému</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Přihlásit se jako jiný uživatel</message>
-	
-	<!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-	<message key="xmlui.administrative.CurateForm.title">Systémové úlohy správy</message>
-	<message key="xmlui.administrative.CurateForm.trail">Úlohy správy</message>
-	<message key="xmlui.administrative.CurateForm.object_label_name">Handle objektu DSpace</message>
-	<message key="xmlui.administrative.CurateForm.object_hint">Tip: zadejte [váš-prefix-handle]/0 pro spuštení úlohy napříč celým repozitářem (ne všechny úlohy musí podporovat tuto možnost)</message>
-	<message key="xmlui.administrative.CurateForm.task_label_name">Úloha</message>
-	<!-- Used by Curate<DSO>Form classes also -->
-	<message key="xmlui.administrative.CurateForm.taskgroup_label_name">Vyberte si z nasledovních skupin</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">Systémové úlohy správy</message>
+        <message key="xmlui.administrative.CurateForm.trail">Úlohy správy</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle objektu DSpace</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Tip: zadejte [váš-prefix-handle]/0 pro spuštení úlohy napříč celým repozitářem (ne všechny úlohy musí podporovat tuto možnost)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Úloha</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Vyberte si z nasledovních skupin</message>
 
 
-	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-	Statistics Aspect
+                     Statistics Aspect
 
-	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	<message key="xmlui.statistics.title">Statistiky</message>
-        <message key="xmlui.statistics.search.title">Statistiky vyhledávání</message>
-        <message key="xmlui.statistics.search.head">Statistiky vyhledávání</message>
-        <message key="xmlui.statistics.search.head-dso">Statistiky vyhledávání pro {0}</message>
-        <message key="xmlui.statistics.search.error">Vyskytla se chyba během generování statistik vyhledávání. Prosím, zkuste to znovu později.</message>
-        <message key="xmlui.statistics.search.no-results">Pro vybrané časové období nejsou k dispozici žádné statistiky vyhledávání.</message>
-        <message key="xmlui.statistics.workflow.title">Statistiky workflow</message>
-	<message key="xmlui.statistics.visits.total">Návštěvy celkem</message>
-	<message key="xmlui.statistics.visits.month">Návštěvy celkem za měsíc</message>
-	<message key="xmlui.statistics.visits.views">Zobrazení</message>
-	<message key="xmlui.statistics.visits.countries">Nejvíce zobrazení ze země</message>
-	<message key="xmlui.statistics.visits.cities">Nejvíce zobrazení z města</message>
-	<message key="xmlui.statistics.visits.bitstreams">Stažení souborů</message>
-	<message key="xmlui.statistics.Navigation.title">Statistiky</message>
-        <message key="xmlui.statistics.Navigation.usage.view">Zobrazit statistiky využívání</message>
-        <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">Zobrazit statistiky využívání</message>
-        <message key="xmlui.statistics.Navigation.search.view">Zobrazit statistiky vyhledávání</message>
-        <message key="xmlui.statistics.Navigation.workflow.view">Zobrazit statistiky workflow</message>
-	<message key="xmlui.statistics.trail">Statistiky</message>
-        <message key="xmlui.statistics.trail-search">Statistiky vyhledávání</message>
-        <message key="xmlui.statistics.trail-workflow">Statistiky workflow</message>
-        <message key="xmlui.statistics.workflow.no-results">Pro vybrané časové období nejsou k dispozici žádné statistiky workflow.</message>
-        <message key="xmlui.statistics.workflow.error">Vyskytla se chyba během generování statistik workflow. Prosím, zkuste to znovu později.</message>
-        <message key="xmlui.statistics.workflow.head">Statistiky workflow</message>
-        <message key="xmlui.statistics.workflow.head-dso">Statistiky workflow pro {0}</message>
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Statistiky</message>
+    <message key="xmlui.statistics.search.title">Statistiky vyhledávání</message>
+    <message key="xmlui.statistics.search.head">Statistiky vyhledávání</message>
+    <message key="xmlui.statistics.search.head-dso">Statistiky vyhledávání pro {0}</message>
+    <message key="xmlui.statistics.search.error">Vyskytla se chyba během generování statistik vyhledávání. Prosím, zkuste to znovu později.</message>
+    <message key="xmlui.statistics.search.no-results">Pro vybrané časové období nejsou k dispozici žádné statistiky vyhledávání.</message>
+    <message key="xmlui.statistics.workflow.title">Statistiky workflow</message>
+    <message key="xmlui.statistics.visits.total">Návštěvy celkem</message>
+    <message key="xmlui.statistics.visits.month">Návštěvy celkem za měsíc</message>
+    <message key="xmlui.statistics.visits.views">Zobrazení</message>
+    <message key="xmlui.statistics.visits.countries">Nejvíce zobrazení ze země</message>
+    <message key="xmlui.statistics.visits.cities">Nejvíce zobrazení z města</message>
+    <message key="xmlui.statistics.visits.bitstreams">Stažení souborů</message>
+    <message key="xmlui.statistics.Navigation.title">Statistiky</message>
+    <message key="xmlui.statistics.Navigation.usage.view">Zobrazit statistiky využívání</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">Zobrazit statistiky využívání</message>
+    <message key="xmlui.statistics.Navigation.search.view">Zobrazit statistiky vyhledávání</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">Zobrazit statistiky workflow</message>
+    <message key="xmlui.statistics.trail">Statistiky</message>
+    <message key="xmlui.statistics.trail-search">Statistiky vyhledávání</message>
+    <message key="xmlui.statistics.trail-workflow">Statistiky workflow</message>
+    <message key="xmlui.statistics.workflow.no-results">Pro vybrané časové období nejsou k dispozici žádné statistiky workflow.</message>
+    <message key="xmlui.statistics.workflow.error">Vyskytla se chyba během generování statistik workflow. Prosím, zkuste to znovu později.</message>
+    <message key="xmlui.statistics.workflow.head">Statistiky workflow</message>
+    <message key="xmlui.statistics.workflow.head-dso">Statistiky workflow pro {0}</message>
 
 
-        <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Nejčastěji vyhledávaná klíčová slova</message>
-        <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Celkem</message>
-        <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Předchozí měsíc</message>
-        <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Předchozích 6 měsíců</message>
-        <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Předchozí rok</message>
-        <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Celkem</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Nejčastěji vyhledávaná klíčová slova</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Celkem</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Předchozí měsíc</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Předchozích 6 měsíců</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Předchozí rok</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Celkem</message>
 
- 
-        <message key="xmlui.statistics.display.table.column-label.search-terms">Vyhledávaná klíčová slova</message>
-        <message key="xmlui.statistics.display.table.column-label.searches">Hledání</message>
-        <message key="xmlui.statistics.display.table.column-label.percent-total">% celku</message>
-        <message key="xmlui.statistics.display.table.column-label.views-search">Zobrazení / Hledání</message>
-        <message key="xmlui.statistics.display.table.column-label.step">Krok</message>
-        <message key="xmlui.statistics.display.table.column-label.performed">Vykonáno</message>
-        <message key="xmlui.statistics.display.table.column-label.average">Průměr</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Krok Přijmout/Zamítnout z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP1">Krok Přijmout/Zamítnout</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Krok Přijmout/Zamítnout/Upravit metadata z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP2">Krok Přijmout/Zamítnout/Upravit metadata</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Krok Upravit metadata z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.STEP3">Krok Upravit metadata</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Krok Přijmout/Zamítnout z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Krok Přijmout/Zamítnout</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Krok Přijmout/Zamítnout/Upravit metadata z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Krok Přijmout/Zamítnout/Upravit metadata</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Krok Upravit metadata z fronty</message>
-        <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Krok Upravit metadata</message>
-        <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Krok Kontroly skóre</message>
-        <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Kontrola skóre</message>
-        <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Vyhodnocení kontroly skóre</message>
-        <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Konfigurace vyhodnocení kontroly skóre</message>
-        <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Kontrola jedním uživatelem z fondu</message>
-        <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Operace automatického přiřazení jednomu uživateli</message>
-        <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Operace kontroly jedním uživatelem</message>
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Vyhledávaná klíčová slova</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Hledání</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% celku</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Zobrazení / Hledání</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Krok</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Vykonáno</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Průměr</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Krok Přijmout/Zamítnout z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Krok Přijmout/Zamítnout</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Krok Přijmout/Zamítnout/Upravit metadata z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Krok Přijmout/Zamítnout/Upravit metadata</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Krok Upravit metadata z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Krok Upravit metadata</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Krok Přijmout/Zamítnout z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Krok Přijmout/Zamítnout</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Krok Přijmout/Zamítnout/Upravit metadata z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Krok Přijmout/Zamítnout/Upravit metadata</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Krok Upravit metadata z fronty</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Krok Upravit metadata</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Krok Kontroly skóre</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Kontrola skóre</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Vyhodnocení kontroly skóre</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Konfigurace vyhodnocení kontroly skóre</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Kontrola jedním uživatelem z fondu</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Operace automatického přiřazení jednomu uživateli</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Operace kontroly jedním uživatelem</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2158,9 +2140,9 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -2169,20 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Tato webstránka používá Manakin, nové uživatelské rozhraní pro DSpace, které vytvořily Texas A&amp;M University Libraries.
-			Rozhraní lze do velké míry přizpůsobit pomocí Manakin Aspects a témat vzhledu založených na XSL.
-			Další informace naleznete na
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> a
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Kontaktujte nás</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Vyjádření názoru</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">Repozitář DSpace/Manakin</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Profil:</message>
@@ -2193,15 +2175,15 @@
 	<message key="xmlui.dri2xhtml.structural.search-advanced">Rozšířené hledání</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-community">V této komunite</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">V této kolekci</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">předchozí strana</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">Zobrazují se záznamy {0}-{1} z {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">další strana</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Původní licence</message>
-		
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -2214,7 +2196,7 @@
 		aby vykonávala potřebnou funkci nebo, vytvořit šablonu odpovídající libovolnému profilu,
 		který používáte.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Náhled</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Název</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
@@ -2224,7 +2206,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Datum</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Nakladatel</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Klíčové slovo</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Soubory tohoto záznamu</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Soubory</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Název</message>
@@ -2232,18 +2214,17 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formát</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Zobrazit</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Popis</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Zobrazit/<wbr/>otevřít</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Přístup na čtení dostupný pro</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Zobrazit/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">K tomuto záznamu nejsou připojeny žádné soubory.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">{0} bajtů</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">K tomuto záznamu jsou přiřazeny následující licenční soubory:</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Kromě případů, kde je uvedeno jinak, licence tohoto záznamu je </message>
-		
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Kromě případů, kde je uvedeno jinak, licence tohoto záznamu je </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		Sumární zobrazení (summaryView) kolekce není momentálně použité nebo implementované.
 		To je možné napravit přepsáním šablony dri2xhtml s názvem collectionSummaryView.
@@ -2252,12 +2233,12 @@
 		Sumární zobrazení (summaryView) komunity není momentálně použité nebo implementované.
 		To je možné napravit přepsáním šablony dri2xhtml s názvem communitySummaryView.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo kolekce</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo komunity</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Bez loga</message>		
-	<message key="xmlui.dri2xhtml.METS-1.0.news">Novinky</message>	
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Bez loga</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Novinky</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
@@ -2265,18 +2246,19 @@
 		Při používaní QDC byste měli používat QDC crosswalk pro záznamy DSpace a DIM nebo MODS
 		pro zpracování komunit a kolekcí.
 	</message>
-		
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Prvky Dublin Core</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termíny Dublin Core</message>
-	
+
         <message key="xmlui.dri2xhtml.METS-1.0.blocked">Zablokované</message>
-	
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Náhled</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Datum</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Název</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
@@ -2469,7 +2451,7 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Oznámení</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Novější verze tohoto záznamu se nachází ve workflow.</message>
 
-    <message key="xmlui.aspect.sherpa.submission.consult">Prosím, navštivte <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a> pro získání informací o autorských právách a zásadách autoarchivace jednotlivých časopisů nebo vydavatelů.</message>
+    <message key="xmlui.aspect.sherpa.submission.consult">Prosím, navštivte <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
     <message key="xmlui.aspect.sherpa.submission.title">Informace o vydavateli</message>
     <message key="xmlui.aspect.sherpa.submission.journal">Časopis: </message>
     <message key="xmlui.aspect.sherpa.submission.publisher">Informace o vydavateli: </message>
@@ -2479,6 +2461,7 @@
     <message key="xmlui.aspect.sherpa.submission.blue">modrá</message>
     <message key="xmlui.aspect.sherpa.submission.white">bílá</message>
     <message key="xmlui.aspect.sherpa.submission.yellow">žlutá</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
 
@@ -2509,272 +2492,4 @@
     <message key="xmlui.mirage2.choice-authority-control.loading">Načítá se...</message>
 
     <message key="xmlui.mirage2.item-list.thumbnail">Náhled</message>
-
-
-
-  <!-- Discovery -->
-
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Předmět</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Typ obsahu</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Datum publikování</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Datum publikování</message>
-
-
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Nedávno přidané</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Zobrazit další</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Poslední příspěvky</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Poslední příspěvky</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Nedávno přidané</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Druh</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Vydavatel</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Je součástí</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Seskupit výsledky dle</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Neseskupovat</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publikace</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Komunita</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Kolekce</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Série</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Prohlížení dle autora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Prohlížení dle názvu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Prohlížení dle předmětu</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Prohlížení dle abstraktu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Prohlížení dle série</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Prohlížení dle sponzora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Prohlížení dle identifikátora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Prohlížení dle jazyka (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Prohlížení dle klíčového slova</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Prohlížení dle taxonu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Prohlížení dle přispěvatele</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Prohlížení dle tvůrce</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Prohlížení dle předmětu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Prohlížení dle popisu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Prohlížení dle vztahu </message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Prohlížení dle Mime-Type</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Prohlížení dle dalšího přispěvatele</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Prohlížení dle vedoucího</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Prohlížení dle oddělení</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Prohlížení dle data publikování</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Název</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Předmět</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Datum publikování</message>
-
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Zobrazují se záznamy {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Filtrovat dle: Autora</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Filtrovat dle předmětu</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Předmět</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Předmět</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Datum publikování</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Začíná písmeny</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Nebo zadejte několik prvních písmen:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Možnosti řazení:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Relevance</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Název sestupně</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Datum publikování sestupně</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Název vzestupně</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Datum publikování vzestupně</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Výsledků na stránku:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Přidat filtr</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Použít</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Odstranit</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Nové filtry:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Aktuální filtry:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Přidat filtry</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">Nebyly nalezeny žádné hodnoty filtrů</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Prohlížení</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... zobrazit další</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Hledat</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Hledat</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Filtry</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Filtry použijte na upřesnění výsledků vyhledávání.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">obsahuje</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">rovná se</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-	<message key="xmlui.Discovery.SimpleSearch.filter.notcontains">neobsahuje</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">nerovná se</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">nemá ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Související záznamy</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Zobrazují se záznamy příbuzné na základě názvu, autora a předmětu.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Zobrazuje se {0} z celkem {1} záznamů komunity: {2}. <span class="searchTime">({3} vteřiny)</span></message>
-   	<message key="xmlui.Discovery.AbstractSearch.head1_collection">Zobrazuje se {0} z celkem {1} záznamů kolekce: {2}. <span class="searchTime">({3} vteřiny)</span></message>
-   	<message key="xmlui.Discovery.AbstractSearch.head1_none">Zobrazuje se {0} z celkem {1} záznamů. <span class="searchTime">({2} vteřiny)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Komunity nebo kolekce odpovídající vašemu dotazu</message>
-   	<message key="xmlui.Discovery.AbstractSearch.head3">Záznamy odpovídající vašemu dotazu</message>
-
-   	<message key="xmlui.Discovery.SimpleSearch.did_you_mean">Měli jste na mysli: </message>
-
-
-  <!-- XMLWorkflow -->
-
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Operace, které můžete s touto úlohou provést:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Přiřadit tuto úlohu sobě.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Převzít úlohu</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Ponechat tuto úlohu v zásobníku, aby ji převzal někdo jiný.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Zanechat úlohu</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Zpět na přehled</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Přijmout/zamítnout úlohu</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Vykonat úlohu: Přijmout/zamítnout záznam</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Operace, které můžete s touto úlohou provést:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Pokud jste záznam zkontrolovali a zjistili jste, že <strong>není</strong> vhodný pro zařazení do kolekce, zvolte „Zamítnout“. Do následující zprávy pak vyplňte, proč je záznam nevhodný, a zda by měl odesílatel něco změnit a záznam znovu odeslat.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Zamítnout záznam</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Pokud jste záznam zkontrolovali a zjistili jste, že je vhodný pro zařazení do kolekce, zvolte „Přijmout“.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Přijmout záznam</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Vykonat úlohu: Přijmout/zamítnout/upravit záznam</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Operace, které můžete s touto úlohou provést:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Pokud jste záznam zkontrolovali a zjistili jste, že <strong>není</strong> vhodný pro zařazení do kolekce, zvolte „Zamítnout“. Do následující zprávy pak vyplňte, proč je záznam nevhodný, a zda by měl odesílatel něco změnit a záznam znovu odeslat.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Zamítnout záznam</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Pokud jste záznam zkontrolovali a zjistili jste, že je vhodný pro zařazení do kolekce, zvolte „Přijmout“.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Přijmout záznam</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Zvolte tuto volbu, když chcete upravit metadata záznamu.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Editovat metadata</message>
-
-    <message key="xmlui.XMLWorkflow.step.unknown">Neznámý stav</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Vykonat úlohu: Přiřadit kontrolora</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Použijte vyhledávací pole níže pro vyhledání uživatele, kterému chcete záznam přiřadit pro kontrolu.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Vyhledat kontrolora</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Vyhledat uživatele</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Zvolit jako kontrolora</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Pokud nejste správná osoba pro kontrolu tohto záznamu, můžete přiřazení úlohy zamítnout tlačítkem „Odmítnout přiřazení úlohy“.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Odmítnout přiřazení úlohy</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Zkontrolovat příspěvky</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Zkontrolovat příspěvek</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Zadejte skóre pro tento příspěvek</message>
-
-
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Přehled workflow</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Přehled workflow</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Přehled workflow</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Krok</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Záznam</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Kolekce</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Odesílatel</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Vrátit vybrané úlohy zpět odesílateli</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Smazat záznamy</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Žádné výsledky</message>
-
-
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Zobrazit položku workflow: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Zobrazit položku workflow</message>
-
-    <message key="xmlui.XMLWorkflow.default.reviewstep">Přijmout/zamítnout</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Přijmout/zamítnout</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Přijmout/zamítnout</message>
-
-    <message key="xmlui.XMLWorkflow.default.editstep">Přijmout/upravit/zamítnout</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Přijmout/upravit/zamítnout</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">Přijmout/upravit/zamítnout</message>
-
-    <message key="xmlui.XMLWorkflow.default.finaleditstep">Finálně přijmout/upravit</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Finálně přijmout/upravit</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Finálně přijmout/upravit</message>
-
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Přiřadit krok kontroly</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Přiřadit kontrolora</message>
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Krok kontroly jediným uživatelem</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Zkontrolovat záznam</message>
-
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Zkontrolovat a přidělit skóre</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Zkontrolovat a přidělit skóre</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Zkontrolovat a přidělit skóre</message>
-
-
-  <!-- SwordClient -->
-
-    <message key="xmlui.swordclient.Navigation.context_head">Kopírování SWORD</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">Zkopírovat záznam do jiného repozitáře</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">Kopírování SWORD</message>
-    <message key="xmlui.swordclient.general.main_head">Zkopírovat záznam: {0}</message>
-
-
-    <message key="xmlui.swordclient.SelectTarget.title">Cíl kopírování SWORD</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">Vyberte cíl</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">Alternativní URL</message>
-    <message key="xmlui.swordclient.SelectTarget.username">Uživatelské jméno</message>
-    <message key="xmlui.swordclient.SelectTarget.password">Heslo</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">Jménem</message>
-
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">Neplatný URL</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">Neplatné uživatelské jméno</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">Neplatné heslo</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Chyba získávání servisního dokumentu SWORD: {0}</message>
-
-    <message key="xmlui.swordclient.SelectCollection.title">Cílové kolekce SWORD</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">Vyberte kolekce</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">Kolekce: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">Název: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">Politika: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">Mediace: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">Typy souborů: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Formáty balíků: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Uložit na toto místo</message>
-
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">Sub-servisní cíl</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Získat sub-servisní dokument</message>
-
-    <message key="xmlui.swordclient.SelectPackagingAction.head">Kolekce: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">Název: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">Politika: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">Mediace: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">Typ souboru</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Formát balíku</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Byl zvolen nepodporovaný formát balíku</message>
-
-    <message key="xmlui.swordclient.DepositAction.success">Záznam byl úspěšně zkopírován</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Chyba formátu balíku</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">Neplatný handle</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Vyskytla se chyba během vytváření objektu balíku</message>
-    <message key="xmlui.swordclient.DepositAction.error">Vyskytla se chyba během zasílání: {0}</message>
-
-    <message key="xmlui.swordclient.SwordResponse.title">Odpověď SWORD</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">Odpověď SWORD</message>
-
 </catalogue>

--- a/src/main/webapp/i18n/messages_cs.xml
+++ b/src/main/webapp/i18n/messages_cs.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="cs">
 
 	<!--
 		The format used by all keys is as follows
@@ -303,7 +304,7 @@
         <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Tento záznam byl vyřazen</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Vybraný záznam byl vyřazen a není nadále dostupný.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Vybraný záznam je záznam s omezeným přístupem a pro jeho zobrazení musíte mít potřebná oprávnění. Prosím, pro zobrazení tohoto záznamu se přihlaste.</message>
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Váš účet nemá potřebná oprávnění pro zobrazení ttohoto záznamu. Jestli máte jakékoliv nejasnosti, obraťte se na správce systému.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Váš účet nemá potřebná oprávnění pro zobrazení tohoto záznamu. Jestli máte jakékoliv nejasnosti, obraťte se na správce systému.</message>
         
 	<!-- Authentication messages used at the top of the login page:  -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Toto je záznam s omezeným přístupem</message>
@@ -385,7 +386,7 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Požadavek na změnu oprávnění</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Požadavek na změnu oprávnění</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Požadavek na změnu oprávnění</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Můžete využít tuto příležitost na opětovné zvážení omezení tohoto dokumentu (aby jste nemuseli odpovídat na tyto požadavky), pokud není důvod pro zachovíní omezení dokumentu. Pokud tak chcete učinit, po vložení vašeho jména a emailu (pro ověření) klikněte na tlačítko „Změnit na Open Access“.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Můžete využít tuto příležitost na opětovné zvážení omezení tohoto dokumentu (aby jste nemuseli odpovídat na tyto požadavky), pokud není důvod pro zachování omezení dokumentu. Pokud tak chcete učinit, po vložení vašeho jména a emailu (pro ověření) klikněte na tlačítko „Změnit na Open Access“.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Jméno</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Email</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">Jméno je nutné vyplnit</message>
@@ -745,7 +746,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Zveřejněno</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Dokument byl již dříve publikován</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Je-li zaškrtávací pole nahoře označeno, ze záznamu se odstraní následující:</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Dátum publikování</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Datum publikování</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Citace zdrojového dokumentu</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Nakladatel</message>
 
@@ -775,7 +776,7 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo na přístup do určeného data</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Viditelný/embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Název</message>
-    <message key="xmlui.Submission.submit.AccessStep.name_help">Krátký, popisní název politiky (do 30 znaků). Může se zobrazit koncovému uživateli. Např. „Pouze pro změstnance“. Nepovinný, ale doporučuje se vyplnit.</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">Krátký, popisní název politiky (do 30 znaků). Může se zobrazit koncovému uživateli. Např. „Pouze pro zaměstnance“. Nepovinný, ale doporučuje se vyplnit.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Popis</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Důvod</message>
     <message key="xmlui.Submission.submit.AccessStep.reason_help">Důvod embarga. Typicky pouze pro interní využití. Nepovinný.</message>
@@ -785,7 +786,7 @@
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Když je zvoleno embargo, vyžaduje se datum</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Identická politika pro tuto skupinu a tuto operaci již existuje.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Seznam politik</message>
-    <message key="xmlui.Submission.submit.AccessStep.policies_help">Politiky uvedené v této sekci mají pripritu před jakýmikoliv výchozími politikami kolekcí, do kterých přidáváte záznam. Pokud si přejete nastavit embargo, ale cílová kolekce umožňuje přístup pro libovolného uživatele, musíte nastavit politiku, která povoluje přístup pro skupinu Anonymous pouze od určitého data dále.</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Politiky uvedené v této sekci mají prioritu před jakýmikoliv výchozími politikami kolekcí, do kterých přidáváte záznam. Pokud si přejete nastavit embargo, ale cílová kolekce umožňuje přístup pro libovolného uživatele, musíte nastavit politiku, která povoluje přístup pro skupinu Anonymous pouze od určitého data dále.</message>
     <message key="xmlui.Submission.submit.AccessStep.no_policies">Pro tento záznam nebyli nastaveny žádné skupinové politiky.</message>
     <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Soukromý záznam</message>
@@ -809,11 +810,11 @@
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Upravit politiku</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-	<message key="xmlui.Submission.submit.UploadStep.head">Nahrat soubory</message>
+	<message key="xmlui.Submission.submit.UploadStep.head">Nahrát soubory</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Soubor</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Prosím, zadejte plnou cestu k souboru na vašem počítači, která odpovídá vašemu záznamu. Po kliknutí na „Procházet...“ se zobrazí nové okno, které vám umožní vybrat soubor z vašeho počítače.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Záznam musí obsahovat alespoň jeden soubor.</message>
-	<message key="xmlui.Submission.submit.UploadStep.upload_error">Vyskytl se problém při nahrávání vašeho souboru. Buď nebyl správně zadán název souboru nebo nastal problém v síti, který znemožnil korektní uložení vašeho souboru. Další přičinou může být pokus o nahrání souboru ve formátu, který je jen pro interní použití. Prosím, zkuste to znovu.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Vyskytl se problém při nahrávání vašeho souboru. Buď nebyl správně zadán název souboru nebo nastal problém v síti, který znemožnil korektní uložení vašeho souboru. Další příčinou může být pokus o nahrání souboru ve formátu, který je jen pro interní použití. Prosím, zkuste to znovu.</message>
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Soubor nebyl nahraný, protože to vypadá, že obsahuje virus.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Vyskytli se technické potíže při pokusu o kontrolu virů. Prosím, kontaktujte správce systému.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Popis souboru</message>
@@ -873,7 +874,7 @@
 	<message key="xmlui.Submission.submit.EditFileStep.description">Popis souboru</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description_help">Můžete dodat stručný popis obsahu tohoto souboru. Například „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.EditFileStep.info1">Z níže uvedeného seznamu vyberte formát souboru, například „<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Zjištený formát</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Zjištěný formát</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Vybraný formát</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formát není v seznamu</message>
 	<message key="xmlui.Submission.submit.EditFileStep.info2">Není-li formát ve výše uvedeném seznamu, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
@@ -904,7 +905,7 @@
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Vyskytla se chyba ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Licencujte své dílo</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.info1">Jestli si přejete, můžete ke svému dílu připojit licenci <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Zvolit licenci</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Pokračovat na výběr licence na webu Creative Commons</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Typ licence</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Vyberte nebo změňte svou licenci ...</message>
@@ -933,7 +934,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Operace, které můžete na této úloze vykonat:</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Přidelit tuto úlohu sobě.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Přidělit tuto úlohu sobě.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Převzít úlohu</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Ponechat tuto úlohu v zásobníku, aby ji převzal někdo jiný.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Zanechat úlohu</message>
@@ -1100,7 +1101,7 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Požadovat certifikát</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Může se přihlásit</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Vygenerovat heslo</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Můžete trvale ostranit tuto e-osobu ze systému nebo jí vygenerovat nové heslo. Po vygenerování hesla se uživateli odešle e-mail obsahující speciální odkaz, kde si může své heslo změnit.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Můžete trvale odstranit tuto e-osobu ze systému nebo jí vygenerovat nové heslo. Po vygenerování hesla se uživateli odešle e-mail obsahující speciální odkaz, kde si může své heslo změnit.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Smazat e-osobu</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Přihlásit se jako e-osoba</message>
 
@@ -1275,7 +1276,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Poznámka o rozsahu</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Další poznámky o tomto metadatovém poli.</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Přidat pole metadat</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aktualizovať pole: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aktualizovat pole: {0}</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aktualizovat pole</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Chyba</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Název pole se již používá, všechny prvky a kvalifikátory musí být jedinečné.</message>
@@ -1288,7 +1289,7 @@
 	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
 	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registr formátů</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registr formátů bitového toku</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Tento seznam formátů bitových toků poskytuje informace o známych formátech a úrovni jejich podpory. Pomocí tohoto nástroje můžete upravovat nebo přidávat nové formáty bitových toků. Formáty označené jako „interní“ jsou uživatelům skryté a používají se na účely správy.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Tento seznam formátů bitových toků poskytuje informace o známých formátech a úrovni jejich podpory. Pomocí tohoto nástroje můžete upravovat nebo přidávat nové formáty bitových toků. Formáty označené jako „interní“ jsou uživatelům skryté a používají se na účely správy.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Přidat nový formát bitového toku</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
@@ -1345,7 +1346,7 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Vyhledat záznam</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Záznamy je možné nalézt dle handle nebo interního ID</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Najít</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Poročilá správa autorizace</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Pokročilá správa autorizace</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Nástroj na správu politik zástupných znaků</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Oprávnění komunity/kolekce</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Vyberte komunitu nebo kolekci k editaci jejích politik.</message>
@@ -1380,7 +1381,7 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Politiky pro svazek {0} ({1})</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Bitový tok {0} ({1})</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Přidat novou politiku záznamu</message>
-	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Přidat novú politiku svazku</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Přidat novou politiku svazku</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Přidat novou politiku bitového toku</message>
 
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Pro tento objekt nebyly nalezeny žádné politiky.</message>
@@ -1583,7 +1584,7 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">zobrazit</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Nahrát nový bitový tok</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Smazat bitové toky</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Aktualizovat pořadí bitvých toků</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Aktualizovat pořadí bitových toků</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Potřebujete oprávnění ADD a WRITE alespoň na záznamu a svazku, abyste mohli nahrávat nové bitové toky.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Pouze správci systému mají oprávnění smazat bitové toky/soubory.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Předchozí:</message>
@@ -1834,9 +1835,9 @@
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">ID množiny OAI</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Formát metadat</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">URL služby poskytovatele OAI cílového repozitáře</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Musíte zadat ID množniny cílové kolekce</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Musíte zadat ID množiny cílové kolekce</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Perzistentní identifikátor, který používá poskytovatel OAI na určení cílové kolekce</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Musíte zadat ID množniny cílové kolekce</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Musíte zadat ID množiny cílové kolekce</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Sklízený obsah</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Sklízet pouze metadata.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Sklízet metadata a odkazy na bitové toky (vyžaduje podporu ORE).</message>
@@ -2046,10 +2047,10 @@
         <message key="xmlui.administrative.CurateForm.title">Systémové úlohy správy</message>
         <message key="xmlui.administrative.CurateForm.trail">Úlohy správy</message>
         <message key="xmlui.administrative.CurateForm.object_label_name">Handle objektu DSpace</message>
-        <message key="xmlui.administrative.CurateForm.object_hint">Tip: zadejte [váš-prefix-handle]/0 pro spuštení úlohy napříč celým repozitářem (ne všechny úlohy musí podporovat tuto možnost)</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Tip: zadejte [váš-prefix-handle]/0 pro spuštění úlohy napříč celým repozitářem (ne všechny úlohy musí podporovat tuto možnost)</message>
         <message key="xmlui.administrative.CurateForm.task_label_name">Úloha</message>
     <!-- Used by Curate<DSO>Form classes also -->
-        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Vyberte si z nasledovních skupin</message>
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Vyberte si z následujících skupin</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2173,7 +2174,7 @@
 
 	<message key="xmlui.dri2xhtml.structural.search">Prohledat DSpace</message>
 	<message key="xmlui.dri2xhtml.structural.search-advanced">Rozšířené hledání</message>
-	<message key="xmlui.dri2xhtml.structural.search-in-community">V této komunite</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">V této komunitě</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">V této kolekci</message>
 
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">předchozí strana</message>
@@ -2340,7 +2341,7 @@
   <!-- explanatory messages for choice authority confidence values -->
   <message key="xmlui.authority.confidence.description.cf_unset">Pro tuto hodnotu nebyla jistota nikdy zaznamenána</message>
   <message key="xmlui.authority.confidence.description.cf_novalue">Autorita nevrátila žádnou rozumnou hodnotu jistoty</message>
-  <message key="xmlui.authority.confidence.description.cf_rejected">Autorita doporučuje zamítnutí tohto příspěvku</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">Autorita doporučuje zamítnutí tohoto příspěvku</message>
   <message key="xmlui.authority.confidence.description.cf_failed">Autorita zjistila vnitřní chybu</message>
   <message key="xmlui.authority.confidence.description.cf_notfound">Autorita neobsahuje odpovídající záznamy</message>
   <message key="xmlui.authority.confidence.description.cf_ambiguous">Autorita obsahuje více odpovídajících hodnot se stejnou platností</message>

--- a/src/main/webapp/i18n/messages_de.xml
+++ b/src/main/webapp/i18n/messages_de.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="de">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_de.xml
+++ b/src/main/webapp/i18n/messages_de.xml
@@ -1,28 +1,18 @@
-<?xml version="1.0"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="de" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">DSpace Startseite</message>
 	<message key="xmlui.general.search">Suche</message>
@@ -35,13 +25,17 @@
 	<message key="xmlui.general.delete">Löschen</message>
 	<message key="xmlui.general.next">Weiter</message>
 	<message key="xmlui.general.untitled">Ohne Titel</message>
-	<message key="xmlui.general.perform">Ausführen</message>
-    <message key="xmlui.general.queue">In die Warteschleife</message>
-	
-	
-	<!-- 
-		Page not found keys 
-		
+        <message key="xmlui.general.perform">Ausführen</message>
+        <message key="xmlui.general.queue">In die Warteschleife</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
@@ -49,40 +43,42 @@
 	<message key="xmlui.PageNotFound.head">Seite nicht gefunden</message>
 	<message key="xmlui.PageNotFound.para1">Die Seite, die Sie angefordert haben, konnte nicht gefunden werden.</message>
 
+
 	<!--
 	   The "utils" non-aspect
        -->
     <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Nur Administratoren dieser Seite dürfen sich als anderer Nutzer anmelden.</message>
     <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Nur authentifizierte Administratoren dürfen sich als anderer Nutzer anmelden.</message>
-    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Sie können nicht die Identität eines anderen Administrators annehmen.</message>	
-	
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Sie können nicht die Identität eines anderen Administrators annehmen.</message>
+
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">Das digitale Repositorium erfasst, speichert, erhält, erschließt und verbreitet digitale Forschungsergebnisse.</message>
-	<message key="xmlui.feed.header">RSS Feeds</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">Feed Bild</message>
 	<message key="xmlui.feed.untitled">Ohne Titel</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">An Alle</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Suchergebnisse für den Bereich: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Suchergebnisse für die Sammlung {0}</message>
@@ -93,9 +89,9 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Die Suche führte zu keinem Treffer.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Gesamter Bestand</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Titel</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">Erscheinungsdatum</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Zugangsdatum</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Titel</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">Erscheinungsdatum</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Zugangsdatum</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">Relevanz</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Liste Dokumente nach</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">sortiert nach</message>
@@ -116,7 +112,6 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Titel</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Schlagwort</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Zusammenfassung</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Betreuer</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Serie</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Sponsor</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Kennung</message>
@@ -131,23 +126,23 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Mime-Typ</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Sonstige beteiligte Person</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Betreuer</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Abteilung</message>	
-	
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Gesamter Text</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">UND</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">ODER</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NICHT</message>
-	
-	
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Abteilung</message>
+
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Gesamter Text</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">UND</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">ODER</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NICHT</message>
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Oder geben Sie die ersten Buchstaben ein:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Auflistung von Dokumenten, die mit diesen Buchstaben anfangen</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Gehe zu einem Punkt im Index:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Wähle Monat)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Wähle Jahr)</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Gehe zu einem Punkt im Index:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Wähle Monat)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Wähle Jahr)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Oder geben Sie ein Jahr ein: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Auflistung von Dokumenten eines bestimmten Jahres.</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Für diese Browse-Ansicht gibt es keine Ergebnisse.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Für diese Browse-Ansicht gibt es keine Ergebnisse.</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Sortiert nach: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Sortierung: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Ergebnisse: </message><!-- /Page -->
@@ -170,17 +165,37 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Auflistung {0} Nach Schlagwort {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Auflistung {0} Nach Schlagwort</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Auflistung {0} nach Titel {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Auflistung {0} nach Titel</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Auflistung {0} nach Erscheinungsdatum {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Auflistung {0} nach Erscheinungsdatum</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Auflistung {0} nach Zugangsdatum {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Auflistung {0} nach Zugangsdatum</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Suchbereich</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Gesamter Bestand</message>
@@ -191,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datum</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Erweiterte Suche</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Neueste Zugänge</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Bereichsliste</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Bereichsliste</message>
@@ -210,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Teilbereiche in diesem Bereich</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Sammlungen in diesem Bereich</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Neueste Zugänge</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Kontakt</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Kontakt</message>
@@ -220,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Onlineformular</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Feedback</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">E-Mail</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Ihre Anregungen/Meinung</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Ihre Anregungen/Meinung</message>
@@ -230,24 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Diese Adresse wird benutzt, damit wir ggf. mit Ihnen Rücksprache halten können.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Kommentar</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Feedback abschicken</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Ihre Anregungen/Meinung</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Ihre Anregungen/Meinung</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Feedback gesendet</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Danke für Ihre(n) Anregungen/Kommentar.</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">DSpace Suche</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Zum Suchen geben Sie den Suchbegriff in das Feld unten ein.</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Dokumentanzeige</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Das Dokument erscheint in:</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Zur Kurzanzeige</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Zur Langanzeige</message>
-	<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Diese Dokument wurde zurückgezogen und steht nicht mehr zur Verfügung.</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Diese Dokument wurde zurückgezogen und steht nicht mehr zur Verfügung.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Stöbern</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Gesamter Bestand</message>
@@ -259,16 +271,16 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Zugangsdatum</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Diese Sammlung</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Diesen Bereich</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Suche</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Suche</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Suche</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Suchbereich</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Volltextsuche</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Dieses Dokument ist nur eingeschränkt zugänglich.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Diese Ressource ist nur eingeschränkt zugänglich.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Zugangsbeschränkung</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Diese Ressource ist nur eingeschränkt zugänglich.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Dieser Bereich ist nur eingeschränkt zugänglich.</message>
@@ -276,38 +288,25 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Dieses Dokument ist nur eingeschränkt zugänglich.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Diese Datei ist nur eingeschränkt zugänglich.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Sie verfügen nicht über das Recht, auf diese eingeschränkt zugängliche Ressource zuzugreifen.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Sie verfügen nicht über das Recht, auf diesen eingeschränkt zugänglichen Bereich  <b>{0}</b> zuzugreifen.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Sie verfügen nicht über das Recht, auf diese eingeschränkt zugängliche Sammlung  <b>{0}</b> zuzugreifen.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Sie verfügen nicht über das Recht, auf dieses eingeschränkt zugängliche Dokument <b>{0}</b> zuzugreifen.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Sie verfügen nicht über das Recht, auf diese eingeschränkt zugängliche Datei  <b>{0}</b> zuzugreifen.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Sie verfügen nicht über das Recht, auf diesen eingeschränkt zugänglichen Bereich  <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Sie verfügen nicht über das Recht, auf diese eingeschränkt zugängliche Sammlung  <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Sie verfügen nicht über das Recht, auf dieses eingeschränkt zugängliche Dokument <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Sie verfügen nicht über das Recht, auf diese eingeschränkt zugängliche Datei  <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">Sammlung</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">Bereich</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">Datei</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">Dokument</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">Ressource</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">unbekannt</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Weiter zur Anmeldung</message>    
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Diese Dokument wurde zurückgezogen</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Das ausgewählte Dokument wurde zurückgezogen und steht nicht länger zur Verfügung.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Das ausgewählte Dokument ist nur für bestimmte Benutzergruppen zugänglich. Bitte melden Sie sich an, wenn Sie zu einer entsprechenden Gruppe gehören.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Ihr Benutzerkonto verfügt nicht über die Rechte, auf dieses Dokument zuzugreifen. Bei Fragen wenden Sie sich bitte an den Administrator..</message>
-            
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Weiter zur Anmeldung</message>
 
-	
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Diese Ressource ist nur eingeschränkt zugänglich.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Zugangsbeschränkung</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">Sammlung</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">Bereich</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">Datei</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">Dokument</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">Ressource</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">unbekannt</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Diese Dokument wurde zurückgezogen</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Das ausgewählte Dokument wurde zurückgezogen und steht nicht länger zur Verfügung.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Das ausgewählte Dokument ist nur für bestimmte Benutzergruppen zugänglich. Bitte melden Sie sich an, wenn Sie zu einer entsprechenden Gruppe gehören.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Ihr Benutzerkonto verfügt nicht über die Rechte, auf dieses Dokument zuzugreifen. Bei Fragen wenden Sie sich bitte an den Administrator..</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Dieses Dokument ist nur eingeschränkt zugänglich.</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Dieses Dokument ist nur eingeschränkt zugänglich.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Das Dokument, auf welches Sie zugreifen wollten, ist nur eingeschränkt zugänglich. Bitte melden Sie sich mit der entsprechenden Zugriffsberechtigung an.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Monatsstatistiken</message>
@@ -316,37 +315,141 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Keine Statistiken verfügbar</message>
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Zur Zeit stehen keine Statistiken zur Verfügung.  Versuchen Sie es später noch einmal.</message>
 
-
-	<!-- Authentication messages used for bitstream authentication -->	
-	<message key="xmlui.BitstreamReader.auth_header">Diese Datei ist nur eingeschränkt zugänglich</message>	
+    <!-- Authentication messages used for bitstream authentication -->
+	<message key="xmlui.BitstreamReader.auth_header">Diese Datei ist nur eingeschränkt zugänglich</message>
 	<message key="xmlui.BitstreamReader.auth_message">Die Datei, auf die Sie zugreifen wollten, ist nur eingeschränkt zugänglich. Bitte melden Sie sich mit der entsprechenden Zugriffsberechtigung an.</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Dieser Export ist für Sie nicht zugänglich.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Der Export, auf den Sie zugreifen wollten, hat eine Zugriffsbeschränkung und Sie verfügen nicht über die entsprechenden Rechte. Bitte melden Sie sich als Benutzer mit entsprechenden Rechten an, um auf diesen Export zuzugreifen.</message>
-	
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Registrierung Neuer Benutzer</message>
 	<message key="xmlui.EPerson.trail_forgot_password">Passwort vergessen</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Registrierung nicht verfügbar</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Registrierung nicht verfügbar</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Dieses DSpace Repositorium ist so konfiguriert, dass eine Registrierung in diesem Kontext nicht möglich ist. Bitte wenden Sie sich and den <a href="../contact">Administrator</a>, wenn Sie Fragen dazu haben.</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">Dieses DSpace Repositorium ist so konfiguriert, dass eine Registrierung in diesem Kontext nicht möglich ist. Bitte wenden Sie sich and den <a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Benutzerdaten aktualisieren</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">Benutzerdaten anlegen</message>
@@ -357,7 +460,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">Vorname</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Nachname</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">Telefon</message>
-	<message key="xmlui.EPerson.EditProfile.Language">Sprache</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Sprache</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Abonnements</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Sie können Sammlungen abonnieren, um laufend per E-Mail über Neuerscheinungen informiert zu werden. Sie können beliebig viele Sammlungen abonnieren. Eine Alternative zur Benachrichtigung per E-Mail sind die RSS feeds.</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">E-Mail-Abonnement</message>
@@ -374,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">Benutzergruppen, denen Sie angehören</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Identifikation</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">Sicherheit</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">E-Mail-Adresse verifizieren</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Benutzerdaten anlegen</message>
@@ -387,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Passwort neu gesetzt</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Passwort neu gesetzt</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Ihr Passwort wurde neu gesetzt.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Ungültige Kennung</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Ungültige Kennung</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Ungültige Kennung</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">Die URL, welche Sie angegeben haben ist ungültig. Gegebenfalls gab es einen Zeilenumbruch durch ihr E-Mail-Programm, wie hier z. B.:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">Wenn dem der Fall ist, so kopieren Sie die gesamte URL und fügen Sie sie direkt in ihren Browser ein anstatt nur auf den Link in der E-Mail zu klicken. Die Adressleiste Ihres Browsers sollte dann etwas in dieser Art enthalten:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">Mein Benutzerkonto</message>
 	<message key="xmlui.EPerson.Navigation.profile">Benutzerdaten</message>
@@ -414,7 +517,7 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">Einen neuen Benutzer registrieren</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">Legen Sie einen Benutzeracccount an, um Dienste wie den Neuerscheinungsinformationsdienst nutzen zu können.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Klicken Sie hier, um einen neuen Benutzeraccount anzulegen.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Einloggen</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Einloggen</message>
@@ -423,7 +526,7 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Der Benutzername und/oder Passwort sind ungültig.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Passwort</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Einloggen</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Einlogart wählen</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">Einlogart wählen</message>
@@ -441,24 +544,24 @@
 	<message key="xmlui.EPerson.FailedAuthentication.title">Authentifizierung fehlgeschlagen</message>
     <message key="xmlui.EPerson.FailedAuthentication.trail">Authentifizierung fehlgeschlagen</message>
     <message key="xmlui.EPerson.FailedAuthentication.h1">Authentifizierung fehlgeschlagen</message>
-	
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">Keine Authentifizierungsmethode gefunden</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">Keine Authentifizierungsmethode gefunden. Bitte wenden Sie sich an den Administrator.</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">Shibboleth Login fehlgeschlagen</message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">Die Authentifizierung vie Shibboleth steht momentan nicht zur Verfügung. Bitte wenden Sie sich an den Administrator.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">Benutzerdaten aktualisiert</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">Benutzerdaten aktualisieren</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">Benutzerdaten aktualisiert</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">Ihre Benutzerdaten wurden aktualisiert.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">Registrierung abgeschlossen</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">Registrierung abgeschlossen</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">Sie sind nun ein registrierter Benutzer.  Jetzt können Sie z. B. den Alerting-Dienst für Neuerscheinungen nutzen.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">Passwort neu setzen</message>
 	<message key="xmlui.EPerson.ResetPassword.head">Passwort neu setzen</message>
@@ -469,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">Passwort neu setzen</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Ihr Passwort muss mindestens 6 Zeichen lang sein.</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Bitte geben Sie Ihr Passwort noch einmal zur Bestätigung ein.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">Passwort vergessen</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">Passwort vergessen</message>
@@ -478,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Geben Sie die E-Mail-Adresse ein, mit der Sie sich registriert haben.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">E-Mail-Adresse nicht gefunden</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Daten abschicken</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Registrierung Neuer Benutzer</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">Die E-Mail-Adresse wird bereits von einem Benutzer verwendet.</message>
@@ -491,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">Diese E-Mail-Adresse wird überprüft und als Ihre Benutzername verwandt.</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Es war nicht möglich, an diese Adresse eine E-Mail zu schicken.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">Registrieren</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">E-Mail zur Verifizierung gesendet.</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">E-Mail zur Verifizierung gesendet.</message>
@@ -503,25 +606,23 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
 
 
 	<!-- general submission aspect messages -->
-	<message key="xmlui.Submission.general.default.title">Ressourcen einreichen</message>
-	<message key="xmlui.Submission.general.default.trail">Ressourcen einreichen</message>
 	<message key="xmlui.Submission.general.mydspace_home">Mein DSpace</message>
 	<message key="xmlui.Submission.general.go_mydspace">Gehe zu Mein DSpace</message>
 	<message key="xmlui.Submission.general.submission.title">Dokument veröffentlichen</message>
 	<message key="xmlui.Submission.general.submission.trail">Dokument veröffentlichen</message>
-	<message key="xmlui.Submission.general.submission.head">Dokument veröffentlichen</message>	
+	<message key="xmlui.Submission.general.submission.head">Dokument veröffentlichen</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Zurück</message>
 	<message key="xmlui.Submission.general.submission.save">Speicher / Abbrechen</message>
 	<message key="xmlui.Submission.general.submission.next">Weiter &gt;</message>
@@ -531,25 +632,27 @@
 	<message key="xmlui.Submission.general.workflow.head">Dokument veröffentlichen</message>
 	<message key="xmlui.Submission.general.showfull">Zur Langanzeige</message>
 	<message key="xmlui.Submission.general.showsimple">Zur Kurzanzeige</message>
-	
+	<message key="xmlui.Submission.general.default.title">Ressourcen einreichen</message>
+	<message key="xmlui.Submission.general.default.trail">Ressourcen einreichen</message>
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Ein Dokument in dieser Sammlung veröffentlichen</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Veröffentlichungen</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Veröffentlichungen &amp; Geschäftsgänge</message>
 	<message key="xmlui.Submission.Submissions.trail">Veröffentlichungen</message>
 	<message key="xmlui.Submission.Submissions.head">Veröffentlichungen  &amp; übernommen Aufgaben</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>ohne Titel</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">E-Mail: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Aufgaben aus Geschäftsgängen</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Dies sind Dokumente, die sich noch im Geschäftsgang befinden. Es gibt zwei Bearbeitungskategorien, eine für Aufgaben, die Sie persönlich übernommen haben, eine andere für Aufgaben, die noch keine Bearbeiter übernommen hat.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Ihre eigenen Aufgaben</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Aufgabe</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Dokument</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Sammlung</message>
@@ -568,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Dies sind Ihre unvollendeten Veröffentlichungen. Sie können statt dessen auch </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">eine neue Veröffentlichung beginnen</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Titel</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Sammlung</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Veröffentlicht von</message>
@@ -592,27 +695,26 @@
 	<message key="xmlui.Submission.Submissions.status_6">Die Veröffentlichung wird abschließend bearbeitet</message>
 	<message key="xmlui.Submission.Submissions.status_7">Die Veröffentlichung wurde archiviert</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Status unbekannt</message>
-
-    <!-- Same transformer, completed submissions section -->
-    <message key="xmlui.Submission.Submissions.completed.head">Angenommene Veröffentlichungen</message>
-    <message key="xmlui.Submission.Submissions.completed.info">Dies sind die Ihre in DSpace angenommenen Veröffentlichungen.</message>
-    <message key="xmlui.Submission.Submissions.completed.column1">Zugangsdatum</message>
-    <message key="xmlui.Submission.Submissions.completed.column2">Titel</message>
-    <message key="xmlui.Submission.Submissions.completed.column3">SAmmlung</message>
-    <message key="xmlui.Submission.Submissions.completed.limit">Es werden 50 Ihrer Veröffentlichungen angezeigt. </message>
-    <message key="xmlui.Submission.Submissions.completed.displayall">Anzeige aller Veröffentlichungen.</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Angenommene Veröffentlichungen</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Dies sind die Ihre in DSpace angenommenen Veröffentlichungen.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Zugangsdatum</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Titel</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">SAmmlung</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Es werden 50 Ihrer Veröffentlichungen angezeigt. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Anzeige aller Veröffentlichungen.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Einleitende Fragen</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Beschreiben</message>
-    <message key="xmlui.Submission.submit.progressbar.access">Zugriffsrechte</message>	
-	<message key="xmlui.Submission.submit.progressbar.upload">Hochladen</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Zugriffsrechte</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Hochladen</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Überprüfen</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons Lizenz</message>
 	<message key="xmlui.Submission.submit.progressbar.CClicense">CC Lizenz</message>
-	<message key="xmlui.Submission.submit.progressbar.license">DSpace Lizenz</message>
+    <message key="xmlui.Submission.submit.progressbar.license">DSpace Lizenz</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Fertig</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Wiederaufnehmen</message>
 
@@ -629,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Speichern, um später daran weiterzuarbeiten</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Löschen</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Einleitende Fragen</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Hinweis: </message>
@@ -638,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Weitere Titel</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Das Dokument hat mehrere Titel <i>z. B.: eine Übersetzung</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Das Dokument hat mehrere Titel <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Wenn das obere Kästchen nicht angehakt ist, werden folgende Titel entfernt: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Bereits veröffentlicht</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Das Dokument wurde bereits veröffentlicht oder öffentlich zugänglich gemacht.</message>
@@ -646,13 +748,13 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Erscheinungsdatum</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Zitation</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Herausgeber</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">Dokument beschreiben</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Fehler: Unbekannter Feldtyp</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Dieses Feld ist obligatorisch</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nachname, <i>z. B. Mustermann</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Vorname(n) + Titel, <i>Max Dr.</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nachname, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Vorname(n) + Titel, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Jahr</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Monat</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Tag</message>
@@ -673,16 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Zugriff bis zu einem bestimmten Datum unter Embargo.</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Sichtbar/Unter Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Beschreibung</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Begründung</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Zugriffsberechtigung bestätigen &amp; eine weitere hinzufügen</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Gruppen</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Ungültiges Datumsformat</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Wenn Embargo ausgwählt wurde, dann ist ein Datum erforderlich.</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Es gibt bereits eine identische Zugriffsberechtigung für diese Gruppe und diese Aktion.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Liste der Zugriffsberechtigungen</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Dokument im privaten Modus</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Wenn ausgewählt, ist das Dokument nicht suchbar.</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Aktion</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Gruppe</message>
@@ -691,29 +799,34 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Bearbeiten</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Entfernen</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Zulässige Formate: jjjj, jjjj-mm, jjjj-mm-tt</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
-    <message key="xmlui.Submission.submit.EditPolicyStep.head">Zugriffsrechte bearbeiten</message>    	
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Zugriffsrechte bearbeiten</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Datei(en) hochladen</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Datei</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Bitte geben Sie den voll qualifizierten Pfad zu der Datei auf Ihrem Rechner an. Wenn Sie auf "Durchsuchen" klicken, öffnet sich ein neues Fenster, in welchem Sie die Datei auf Ihrem Rechner suchen und auswählen können.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">Das Dokument muss mindestens eine Datei enthalten.</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">Ein Problem ist während des Hochladens Ihrer Datei aufgetreten. Dies kann verschiedene Gründe haben: der Dateiname war fehlerhaft, aufgrund eines Netzwerkproblems wurde die Datei nicht korrekt übertragen oder Sie haben versucht, eine Dateiformat hochzuladen, welches auf dem Repositorium nicht zugelassen ist. Bitte überprüfen Sie Ihre Eingaben und versuchen es noch einmal.</message>
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Die Datei wurde nich hochgeladen, da sie scheinbar einen Virus enthält. Bitte wenden Sie sich an den System-Administrator.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Beim Virusscan der Datei ist ein technisches Problem aufgetreten. Bitte wenden Sie sich an den System-Administrator.</message>
-	<message key="xmlui.Submission.submit.UploadStep.file_error">Das Dokument muss mindestens eine Datei enthalten.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Beschreibung</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei eingeben, z. B. "<i>Hauptband</i>", oder "<i>Anhang</i>".</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Beschreibung</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei eingeben, z. B. "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Datei hochladen und/oder noch eine hinzufügen</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Hochgeladene Dateien</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Primäre Datei</message>
-	<message key="xmlui.Submission.submit.UploadStep.column1"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
 	<message key="xmlui.Submission.submit.UploadStep.column2">Datei</message>
 	<message key="xmlui.Submission.submit.UploadStep.column3">Größe</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Beschreibung</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Unbekannt</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">unbekanntes Format</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Unterstützt)</message>
@@ -723,6 +836,8 @@
 	<message key="xmlui.Submission.submit.UploadStep.checksum">Prüfsumme:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Ausgewählte Datei(en) entfernen</message>
 
+
+
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Datei(en) hochladen</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Datei</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Bitte geben Sie den vollständigen Dateipfad an.Wenn Sie auf "Durchsuchen" klicken, öffnet sich ein neues Fenster, in dem Sie die Datei aussuchen können.</message>
@@ -731,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Die Datei wurde nicht hochgeladen, da sie einen Virus zu enthalten scheint. Bitte wenden Sie sich an den Systemadministrator.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Bei dem Versuch die Datei auf Viren zu überprüfen ist ein Fehler aufgetreten. Bitte wenden Sie sich an den Systemadministrator.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Beschreibung der Datei</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Bei Bedarf können Sie ein kurze Beschreibung der Datei eingeben.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Bei Bedarf können Sie ein kurze Beschreibung der Datei eingeben.<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Datei Hochladen &amp; und eine weitere hinzufügen</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Hochgeladene Dateien</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primärdatei</message>
@@ -740,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Größe</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Beschreibung</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unbekannt</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">Unbekanntes Format</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Unterstützt)</message>
@@ -750,23 +865,25 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Prüfsumme:</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Ausgewählte Datei(en) löschen</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Zugriffsrechte</message>
-    	
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Datei bearbeiten</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Datei</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Dateibeschreibung</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Zusätzlich können Sie ein kurze Beschreibung der Datei eingeben, z. B. "<i>Hauptband</i>", oder "<i>Anhang</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Wählen Sie das entsprechende Dateiformat aus der Liste, z. B.  "<i>Adobe PDF</i>" oder "<i>Microsoft Word</i>." <strong>Wenn das Format nicht in der Liste enthalten ist</strong>, geben Sie bitte eine kurze Beschreibung in das Feld unten ein.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Zusätzlich können Sie ein kurze Beschreibung der Datei eingeben, z. B. "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Wählen Sie das entsprechende Dateiformat aus der Liste, z. B.  "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Erkanntes Format</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Gewähltes Format</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Format nicht in Auswahlliste</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Wenn Ihr Format nicht in der Liste vorhanden ist, <strong>wählen Sie "Format nicht in Auswahlliste" </strong> und geben Sie eine kurze Beschreibung des Formats in das Feld unten ein.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Wenn Ihr Format nicht in der Liste vorhanden ist, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Sonstiges Format</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Die Anwendung inkl. Versionsnummer mit der die Datei erstellt wurde z. B. "<i>ACMESoft SuperApp version 1.5</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Die Anwendung inkl. Versionsnummer mit der die Datei erstellt wurde z. B. "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Zugriffsrechte für Datei bearbeiten</message>
-    
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Veröffentlichung überprüfen</message>
 	<message key="xmlui.Submission.submit.ReviewStep.yes">Ja</message>
@@ -782,21 +899,21 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">unbekannt</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">bekannt</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">unterstützt</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Ein Fehler ist aufgetreten ... {0}</message>	
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons Lizenz</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">Wenn Sie eine  <a href="http://creativecommons.org/">Creative Commons</a> Lizenz zu Ihrem Dokument hinzufügen: <strong>Creative Commons Lizenzen legen fest, wie ihr Werk genutzt werden kann.</strong> Wenn Sie eine Creative Commons Lizenz hinzufügen möchten, klicken sie auf die untere Schaltfläche. Sie werden dann zur Creative Commons Seite weitergeleite, wo Sie aus verschiedenen Lizenzmodellen auswählen können.  Nachdem Sie eine Lizenz ausgewählt haben, kehren Sie zu dieser Seite zurück.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Wählen Sie eine Lizenz</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Weiter zur Creative Commons Seite, um eine Lizenz auszuwählen.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Lizenz</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">keine Creative Commons Lizenz wurde ausgewählt</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Sie müssen auf "Weiter" klicken, um Ihre Ändeurngen zu speichern.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Auswahl oder Änderung der Lizenz</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Ein Fehler ist aufgetreten ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons Lizenz</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Wenn Sie eine  <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Wählen Sie eine Lizenz</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Weiter zur Creative Commons Seite, um eine Lizenz auszuwählen.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Lizenz</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Auswahl oder Änderung der Lizenz</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">keine Creative Commons Lizenz wurde ausgewählt</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Sie müssen auf "Weiter" klicken, um Ihre Ändeurngen zu speichern.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">DSpace Lizenz</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Dies ist der letzte Schritt:</strong> Damit Ihr Dokument im Institutionellen Repositorium entsprechend verarbeitet und weiterverbreitet werden kann, müssen Sie folgenden Bedingungen zustimmen.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Akzeptieren Sie die Standardlizenzbestimmung des Repositoriums indem Sie 'Ich akzeptiere die Lizenzbestimmungen' anhaken und klicken Sie dann auf 'Veröffentlichung abschließen'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Wenn Sie Fragen zu den Lizenzbestimmungen haben, wenden Sie sich an den Administrator.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Lizenzbestimmung</message>
@@ -806,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">Veröffentlichung gelöscht</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">Ihre Veröffentlichung wurde abgebrochen und das unfertige Dokument vom System gelöscht.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Zur Veröffentlichungsseite</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Zur Veröffentlichungsseite</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Veröffentlichung abgeschlossen</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">Ihre Veröffentlichung durchläuft nun den für diese Sammlung festgelegten Geschäftsgang. Sie werden per E-Mail benachrichtigt, sobald dieser abgeschlossen umd Ihr Dokument in der Sammlung archiviert wurde oder erhalten ggf. eine E-Mail mit Rückfragen des Bearbeiters. Den Bearbeitungsstand Ihrer Veröffentlichung können Sie über Ihre Veröffentlichungsseite einsehen.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Zur Veröffentlichungsseite</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Ein weiteres Dokument veröffentlichen</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Veröffentlichung abgeschlossen</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Ihre Veröffentlichung durchläuft nun den für diese Sammlung festgelegten Geschäftsgang. Sie werden per E-Mail benachrichtigt, sobald dieser abgeschlossen umd Ihr Dokument in der Sammlung archiviert wurde oder erhalten ggf. eine E-Mail mit Rückfragen des Bearbeiters. Den Bearbeitungsstand Ihrer Veröffentlichung können Sie über Ihre Veröffentlichungsseite einsehen.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Zur Veröffentlichungsseite</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Ein weiteres Dokument veröffentlichen</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Aktionen, die Sie in diesem Bearbeitungsschritt durchführen können:</message>
@@ -824,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Ressource akzeptieren</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Nach der Bearbeitung der Ressource, wählen Sie diese Option, um sie ins Archiv zu überführen.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Ins Archiv überführen</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Wenn Sie eine Ressource begutachtet haben und diese <strong>NICHT</strong> in das Repositorium aufgenommen werden soll, wählen Sie "Ressource Ablehnen".  Sie können dann dem Veröffentlichenden die Gründe  und ob Änderung und ein erneutes Einreichen möglich sind mitteilen.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Wenn Sie eine Ressource begutachtet haben und diese <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Ressource ablehnen</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Wählen Sie diese Option, wenn Sie die Metadaten der Ressource bearbeiten möchten.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Metadaten bearbeiten</message>
@@ -837,21 +954,22 @@
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Sie müssen den Ablehnungsgrund angeben</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Ressource ablehnen</message>
 
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Die Aufgabe wurde erfolgreich ausgeführt.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Die Aufgabe wurde unerwartet abgebrochen oder die Ausführung ist fehlgeschlagen. Für weitere Informationen wenden Sie sich an den Administrator und überprüfen Sie die Log-Dateien.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Die Aufgabe wurde erfolgreich in die Warteschlange eingereiht.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Die Aufgabe konnte nicht in die Warteschlange eingefügt werden. Es ist ein Fehler aufgetreten.Für weitere Informationen wenden Sie sich an den Administrator und überprüfen Sie die Log-Dateien.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Der Benutzeraccount wurde angelegt.</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Die Aufgabe wurde erfolgreich ausgeführt.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Die Aufgabe wurde unerwartet abgebrochen oder die Ausführung ist fehlgeschlagen. Für weitere Informationen wenden Sie sich an den Administrator und überprüfen Sie die Log-Dateien.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Die Aufgabe wurde erfolgreich in die Warteschlange eingereiht.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Die Aufgabe konnte nicht in die Warteschlange eingefügt werden. Es ist ein Fehler aufgetreten.Für weitere Informationen wenden Sie sich an den Administrator und überprüfen Sie die Log-Dateien.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Der Benutzeraccount wurde angelegt.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Der Benutzeraccount wurde aktualisiert.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Dem Benutzer wurde eine E-Mail mit entsprechender Kennung gesandt, unter der er sein Passwort neu vergeben kann.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Der/Die Benutzer wurden gelöscht.</message>
@@ -878,10 +996,10 @@
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Ausgewählte Datei(en) gelöscht.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">Dokument(e) gespiegelt.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Die Dokumentspiegelung wurde rückgängig gemacht.</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Benutzerverwaltung</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Kontext</message>
@@ -893,10 +1011,10 @@
 	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Teilbereich anlegen</message>
 	<message key="xmlui.administrative.Navigation.context_create_community">Bereich anlegen</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">Dokument Exportieren</message>
-    <message key="xmlui.administrative.Navigation.context_export_collection">Sammlung Exportieren</message>
-    <message key="xmlui.administrative.Navigation.context_export_community">Bereich Exportieren</message>
-    <message key="xmlui.administrative.Navigation.context_export_metadata">Metadaten Exportieren</message>
-	
+        <message key="xmlui.administrative.Navigation.context_export_collection">Sammlung Exportieren</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Bereich Exportieren</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Metadaten Exportieren</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">Zugriffsrechte</message>
@@ -906,18 +1024,20 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Referenzlisten</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadaten</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Formate</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Dokumente</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Verworfene Dokumente</message>
-    <message key="xmlui.administrative.Navigation.administrative_private">Nicht sichtbare Dokumente</message>    
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Systemdaten</message>
-	<message key="xmlui.administrative.Navigation.statistics">Statistiken</message>
-	<message key="xmlui.administrative.Navigation.administrative_import_metadata">Metadaten Importieren</message>
-	<message key="xmlui.administrative.Navigation.administrative_curation">Datenpflege - Aufgabens</message>
-	
+    <message key="xmlui.administrative.Navigation.administrative_private">Nicht sichtbare Dokumente</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Systemdaten</message>
+    <message key="xmlui.administrative.Navigation.statistics">Statistiken</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Metadaten Importieren</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Datenpflege - Aufgabens</message>
+
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Meine Exporte</message>
-	
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Exportierte Archive</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">Die ID des Dokumentes ist ungültig.</message>
@@ -926,13 +1046,14 @@
 	<message key="xmlui.administrative.ItemExport.item.not.found">Das angeforderte Dokument wurde nicht gefunden.</message>
 	<message key="xmlui.administrative.ItemExport.collection.not.found">Die angeforderte Sammlung wurde nicht gefunden.</message>
 	<message key="xmlui.administrative.ItemExport.community.not.found">Der angeforderte Bereich wurde nicht gefunden.</message>
-		<message key="xmlui.administrative.ItemExport.item.success">Das Dokument wurde exportiert. Sie werden per E-Mail benachrichtigt, sobald das Archiv zum Herunterladen bereitsteht. Sie können auch den Link "Meine Exporte" verwenden, um zu einer Auflistung aller Ihrer Exporte zu gelangen.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Das Dokument wurde exportiert. Sie werden per E-Mail benachrichtigt, sobald das Archiv zum Herunterladen bereitsteht. Sie können auch den Link "Meine Exporte" verwenden, um zu einer Auflistung aller Ihrer Exporte zu gelangen.</message>
 	<message key="xmlui.administrative.ItemExport.collection.success">Die Sammlung wurde exportiert.  Sie werden per E-Mail benachrichtigt, sobald das Archiv zum Herunterladen bereitsteht. Sie können auch den Link "Meine Exporte" verwenden, um zu einer Auflistung aller Ihrer Exporte zu gelangen.</message>
 	<message key="xmlui.administrative.ItemExport.community.success">Der Bereich wurde exportiert.  Sie werden per E-Mail benachrichtigt, sobald das Archiv zum Herunterladen bereitsteht. Sie können auch den Link "Meine Exporte" verwenden, um zu einer Auflistung aller Ihrer Exporte zu gelangen.</message>
 	<message key="xmlui.administrative.ItemExport.available.head">Archive, die zum Herunterladen bereitstehen:</message>
-	
-		
-	<!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
+
+
+
+    <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Benutzeraccounts verwalten</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Benutzerverwaltung</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Aktionen</message>
@@ -944,14 +1065,14 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Benutzer werden nach Wortfragmenten aus Name und E-Mail-Adresse gesucht.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Unten ist eine Liste aller Benutzer, auf die Ihre Suchanfrage zutraf. Wählen Sie den Benutzer aus, den Sie löschen möchten und klicken Sie auf Löschen, um den Benutzer zu löschen oder auf die E-Mail-Adresse oder den Namen, um den Benutzer zu bearbeiten.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Suchergebnisse</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Name</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">E-Mail-Adresse</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Benutzeraccount löschen</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Ihre Suche führte zu keinem Treffer.</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Benutzer hinzufügen</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Benutzer hinzufügen</message>
@@ -965,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Zertifikat erforderlich</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Benutzer kann sich einloggen</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Benutzeraccount anlegen</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Benutzeraccount bearbeiten</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Benutzeraccount bearbeiten</message>
@@ -982,17 +1103,19 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Sie können diesen Benutzer auch dauerhaft löschen oder veranlassen, dass er ein neues Passwort setzen muss. Beim Neusetzen des Passworts wird dem Benutzer eine E-Mail mit den entsprechenden Informationen zugeschickt.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Benutzeraccount löschen</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Anmelden als anderer Benutzer</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Gruppen, denen der Benutzer zugeordnet ist:</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(indirekt über die Gruppe: {0})</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">Keine</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Der Benutzeraccount konnte aufgrund folgender Abhängigkeiten nicht gelöscht werden:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">und</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">unter dem Benutzeraccount wurden ein oder mehrere Dokumente veröffentlicht</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">der Benutzer hat eine noch im Geschäftsgang befindliche Veröffentlichung</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">der Benutzer muss noch Aufgaben im Rahmen des Geschäftsganges erledigen</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">zu dem Benutzer gibt es eine sonstige Abhängigkeit im System</message>
-		
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Gruppen, denen der Benutzer zugeordnet ist:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(indirekt über die Gruppe: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">Keine</message>
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Benutzeraccount löschen bestätigen</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Löschung bestätigen</message>
@@ -1017,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Gruppensuche</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Sie können nach jedem Teil des Gruppennamens suchen.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Suchergebnisse</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Name</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Mitglieder</message>
@@ -1049,24 +1172,24 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Name</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">E-Mail</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Name</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Mitglieder</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Sammlung</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">anzeigen</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Mitglieder</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Name</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">E-Mail</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">Gruppe: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">Gruppe: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Diese Gruppe hat keine Mitglieder.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[anhängig]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Mitglieder entfernen</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Mitglieder entfernen</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Löschung der Gruppe bestätigen</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Löschung bestätigen</message>
@@ -1076,11 +1199,11 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Name</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Benutzer</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Gruppen</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Referenzliste der Format</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Referenzliste der Metadatenschema und -felder</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Referenzliste der Metadatenschema und -felder</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Dateiformat</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Dateiformate Löschen</message>
@@ -1094,9 +1217,9 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Felder löschen</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Felder löschen/</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Löschung bestätigen</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Sind Sie <b>absolut</b> sicher, dass dieses Feld gelöscht werden soll? Stellen Sie vorher sicher, dass dieses Metadatenfeld von keinem Dokument verwendet wird.</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Diese Aktion verursacht einen Fehler, wenn ein Item Metadaten dieses Feldtyps enthält.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Sind Sie <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ACHTUNG: </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Diese Aktion verursacht einen Fehler, wenn ein Item Metadaten dieses Feldtyps enthält.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Name</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Gültigkeitsbereich</message>
@@ -1105,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Schema löschen</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Schema löschen</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Löschung bestätigen</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Sind Sie <b>absolut</b> sicher, dass dieses Schema gelöscht werden soll? Wenn Dokumente Metadatenfelder dieses Schemas enthalten, kann es nicht gelöscht werden.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Sind Sie <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">WARNING: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Der Löschung verursacht einen Fehler, wenn Dokumente Metadatenfelder dieses Schemas enthalten.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1140,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadatenschema: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Dies ist das Metadatenschema für: "{0}". Sie können Felder hinzufügen, löschen oder aktualisieren. Felder können zudem in ein anderes Schema verschoben werden. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Felder des Metadatenschemas</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Feld</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Gültigkeitsbereich</message>
@@ -1167,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Dateiformate Referenzliste</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Diese Referenzliste enthält Informationen zu bekannten Dateiformaten und ihren Unterstützungsgrad durch das Repositorium. Mit diesem Werkzeug können Sie bereits eingetragene Formate bearbeiten oder nue Formate hinzufügen. Formate die mit "internal' gekennzeichnet sind, bleiben dem Benutzer verborgen und werden für administrative Zwecke verwendet.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Dateiformat hinzufügen</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Name</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Typ</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Unterstützungsgrad</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>intern</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Unbekannt</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Bekannt</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Unterstützungsgrad</message>
@@ -1182,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadaten Referenzliste</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadaten Referenzliste</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Die Metadatenreferenzliste enthält alle Metadatenfelder dieses Repositoriums. Die Metadatenfelder können auf mehrere Schema aufgeteilt werden. DSpace benötigt als Basis qualifiziertes Dublin Core. Sie können das Dublin Core Schema erweitern oder neue Schemata anlegen.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namensraum</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Name</message>
@@ -1206,13 +1329,14 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Gültigkeitsbereich</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Verschiebe in das Schema: </message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Felder verschieben</message>
-		
-	
-	
+
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">Rechte</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Auflistung der Rechte</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Rechte verwalten</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Rechte verwalten</message>
@@ -1225,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Klicken Sie hier, um zur erweiterten Rechtevergabe zu gelangen.</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Rechte von Bereichen und Sammlungen</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Klicken Sie auf einen Bereich oder eine Sammlung, um die zugehörigen Rechte zu bearbeiten.</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Rechte bearbeiten</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Bestehende Rechte</message>
@@ -1236,16 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Klicken Sie hier, um eine neue Autorisierung anzulegen. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Hinzufügen</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>	
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Aktion</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Enddatum</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Gruppe</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Anfangsdatum</message>	
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Anfangsdatum</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Enddatum</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Auswahl löschen</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Bearbeiten</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Rechte des Dokuments bearbeiten</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Rechteliste</message>
@@ -1258,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Ein neues Recht für ein Dokument hinzufügen</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Ein neues Recht für ein Bündle hinzufügen</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Ein neues Recht für eine Datei hinzufügen</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Es sind keine Rechte mit diesem Objekt assoziiert.</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Rechte bearbeiten</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Rechte bearbeiten</message>
@@ -1269,11 +1393,11 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Bearbeite Recht {0} für {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Keine Gruppe ausgewählt</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Keine Aktion ausgewählt</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Name</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Aktionen für diese Ressource</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Setzen</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">aktuelle</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Suchergebnisse</message>
@@ -1281,17 +1405,17 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Gruppe suchen</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Suche</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Aktion wählen</message>
-    
+
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Beschreibung</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Enddatum</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Anfangsdatum</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Ungültiges Datum</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Es existiert bereits ein identisches Zugriffsrecht für diese Gruppe und diese Aktion.</message>	
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Das Startdatum liegt nach dem Enddatum.</message>	      
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Zulässige Formate: jjjj, jjjj-mm, jjjj-mm-tt</message>    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Enddatum</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Ungültiges Datum</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Es existiert bereits ein identisches Zugriffsrecht für diese Gruppe und diese Aktion.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Das Startdatum liegt nach dem Enddatum.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Zulässige Formate: jjjj, jjjj-mm, jjjj-mm-tt</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Erweiterte Rechtevergabe</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Erweiterte Autorisierungen</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Erweiterte Rechtevergabe</message>
@@ -1306,7 +1430,7 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Sammlung</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Rechte hinzufügen</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Rechte löschen</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Zulässige Formate: JJJJ, JJJJ-MM, JJJJ-MM-TT</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Zulässige Formate: JJJJ, JJJJ-MM, JJJJ-MM-TT</message>
 
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Beschreibung</message>
@@ -1315,8 +1439,8 @@
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Ungültiges Datum</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Anfangsdatum ist später als das Enddatum</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Bitte wählen Sie mindestens eine Gruppe aus.</message>
-    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Bitte wählen Sie mindestens eine Sammlung aus.</message>	
-	
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Bitte wählen Sie mindestens eine Sammlung aus.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Löschung der Autorisierung bestätigen</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Löschung bestätigen</message>
@@ -1325,7 +1449,42 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Aktion</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Gruppe</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Dokumente</message>
 	<message key="xmlui.administrative.item.general.template_head">Metadatenschablone für die Sammlung: {0} bearbeiten</message>
@@ -1334,9 +1493,9 @@
 	<message key="xmlui.administrative.item.general.option_bitstreams">Zugehörige Dateien</message>
 	<message key="xmlui.administrative.item.general.option_metadata">Metadaten</message>
 	<message key="xmlui.administrative.item.general.option_view">Dokumentanzeige</message>
-	<message key="xmlui.administrative.item.general.option_curate">Pflege</message>
-    <message key="xmlui.administrative.item.general.option_queue">Zu Bearbeiten</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">Pflege</message>
+        <message key="xmlui.administrative.item.general.option_queue">Zu Bearbeiten</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">Datei hochladen</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Datei hochladen</message>
@@ -1350,10 +1509,10 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Datei</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Bitte geben Sie den Dateinamen mit voll qualifizierten Pfad auf Ihrem Rechner ein. Wenn Sie auf "Stöbern" klicken, öffnet sich ein neues Fenster, in dem Sie die Datei auf Ihrem Rechner heraussuchen können. Nachdem Sie die entsprechende Datei gewählt haben, wird das Fenster automatisch geschlossen.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Beschreibung</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei, z. B. Anhang, Hauptband, Messergebnisse usw. eingeben.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei, z. B. Anhang, Hauptband, Messergebnisse usw. eingeben.<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Hochladen</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Sie benötigen ADD (Hinzufügen) und WRITE (Schreib) Rechte zu mindestens einem Originalbündel, um eine Datei hochspielen zu können.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Löschung bestätigen</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Löschung bestätigen</message>
@@ -1362,8 +1521,8 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Name</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Beschreibung</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
-	
-	<!-- org.dspace.app.xmlui.administrative.item.ConfrimItemForm -->
+
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Bestätigen</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Bestätigen</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Dokument bearbeiten: {0}</message>
@@ -1376,9 +1535,9 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Verwerfen</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Wieder aktivieren</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Nicht sichtbar machen</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Sichtbar machen</message>	
-	
-	<!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Sichtbar machen</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
 	<message key="xmlui.administrative.item.MoveItemForm.title">Verschieben</message>
 	<message key="xmlui.administrative.item.MoveItemForm.trail">Verschieben</message>
 	<message key="xmlui.administrative.item.MoveItemForm.head1">Dokument: {0} verschieben</message>
@@ -1387,7 +1546,7 @@
 	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Sammlung wählen</message>
 	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Verschieben</message>
     <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Rechte erben</message>
-    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Die Standardrechte der Zielsammlung erben</message>	
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Die Standardrechte der Zielsammlung erben</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">Datei bearbeiten</message>
@@ -1398,31 +1557,28 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">ja</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">nein</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Beschreibung</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei eingeben, z. B.: Hauptband, Anhang, Messdaten.</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Wählen Sie das Dateiformat aus der Liste oder, wenn Ihr Format nicht in der Liste enthalten ist, beschreiben Sie es in dem dafür vorgesehenen Feld.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Zusätzlich können Sie eine kurze Beschreibung der Datei eingeben, z. B.: Hauptband, Anhang, Messdaten.<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Wählen Sie das Dateiformat aus der Liste oder, wenn Ihr Format nicht in der Liste enthalten ist, beschreiben Sie es in dem dafür vorgesehenen Feld.<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Ausgewähltes Format</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format nicht zur Auswahl</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Wenn das Format nicht in der Auswahlliste ist, <strong>wählen Sie "Format nicht zur Auswahl"</strong> und beschreiben Sie das Format in dem dafür vorgesehenen Feld.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Wenn das Format nicht in der Auswahlliste ist, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Sonstiges Format</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Die Anwendung mit der die Datei erstellt wurde und die Versionsnummer, z. B.: "<i>ACMESoft SuperApp version 1.5</i>".</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Die Anwendung mit der die Datei erstellt wurde und die Versionsnummer, z. B.: "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Dateiname</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Datei umbenennen. Dies führt zu einer Änderung in der angezeigten URL aber alte Links werden solange sich die Sequence ID nicht ändert korrekt aufgelöst.</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Vorher:</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Nach oben</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Nach unten</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Zur Ressourcegehörige Dateien</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Zur Ressourcegehörige Dateien</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Dateien</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Name</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Beschreibung</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Anzeige</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Sortierung</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bündle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (primär) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">anzeigen</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Eine neue Datei hochladen</message>
@@ -1430,7 +1586,10 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Dateisortierung ändern</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Sie benötigen ADD (Hinzufügen) und WRITE (Schreib) Rechte an Dokument und Bündel, um eine Datei hochspielen zu können.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Sie benötigen REMOVE (Lösch) Rechte an Dokument und Bündel, um Dateien löschen zu können.</message>
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Vorher:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Nach oben</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Nach unten</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadaten der Ressource</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadaten der Ressource</message>
@@ -1458,12 +1617,12 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Rechte des Dokumentes</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Ein Dokument aus dem Repositorium zurückziehen.</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Ein Dokument wieder im Repositorium zugänglich machen.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Dokument in eine andere Sammlung verschieben</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Dokument endgültig löschen</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Rechte bearbeiten</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Verwerfen</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Wieder aktivieren</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Verschieben...</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Dokument in eine andere Sammlung verschieben</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Endgültig löschen</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(nur für Systemadministratoren)</message>
@@ -1473,112 +1632,113 @@
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Sichtbar machen</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Unsichtbar machen...</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Sichtbar machen...</message>
-    	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Dokumentanzeige</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Dokumentanzeige</message>
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Pflege des Dokuments: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Dokumentpflege</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Kurator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Aufgabe</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-    <message key="xmlui.administrative.item.CurateItemForm.main_head">Pflege des Dokuments: {0}</message>
-    <message key="xmlui.administrative.item.CurateItemForm.title">Dokumentpflege</message>
-    <message key="xmlui.administrative.item.CurateItemForm.trail">Kurator</message>
-    <message key="xmlui.administrative.item.CurateItemForm.label_name">Aufgabe</message>
-    	
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Dokumentsuche</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Dokumentsuche</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Interne Dokument-ID oder Handle</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Kennung konnte nicht zugeordnet werden.</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">Finde</message>
-	
-	<!-- org.dspace.app.xmlui.administrative.metadataimport -->
-    <message key="xmlui.administrative.metadataimport.general.title">Metadaten importieren</message>
-    <message key="xmlui.administrative.metadataimport.general.head1">Metadaten importieren</message>
-    <message key="xmlui.administrative.metadataimport.general.trail">Metadaten importieren</message>
-    <message key="xmlui.administrative.metadataimport.general.changes">Änderungen</message>
-    <message key="xmlui.administrative.metadataimport.general.no_changes">Es wurden keine Änderungen gefunden</message>
-    <message key="xmlui.administrative.metadataimport.general.new_item">Neues Dokument</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_successful">Das Hochladen war erfolgreich</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_failed">Beim Hochladen ist ein Fehler aufgetreten</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unbekanntes Metadatenschema in der Überschrift</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unbekanntes Metadatenelement in der Überschrift</message>
-    <message key="xmlui.administrative.metadataimport.flow.import_successful">Import erfolgreich</message>
-    <message key="xmlui.administrative.metadataimport.flow.import_failed">Import fehlgeschlagen</message>
-    <message key="xmlui.administrative.metadataimport.flow.over_limit">Die Anzahl der durchzuführenden Änderungen übersteigt die maximale erlaubte Anzahl. Beschränken Sie Ihre Änderungen oder ändern Sie bulkedit.gui-item-limit in dspace.cfg</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">CSV Hochladen</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Metadaten importieren</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Metadaten importieren</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Metadaten importieren</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">Änderungen</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Es wurden keine Änderungen gefunden</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Neues Dokument</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Das Hochladen war erfolgreich</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Beim Hochladen ist ein Fehler aufgetreten</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unbekanntes Metadatenschema in der Überschrift</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unbekanntes Metadatenelement in der Überschrift</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import erfolgreich</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import fehlgeschlagen</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Die Anzahl der durchzuführenden Änderungen übersteigt die maximale erlaubte Anzahl. Beschränken Sie Ihre Änderungen oder ändern Sie bulkedit.gui-item-limit in dspace.cfg</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Bearbeitung erfolgreich</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Änderungen, die an dem Dokument durchgeführt wurden:</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Hinzugefügt: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Entfernt: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Zu besitzender Sammlung hinzugefügt</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Aus besitzender Sammlung entfernt</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">In Sammlung gespiegelt</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Spiegelung aus Sammlung gelöscht</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ressource gelöscht</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ressource zurückgezogen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ressource wieder frei gegeben</message>
-        
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Hinzufügen: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Entfernen: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Zur neuen besitzenden Sammlung hinzufügen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Aus besitzender Sammlung entfernen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">In Sammlung spiegeln</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Spiegelung in Sammlung löschen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Anstehenden Änderungen für das Dokument</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Änderungen durchführen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Die anstehenden Änderungen sind unten zur Kontrolle aufgeführt.</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Ressource löschen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Ressource zurückziehen</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Ressource wieder veröffentlichen</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">CSV Hochladen</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Bearbeitung erfolgreich</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Änderungen, die an dem Dokument durchgeführt wurden:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Hinzugefügt: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Entfernt: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Zu besitzender Sammlung hinzugefügt</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Aus besitzender Sammlung entfernt</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">In Sammlung gespiegelt</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Spiegelung aus Sammlung gelöscht</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ressource gelöscht</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ressource zurückgezogen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ressource wieder frei gegeben</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Hinzufügen: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Entfernen: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Zur neuen besitzenden Sammlung hinzufügen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Aus besitzender Sammlung entfernen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">In Sammlung spiegeln</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Spiegelung in Sammlung löschen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Anstehenden Änderungen für das Dokument</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Änderungen durchführen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Die anstehenden Änderungen sind unten zur Kontrolle aufgeführt.</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Ressource löschen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Ressource zurückziehen</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Ressource wieder veröffentlichen</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Dokumente Spiegeln</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Dokumente spiegeln</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Dokumente spiegeln - Dokumente von anderen Sammlungen spiegeln</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Sammlung: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Dieses Werkzeug erlaubt es Administratoren und Sammlungsadministratoren Dokumente von einer Sammlung in eine andere zu spiegeln. Sie können nach Dokumente suchen, um diese zu spiegeln oder sich die Liste der aktuell gespiegelten Dokumente anzeigen lassen.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statistik</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} von {1}</strong> Dokument(en) in dieser Sammlung ist/sind aus anderen gespiegelt</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Suche</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Dokumente suchen</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Gespiegelte Dokumente auflisten</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">(erfordert ADD (Hinzufügen) Recht für diese Sammlung)</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Dokumente suchen</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Dokumente suchen</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Treffer: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Ausgewählte Dokumente spiegeln</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Sammlung</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Titel</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Auflistung gespiegelter Dokumente</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Auflistung gespiegelter Dokumente</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Auflistung gespiegelter Dokumente</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Spiegelungen löschen</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Sammlung</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Titel</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Sie benötigen REMOVE (Entfernen) Rechte an dieser Sammlung, um Spiegelungen zu löschen.</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">Sammlungen</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Metadaten bearbeiten</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Bearbeiterrollen zuordnen</message>	
-	<message key="xmlui.administrative.collection.general.options_curate">Pflegen</message>
-    <message key="xmlui.administrative.collection.general.options_queue">Zu Bearbeiten</message>
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">Sammlungen</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Metadaten bearbeiten</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Bearbeiterrollen zuordnen</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Pflegen</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Zu Bearbeiten</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Bearbeiterrollen der Sammlung bearbeiten</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rollen</message>
@@ -1605,16 +1765,16 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Bearbeiten Schritt</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Veröffentlichungsberechtigte</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Standard lesender Zugriff</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(nur für Systemadministratoren)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Gruppe auf Repositoriumsebene, nur für Systemadministratoren)</message>	
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(Sie haben nicht die Berechtigung dies zu konfigurieren)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-    <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Pflege der Sammlung: {0}</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.title">Pflege einer Sammlung</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Kurator</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Aufgabe</message>
-        
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Pflege der Sammlung: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Pflege einer Sammlung</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Kurator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Aufgabe</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Löschung bestätigen</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Bestätigen</message>
@@ -1623,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">alle Dokumente und unvollendeten Veröffentlichungen in dieser Sammlung</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">den kompletten Inhalt und die Metadaten dieser Dokumente</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Alle Rechte</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Rollenlöschung bestätigen</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Bestätigen</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Bestätigen Sie die Löschung der Rolle: {0}</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Sind Sie sicher, dass diese Rolle gelöscht werden soll? Wenn Sie diese Gruppe löschen, erhalten alle Benutzer READ (Lese) Rechte für alle Dokumente, die ab jetzt in der Sammlung veröffentlicht werden. Diese Änderung wirkt nicht retrospektiv. Bereits in der Sammlung vorhandene Dokumente behalten ihre Rechte.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Sind Sie sicher, dass diese Rolle gelöscht werden soll? Alle Änderungen und Anpassungen an dieser Gruppe: {0} gehen verloren und müssen ggf. neu angelegt werden.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Metadaten der Sammlung bearbeiten</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadaten</message>
@@ -1650,13 +1810,14 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Logo entfernen</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Sammlung löschen</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Änderungen speichern</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(nur für Systemadministratoren)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Sammlung anlegen</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Sammlung anlegen</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Geben Sie die Informationen zur Sammlung: {0} ein</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Anlegen</message>
+
 	<!-- General to the harvesting options under collection -->
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Harvesting-Einstellungen für Sammlungen</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
@@ -1665,7 +1826,7 @@
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Dies ist eine Standard-DSpace-Sammlung</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Diese Sammlung bezieht ihren Inhalt via Harvesting aus einer externen Quelle.</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Speichern</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Die per Harvesting bearbeitete Sammlung</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Harvesting Optionen</message>
@@ -1681,7 +1842,7 @@
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Beziehe die Metadaten über Harvesting und referenziere die Dateien (hierfür ist ORE Unterstützung Voraussetzung).</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Beziehe sowohl die Metadaten alsauch die Dateien über Harvesting (hierfür ist ORE Unterstützung Voraussetzung).</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Test-Einstellungen</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Die per Harvesting bearbeitete Sammlung</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
@@ -1720,15 +1881,15 @@
 	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Generator Einstellungen</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE Quelle</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Einstellungen</message>	
-	
-		<!-- General tags for community management -->
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Einstellungen</message>
+
+	<!-- General tags for community management -->
 	<message key="xmlui.administrative.community.general.community_trail">Bereiche</message>
 	<message key="xmlui.administrative.community.general.options_metadata">Metadinformationen bearbeiten</message>
 	<message key="xmlui.administrative.community.general.options_roles">Bearbeiterrollen vergeben</message>
-	<message key="xmlui.administrative.community.general.options_curate">Bestandspflege</message>
-    <message key="xmlui.administrative.community.general.options_queue">Zu Bearbeiten</message>
-	
+        <message key="xmlui.administrative.community.general.options_curate">Bestandspflege</message>
+        <message key="xmlui.administrative.community.general.options_queue">Zu Bearbeiten</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
 	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Bearbeiten der Rollen für den Bereich</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Rollen</message>
@@ -1743,14 +1904,14 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Zugehörige Gruppe</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administratoren</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(nur für Systemadministratoren)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-    <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Bereichspflege: {0}</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.title">Bereichspflege</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.trail">Kurator</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Aufgabe</message>
-        		
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Bereichspflege: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Bereichspflege</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Kurator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Aufgabe</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Löschung bestätigen</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Bestätigen</message>
@@ -1766,7 +1927,7 @@
 	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Bestätigen</message>
 	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Löschen der Rolle: {0} bestätigen</message>
 	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Sind Sie sicher, dass diese Rolle gelöscht werden soll? Alle Änderungen und Anpassungen an der Gruppe {0} sind damit unwiderruflich verloren.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Bereichsmetadaten bearbeiten</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadaten</message>
@@ -1781,14 +1942,14 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Aktuelles Logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Logo entfernen</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Bereich löschen</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Bereich anlegen</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Bereich anlegen</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Metadaten des neuen Teilbereiches von {0} ein.</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Metadaten des Hauptbereiches</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Anlegen</message>
-	
+
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
 	<message key="xmlui.administrative.ControlPanel.title">Systeminformationen</message>
@@ -1812,18 +1973,18 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Zugeordneter Speicher</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Benutzer Speicher</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Freier Speicher</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Information</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Verzeichnis</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Arbeitsverzeichnis</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Hauptcache Größe: ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Cache sofort löschen)</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistente Cache Größe ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Flüchtige Cache Größe ({0})</message>	
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Information</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Verzeichnis</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Arbeitsverzeichnis</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Hauptcache Größe: ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Cache sofort löschen)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistente Cache Größe ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Flüchtige Cache Größe ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">DSpace Einstellungen</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">DSpace Installationsverzeichnis</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">DSpace Basis-URL</message>
-	<message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">DSpace Name des Hosts</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_name">Name der Seite</message>
 	<message key="xmlui.administrative.ControlPanel.db_name">Datenbank Name</message>
@@ -1847,11 +2008,11 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 Minuten</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 Stunde</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Aktuellen Countdown behalten</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Sitzungen verwalten</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Authentifizierte Sitzungen weiterhin zulassen</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Authentifizierungen einschränken, aber laufende Sitzungen beibehalten.</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Authentifizierungen einschränken und laufende Sitzungen beenden.</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Bitte beachten Sie:</strong> Administratoren der Seite werden vom Sizungsmanagement nicht tangiert.</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Sitzungen verwalten</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Authentifizierte Sitzungen weiterhin zulassen</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Authentifizierungen einschränken, aber laufende Sitzungen beibehalten.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Authentifizierungen einschränken und laufende Sitzungen beenden.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktivieren</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Deaktivieren</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Laufende Aktivität ({0} maximale Seiten)</message>
@@ -1864,14 +2025,14 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP-Adressen</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-Agent</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonym {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonym {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Abgesehen von Ihren eigen gab es keine Seitenzugriffe in den letzen {0} Tagen.</message>
-		
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">Benutzen Sie die Reiter, um zur entsprechenden Information zu gelangen</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} Minuten</strong>: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Keine Berechtigung</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">Keine Berechtigung</message>
@@ -1880,18 +2041,18 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">Systemadministratoren</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Als anderer Benutzer einloggen.</message>
-
-    <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-    <message key="xmlui.administrative.CurateForm.title">Datenpflege</message>
-    <message key="xmlui.administrative.CurateForm.trail">Datenpflege - Aufgaben</message>
-    <message key="xmlui.administrative.CurateForm.object_label_name">Handle eines DSpace Objektes</message>
-    <message key="xmlui.administrative.CurateForm.object_hint">Hinweis: Geben Sie [ihr-handle-prefix]/0 ein um ein Aufgabe systemweit durchzuführen (nicht alle Aufgaben können auf allen Objekten ausgeführt werden).</message>
-    <message key="xmlui.administrative.CurateForm.task_label_name">Aufgabe</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">Datenpflege</message>
+        <message key="xmlui.administrative.CurateForm.trail">Datenpflege - Aufgaben</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle eines DSpace Objektes</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hinweis: Geben Sie [ihr-handle-prefix]/0 ein um ein Aufgabe systemweit durchzuführen (nicht alle Aufgaben können auf allen Objekten ausgeführt werden).</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Aufgabe</message>
     <!-- Used by Curate<DSO>Form classes also -->
-    <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Wählen Sie aus den folgenden Gruppen</message>	
-	
-	
-	    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Wählen Sie aus den folgenden Gruppen</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                      Statistics Aspect
 
@@ -1911,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Dateiabrufe</message>
     <message key="xmlui.statistics.Navigation.title">Statistik</message>
     <message key="xmlui.statistics.Navigation.usage.view">Benutzungsstatistik</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Suchstatistik</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Geschäftsgangstatistik</message>
     <message key="xmlui.statistics.trail">Statistik</message>
@@ -1958,14 +2120,29 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Einzelnutzer Begutsachtung Aktion</message>
 
 
-	
-	
-	
-	
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -1974,20 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Diese Seite verwendet Manakin, das neue DSpace Front-End, welches von den Texas A&amp;M University 
-			Libraries entwickelt wurde. Das Front-End ist extrem flexibel und kann über Manakin Aspekte und XLS basierte Themen angepasst werden. 
-			Weiterführende Informationen finden Sie unter:
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> und
-			<a href="http://dspace.org">http://dspace.org</a>                            
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Kontakt</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Feedback abschicken</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace Repositorium (Manakin basiert)</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Profil: </message>
@@ -1998,15 +2175,15 @@
 	<message key="xmlui.dri2xhtml.structural.search-advanced">Erweiterte Suche</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-community">In diesem Bereich</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">In dieser Sammlung</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">Vorherige Seite</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">Anzeige der Dokumente {0}-{1} von {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">Nächste Seite</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons Lizenz</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Originallizenz</message>
-		
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -2018,7 +2195,7 @@
 		Sie können entweder die allgemeingültige Schablone in dri2xhtml überschreiben oder ihre eigene Schablone 
 		anlegen, um Ihrem Profil gerecht zu werden.
     </message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Vorschau</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Titel</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
@@ -2028,25 +2205,25 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Datum</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Verlag</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Schlagwort</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Dateien zu dieser Ressource</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Dateien</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Größe</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Anzeige</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Beschreibung</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Öffnen</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Öffnen<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Zu diesem Dokument gibt es keine Dateien.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">Bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Die folgenden Lizenzbestimmungen sind mit dieser Ressource verbunden:</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Solange nicht anders angezeigt, wird die Lizenz wie folgt beschrieben: </message>	
-	
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Solange nicht anders angezeigt, wird die Lizenz wie folgt beschrieben: </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		Die zusammenfassende Darstellung einer Sammlung ist noch nicht implementiert. Sie können dies tun, 
 		indem Sie das dri2xhtml template "collectionSummaryView" überschreiben.
@@ -2055,14 +2232,12 @@
 		Die zusammenfassende Darstellung eines Bereiches ist noch nicht implementiert. Sie können dies tun, 
 		indem Sie das dri2xhtml template "communitySummaryView" überschreiben.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Das Logo der Sammlung</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Das Logo des Bereiches</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Kein Logo</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.news">Aktuelles</message>	
-	
-		
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Aktuelles</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
@@ -2070,18 +2245,23 @@
 	    QDC verwenden, sollten Sie den QDC crosswalk für DSpace Dokumente und entweder DIM oder MODS zur Verarbeitung von Bereichen 
 	    und Sammlungen verwenden.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core Elemente</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core Ausdrücke</message>
-	
-	
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Vorschau</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Datum</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Titel</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
-	
-	  <!--###### File Format MIME Type Mappings ######-->
+
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+
+  <!--###### File Format MIME Type Mappings ######-->
 
   <!-- Application-based formats -->
   <message key="xmlui.dri2xhtml.mimetype.application/marc">MARC Datensatz</message>
@@ -2155,8 +2335,8 @@
   <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 Video</message>
   <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 Video</message>
   <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime Video</message>
-  
-    <!-- explanatory messages for choice authority confidence values -->
+
+  <!-- explanatory messages for choice authority confidence values -->
   <message key="xmlui.authority.confidence.description.cf_unset">Dieser Wert wurde niemals validiert.</message>
   <message key="xmlui.authority.confidence.description.cf_novalue">Im Normdatenbereich gibt es keinen passenden Wert.</message>
   <message key="xmlui.authority.confidence.description.cf_rejected">Die Normdatenreferenz empfiehlt, diese Veröffentlichung abzulehnen</message>
@@ -2182,12 +2362,20 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Ergebniss(e) @1@ bis @2@ von @3@ für "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Laden der Auswahldaten fehlgeschlagen: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name des Herausgebers</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Herausgeber nachschlagen</message>
   <!-- Params are: search-value -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Nicht-Referenzwert: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in der Form "Nachname, Vorname"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Nachname, z. B. "Müller"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Vorname(n) z. B. "Michael"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Personennamenreferenzdatenbank</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Lokaler Wert "@1@" (nicht in Referenzdatenbank)</message>
 
   <!-- mobile theme -->
   <message key="xmlui.mobile.home_mobile">DSpace Mobil</message>
@@ -2200,314 +2388,107 @@
   <message key="xmlui.mobile.related_google_scholar">verwandt</message>
   <message key="xmlui.mobile.items_in_google_scholar">Dokumente in Google Scholar</message>
   <message key="xmlui.mobile.download">Download</message>
-  
-  <!-- Choice Lookup - sample config for dc.contributor.author field -->
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in der Form "Nachname, Vorname"</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Nachname, z. B. "Müller"</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Vorname(n) z. B. "Michael"</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Personennamenreferenzdatenbank</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Lokaler Wert "@1@" (nicht in Referenzdatenbank)</message>
-
-  <!-- Versioning -->
-  <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Eine neue Version dieses Dokumentes anlegen</message>
-  <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Versionsgeschichte anzeigen</message>
-
-  <message key="xmlui.aspect.versioning.VersionItemForm.title">Neue Version anlegen</message>
-  <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
-  <message key="xmlui.aspect.versioning.VersionItemForm.head1">Neue Version des Dokumentes: {0} anlegen</message>
-  <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
-  <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Version aktualisieren</message>
-  <message key="xmlui.aspect.versioning.VersionItemForm.summary">Grund für die neue Version</message>
-
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Version aktualisieren</message>
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Version des Dokumentes: {0} aktualisieren</message>
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Version aktualisieren</message>
-  <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Zusammenfassung</message>
 
 
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Löschen bestätigen</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Löschen bestätigen</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Löschen bestätigen</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Sind Sie sicher, dass dieser Version(en) gelöscht werden sollen? </message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">Bitte Beachten: gelöschte Versionen werden nicht länger zugänglich sein.</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Dokument</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Bearbeiter</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Datum</message>
-  <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Zusammenfassung</message>
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Eine neue Version dieses Dokumentes anlegen</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Versionsgeschichte anzeigen</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Neue Version anlegen</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Neue Version des Dokumentes: {0} anlegen</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Version aktualisieren</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Grund für die neue Version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Version aktualisieren</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Version des Dokumentes: {0} aktualisieren</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Version aktualisieren</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Zusammenfassung</message>
 
 
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Version wiederherstellen</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Version wiederherstellen</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Version wiederherstellen</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Sind Sie sicher, dass Sie diese Version wiederherstellen möchten:</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Bearbeiter</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Datum</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Zusammenfassung</message>
-  <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Wiederherstellen</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Löschen bestätigen</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Löschen bestätigen</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Löschen bestätigen</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Sind Sie sicher, dass dieser Version(en) gelöscht werden sollen? </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">Bitte Beachten: gelöschte Versionen werden nicht länger zugänglich sein.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Dokument</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Bearbeiter</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Datum</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Zusammenfassung</message>
 
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Versionsgeschichte</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Dokument</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Bearbeiter</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Datum</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Zusammenfassung</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Aktionen</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Wiederherstellen</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Aktualisieren</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">* Ausgewählte Version(en)</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Version(en) löschen</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Zurück</message>
-  <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(nur für Sammlungsadministratoren)</message>
-  <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Hinweis</message>
-  <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Dies ist nicht die aktuellste Version von diesem Dokument. Die aktuellste Version finden Sie unter: </message>
-  <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Hinweis</message>
-  <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Eine neuere Fassung von diesem Dokument befindet sich zur Zeit im Geschäftsgang.</message>
-  <!-- End Versioning -->
-  
-  <!-- Start Discovery -->
 
-  <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Typ</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Erscheinungsdatum</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Erscheinungsdatum</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Version wiederherstellen</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Version wiederherstellen</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Version wiederherstellen</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Sind Sie sicher, dass Sie diese Version wiederherstellen möchten:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Bearbeiter</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Datum</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Zusammenfassung</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Wiederherstellen</message>
 
-  <!-- Site Leve Recently Added Content -->
-  <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Neuzugänge</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Versionsgeschichte</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Dokument</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Bearbeiter</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Datum</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Zusammenfassung</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Aktionen</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Wiederherstellen</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Aktualisieren</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">* Ausgewählte Version(en)</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Version(en) löschen</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Zurück</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(nur für Sammlungsadministratoren)</message>
 
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Kind</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Verlag</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Hinweis</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Dies ist nicht die aktuellste Version von diesem Dokument. Die aktuellste Version finden Sie unter: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Hinweis</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Eine neuere Fassung von diesem Dokument befindet sich zur Zeit im Geschäftsgang.</message>
 
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Überordnung</message>
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
 
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Ergebnisse gruppieren nach</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Nichts</message>
 
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Veröffentlichung</message>
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
 
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Bereich</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Sammlung</message>
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
 
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Serie</message>
 
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Auflistung nach: Autor</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Auflistung nach: Titel</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Auflistung nach: Schlagwort</message>
-        
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Auflistung nach: Kurzfassung</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Auflistung nach: Serie</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Auflistung nach: Sponsor</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Auflistung nach: Kennung</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Auflistung nach: Sprache (ISO)</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Auflistung nach: Stichwort</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Auflistung nach: Kategorie</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Auflistung nach: Mitarbeiter</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Auflistung nach: Urheber</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Auflistung nach: Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Auflistung nach: Beschreibung</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Auflistung nach: Beziehung</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Auflistung nach: Mime-Typ</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Auflistung nach: Sonstige Beteiligte</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Auflistung nach: Betreuer</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Auflistung nach: Abteilung</message>
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Auflistung nach: Erscheinungsdatum</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
 
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Titel</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Erscheinungsdatum</message>
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
-  <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Anzeige der Dokumente {0}-{1}</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
 
-  <message key="xmlui.Discovery.AbstractSearch.type_author">Filtern nach: Autor</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message>
-  <message key="xmlui.Discovery.AbstractSearch.type_subject">Filtern nach: Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Schlagwort</message>
-  <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Erscheinungsdatum</message>
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
-  <message key="xmlui.Discovery.AbstractSearch.startswith">Anfang</message>
-  <message key="xmlui.Discovery.AbstractSearch.startswith.help">oder geben Sie die ersten Zeichen ein:</message>
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
 
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Sortiermöglichkeiten:</message>
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Relevanz</message>
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Titel absteigend</message>
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Erscheinungsdatum absteigend</message>
-
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Titel aufsteigend</message>
-  <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Erscheinungsdatum aufsteigend</message>
-
-  <message key="xmlui.Discovery.AbstractSearch.rpp">Ergebnisse pro Seite:</message>
-
-  <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Filter hinzufügen</message>
-  <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Anwenden</message>
-  <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Entfernen</message>
-  <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Neue Filter:</message>
-  <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Aktuelle Filter:</message>
-  <message key="xmlui.Discovery.AbstractSearch.filters.display">Filter hinzufügen</message>
-
-  <message key="xmlui.discovery.SearchFacetFilter.no-results">Keine Filterwerte gefunden</message>
-
-  <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Entdecke</message>
-  <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... mehr</message>
-
-  <message key="xmlui.Discovery.SimpleSearch.search_scope">Suche</message>
-  <message key="xmlui.discovery.SimpleSearch.search_label">Suche</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter_head">Filter</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter_help">Verwenden Sie Filter, um die Suchergebnisse zu verfeinern.</message>
-
-  <message key="xmlui.Discovery.SimpleSearch.filter.contains">Enthält</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter.equals">Entspricht</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter.authority">Kennung</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">enthält nicht</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter.notequals">entspricht nicht</message>
-  <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">Keine Kennung</message>
-    
-  <message key="xmlui.Discovery.RelatedItems.head">Verwandte Dokumente</message>
-  <message key="xmlui.Discovery.RelatedItems.help">Anzeige der Dokumente mit ähnlichem Titel, Autor, Urheber und Thema.</message>
-
-  <message key="xmlui.Discovery.AbstractSearch.head1_community">Anzeige von {0} der {1} Treffer für den Bereich: {2}. <span class="searchTime">({3} Sekunden)</span></message>
-  <message key="xmlui.Discovery.AbstractSearch.head1_collection">Anzeige von {0} der {1} Treffer für die Sammlung: {2}. <span class="searchTime">({3} Sekunden)</span></message>
-  <message key="xmlui.Discovery.AbstractSearch.head1_none">Anzeige von {0} der {1} Treffer. <span class="searchTime">({2} Sekunden)</span></message>
-
-  <message key="xmlui.Discovery.AbstractSearch.head2">Bereiche und Sammlungen, die Ihrer Suche entsprechen.</message>
-  <message key="xmlui.Discovery.AbstractSearch.head3">Dokumente, die Ihrer Suche entsprechen.</message>
-  <!-- End Discovery -->
-
-  <!--   Start Sword Client  -->
-  <message key="xmlui.swordclient.Navigation.context_head">Sword Kopie</message>
-  <message key="xmlui.swordclient.Navigation.context_copy">Dokument in ein anderes Repositorium kopieren</message>
-  <message key="xmlui.swordclient.general.SwordCopy_trail">Sword Kopie</message>
-  <message key="xmlui.swordclient.general.main_head">Kopie von Dokument: {0}</message>
-
-  <message key="xmlui.swordclient.SelectTarget.title">Sword Kopie - Ziel</message>
-  <message key="xmlui.swordclient.SelectTarget.trail">Ziel auswählen</message>
-  <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-  <message key="xmlui.swordclient.SelectTarget.other_url">Alternative URL</message>
-  <message key="xmlui.swordclient.SelectTarget.username">Benutzername</message>
-  <message key="xmlui.swordclient.SelectTarget.password">Passwort</message>
-  <message key="xmlui.swordclient.SelectTarget.on_behalf_of">Im Auftrag von</message>
-
-  <message key="xmlui.swordclient.SelectTargetAction.url_error">Ungültige URL</message>
-  <message key="xmlui.swordclient.SelectTargetAction.username_error">Ungültiger Benutzername</message>
-  <message key="xmlui.swordclient.SelectTargetAction.password_error">Ungültiges Passwort</message>
-  <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Beim Anforden des Sword Servicedokuments ist ein Fehler aufgetreten: {0}</message>
-
-  <message key="xmlui.swordclient.SelectCollection.title">Sword Zielsammlungen</message>
-  <message key="xmlui.swordclient.SelectCollection.trail">Sammlung(en) auswählen</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_head">Sammlung: {0}</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_title">Titel: {0} </message>
-  <message key="xmlui.swordclient.SelectCollection.collection policy">Policy: {0}</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_mediation">Mediation: {0}</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_file_types">Dateitypen: {0}</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Paketformate: {0}</message>
-  <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Hier veröffentlichen</message>
-
-  <message key="xmlui.swordclient.SelectCollection.sub_service_target">Ziel des untergeordneten Dienstes</message>
-  <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Servicedokument des untergeordneten Dienstes</message>
-
-  <message key="xmlui.swordclient.SelectPackagingAction.head">Sammlung:{0}</message>
-  <message key="xmlui.swordclient.SelectPackagingAction.title">Titel: {0}</message>
-  <message key="xmlui.swordclient.SelectPackagingAction.policy">Policy: {0} </message>
-  <message key="xmlui.swordclient.SelectPackagingAction.mediation">Mediation:{0} </message>
-  <message key="xmlui.swordclient.SelectPackagingAction.file_types">Dateityp</message>
-  <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Paketformat</message>
-  <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Das gewählte Paketformat wird nicht unterstützt</message>
-
-  <message key="xmlui.swordclient.DepositAction.success">Dokument erfolgreich kopiert</message>
-  <message key="xmlui.swordclient.DepositAction.package_error">Paketformatfehler</message>
-  <message key="xmlui.swordclient.DepositAction.invalid_handle">Ungültiges Handle</message>
-  <message key="xmlui.swordclient.DepositAction.package_error">Bei Erstellung des Paketobjektes ist ein Fehler aufgetreten.</message>
-  <message key="xmlui.swordclient.DepositAction.error">Beim Deposit ist ein Fehler aufgetreten: {0}</message>
-
-  <message key="xmlui.swordclient.SwordResponse.title">Sword Antwort</message>
-  <message key="xmlui.swordclient.SwordResponse.trail">Sword Antwor</message>
-  <!--   End Sword Client  -->
-
-  <!-- Start XMLWorkflow -->
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Aktionen, die Sie durchführen können:</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Aufgabe sich selbst zuordnen.</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Aufgabe übernehmen</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Aufgabe im Aufgabenpool belassen.</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Aufgabe nicht übernehmen</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Zurück zur Übersicht</message>
-  <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Annehmen/Ablehnen Schritt</message>
-
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Aufgabe durchführen: Annehmen/Ablehnen des Dokumentes</message>
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Aktionen, die Sie durchführen können:</message>
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Wenn Sie das Dokument begutachtet haben und es <strong>not</strong> nicht angenommen werden kann, wählen Sie "Ablehnen".  Sie haben dann die Möglichkeit, den Grund anzugeben und mögliche Verbesserungen aufzuzeigen.</message>
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Dokument ablehnen</message>
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Wenn Sie das Dokument begutachtet haben und es in die Sammlung aufgenommen werden soll, wählen Sie "Annehmen".</message>
-  <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Dokument annehmen</message>
-
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Aufgabe durchführen: Dokument Annehmen/Ablehnen/Bearbeiten</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Aktionen, die Sie durchführen können:</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Wenn Sie das Dokument begutachtet haben und es <strong>not</strong> nicht angenommen werden kann, wählen Sie "Ablehnen".  Sie haben dann die Möglichkeit, den Grund anzugeben und mögliche Verbesserungen aufzuzeigen, so dass das Dokument ggf. neu eingereicht werden kann.</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Dokument ablehnen</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Wenn Sie das Dokument begutachtet haben und es in die Sammlung aufgenommen werden soll, wählen Sie "Annehmen".</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Dokument annehmen</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Wählen Sie dies aus, um das Dokument zu bearbeiten.</message>
-  <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Metadaten bearbeiten</message>
-
-  <message key="xmlui.XMLWorkflow.step.unknown">Unknown state</message>
-
-  <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Aufgabe durchführen: Gutachter zuordnen</message>
-  <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Verwenden Sie das Suchfeld, um eine Person als Gutachter auszusuchen.</message>
-  <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Suche nach Gutachter</message>
-  <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Suche nach Person</message>
-  <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Als Gutachter auswählen</message>
-
-  <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Wenn Sie nicht für die Begutachtung zuständig sind, so können Sie die Aufgabe ablehnen, indem Sie auf "Aufgabe ablehnen" klicken.</message>
-  <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Aufgabe ablehnen</message>
-
-  <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Eingereichtes Dokument begutachten</message>
-  <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Eingereichtes Dokument begutachten</message>
-  <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Geben Sie das Ergebnis für das eingereichte Dokument ein.</message>
-
-  <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Geschäftsgang Übersicht</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Geschäftsgang Übersicht</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Geschäftsgang Übersicht</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Schritt</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Dokument</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Sammlung</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Eingereicht von</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Dokument an den Einreichenden zurücksenden</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Dokumente löschen</message>
-  <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Keine Treffer</message>
-
-  <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Anzeige Dokument im Geschäftsgang: {0}</message>
-  <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Dokument im Geschäftsgang anzeigen</message>
-
-  <message key="xmlui.XMLWorkflow.default.reviewstep">Annehmen/Ablehnen</message>
-  <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Annehmen/Ablehnen</message>
-  <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Annehmen/Ablehnen</message>
-
-  <message key="xmlui.XMLWorkflow.default.editstep">Annehmen/Bearbeiten/Ablehnen Schritt</message>
-  <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Annehmen/Bearbeiten/Ablehnen</message>
-  <message key="xmlui.XMLWorkflow.default.editstep.editaction">Annehmen/Bearbeiten/Ablehnen</message>
-
-  <message key="xmlui.XMLWorkflow.default.finaleditstep">Abschließend Annehmen/Bearbeiten</message>
-  <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Abschließend Annehmen/Bearbeiten</message>
-  <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Abschließend Annehmen/Bearbeiten</message>
-
-  <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Gutachter zuordnen</message>
-  <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Gutachter zuordnen</message>
-
-  <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Begutachtung durch eine einzelne Person</message>
-  <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Eingereichtes Dokument begutachten</message>
-
-  <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Score review</message>
-  <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Score review</message>
-  <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Score review</message>
-  <!-- End XMLWorkflow -->  
-  
-  
-  
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_el.xml
+++ b/src/main/webapp/i18n/messages_el.xml
@@ -1,28 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="el" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">DSpace Αρχική</message>
 	<message key="xmlui.general.search">Αναζήτηση</message>
@@ -35,45 +25,60 @@
 	<message key="xmlui.general.delete">Διέγραψε</message>
 	<message key="xmlui.general.next">Επόμενο</message>
 	<message key="xmlui.general.untitled">Χωρίς τίτλο</message>
-	
-	
-	<!-- 
-		Page not found keys 
-		
+        <message key="xmlui.general.perform">Perform</message>
+        <message key="xmlui.general.queue">Queue</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">Δε βρέθηκε η σελίδα</message>
 	<message key="xmlui.PageNotFound.head">Δε βρέθηκε η σελίδα</message>
 	<message key="xmlui.PageNotFound.para1">Δεν βρέθηκε η σελίδα που ζητήσατε.</message>
-	
-	
+
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Only site administrators may assume login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">Το Ιδρυματικό καταθετήριο Dspace αποθηκεύει, αρχειοθετεί, διατηρεί και διανέμει ψηφιακό ερευνητικό υλικό.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">Η εικόνα του καναλιού</message>
 	<message key="xmlui.feed.untitled">Χωρίς τίτλο</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">Σημείωση</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Αποτελέσματα αναζήτησης για την κοινότητα: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Αποτελέσματα αναζήτησης για τη συλλογή: {0}</message>
@@ -84,9 +89,9 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Η αναζήτηση δεν παρήγαγε αποτελέσματα.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Όλο το DSpace</message>
 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Τίτλο</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">ημερομηνία δημοσίευσης</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Ημερομηνία υποβολής</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Τίτλο</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">ημερομηνία δημοσίευσης</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Ημερομηνία υποβολής</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">Σχετικότητα</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ταξινόμηση τεκμηρίων κατά</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">Με σειρά</message>
@@ -112,31 +117,32 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Αναγνωριστικό</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Γλώσσα (ISO)</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Λέξη κλειδί</message>
-	
-	<!--  some common other possibilities for Advanced Search Fields -->
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Συντελεστής</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Δημιουργός</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Περιγραφή</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Σχεση</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Τύπος Mime</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Άλλος συντελεστής</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Επιβλέπων</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Τμήμα</message>
-	
-        <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Πλήρες κείμενο</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">ΚΑΙ</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">Ή</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">ΟΧΙ</message>
-	
-	
+
+   <!--  some common other possibilities for Advanced Search Fields -->
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Συντελεστής</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Δημιουργός</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Περιγραφή</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Σχεση</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Τύπος Mime</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Άλλος συντελεστής</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Επιβλέπων</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Τμήμα</message>
+
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Πλήρες κείμενο</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">ΚΑΙ</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">Ή</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">ΟΧΙ</message>
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ή εισάγετε τα πρώτα γράμματα:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Πλοήγηση σε τεκμήρια που ξεκινούν με τα γράμματα</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Μεταβείτε σε ένα σημείο του καταλόγου:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Επιλέξτε μήνα)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Επιλέξτε έτος)</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Μεταβείτε σε ένα σημείο του καταλόγου:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Επιλέξτε μήνα)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Επιλέξτε έτος)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ή πληκτρολογήστε μήνα: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Πλοηγηθείτε στα τεκμήρια του δεδομένου έτους.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sorry, there are no results for this browse.</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Ταξινόμηση κατά: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Σειρά: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Αποτελέσματα: </message><!-- /Page -->
@@ -159,17 +165,37 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Πλοήγηση {0} ανά Θέμα {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Πλοήγηση {0} ανά Θέμα</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Πλοήγηση {0} ανά Τίτλο {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Πλοήγηση {0} ανά Τίτλο</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Πλοήγηση {0} ανά ημερομηνία δημοσίευσης {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Πλοήγηση {0} ανά ημερομηνία δημοσίευσης</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Πλοήγηση {0} ανά ημερομηνία υποβολής {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Πλοήγηση {0} ανά ημερομηνία υποβολής</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Αναζήτηση σε</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Όλο το Έυρηκα!</message>
@@ -180,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Ημερομηνία</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Σύνθετη αναζήτηση</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Πρόσφατες υποβολές</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Λίστα κοινοτήτων</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Λίστα κοινοτήτων</message>
@@ -199,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Υπο-κοινότητες μέσα σε αυτή την κοινότητα</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Συλλογές μέσα σε αυτή την κοινότητα</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Πρόσφατες υποβολές</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Επικοινωνήστε μαζί μας</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Επικοινωνήστε μαζί μας</message>
@@ -209,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">On-line φόρμα</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Feedback</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Στείλτε σχόλια</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Στείλτε σχόλια</message>
@@ -219,23 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Αυτή η διεύθυνση θα χρησιμοποιηθεί για τα σχόλιά σας.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Σχόλια</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Αποστολή Σχολίων</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Στείλτε σχόλια</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Στείλτε σχόλια</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Σχόλια εστάλησαν</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Τα σχόλιά σας ελήφθησαν.</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Αναζήτηση στο DSpace</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Εισάγετε κείμενο στο πλαίσιο κάτω για να αναζητήσετε στο DSpace</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Προβολή τεκμηρίου</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Αυτό το τεκμήριο εμφανίζεται στις ακόλουθες συλλογές</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Εμφάνιση απλής εγγραφής</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Εμφάνιση πλήρους εγγραφής</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Πλοήγηση</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Όλο το DSpace</message>
@@ -254,7 +278,7 @@
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Αναζήτηση</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Αναζήτηση σε</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Αναζήτηση πλήρους κειμένου</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Αυτό το τεκμήριο έχει περιορισμούς πρόσβασης</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Περιορισμένο</message>
@@ -274,46 +298,158 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">τεκμήριο</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">πόρος</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">unknown</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Απαγορεύεται η πρόσβαση σε αυτό το τεκμήριο</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Απαγορεύεται η πρόσβαση σε αυτό το τεκμήριο</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Το τεκμήριο που προσπαθείτε να ανακτήσετε έχει περιορισμόυς που απαιτούν επιπλέον δικαιώματα. Παρακαλώ συνδεθείτε για να αποκτήσετε πρόσβαση.</message>
 
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Μηνιαίες αναφορές</message>
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Συγκεντρωτικά στατιστικά</message>
-	
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Δεν υπάρχουν διαθέσιμες αναφορές</message>
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Δεν υπάρχουν διαθέσιμες αναφορές για την υπηρεσία. Παρακαλώ δοκιμάστε αργότερα.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Μηνιαίες αναφορές</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Συγκεντρωτικά στατιστικά</message>
 
-	<!-- Authentication messages used for bitstream authentication -->	
-	<message key="xmlui.BitstreamReader.auth_header">Αυτό το αρχείο έχει περιορισμούς πρόσβασης</message>	
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Δεν υπάρχουν διαθέσιμες αναφορές</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Δεν υπάρχουν διαθέσιμες αναφορές για την υπηρεσία. Παρακαλώ δοκιμάστε αργότερα.</message>
+
+    <!-- Authentication messages used for bitstream authentication -->
+	<message key="xmlui.BitstreamReader.auth_header">Αυτό το αρχείο έχει περιορισμούς πρόσβασης</message>
 	<message key="xmlui.BitstreamReader.auth_message">Το αρχείο που προσπαθείτε να ανακτήσετε έχει περιορισμούς που απαιτούν επιπλέον δικαιώματα. Παρακαλώ συνδεθείτε για να αποκτήσετε πρόσβαση.</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Αυτή η εξαγωγή έχει περιορισμόυς.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Η εξαγωγή που επιχειρείτε να λάβετε έχει περιορισμούς πρόσβασης. Παρακαλούμε συνδεθείτε για να αποκτήσετε πρόσβαση.</message>
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Νέος χρήστης</message>
 	<message key="xmlui.EPerson.trail_forgot_password">Ξεχάσατε τον κωδικό σας;</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Εγγραφή μη διαθέσιμη</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Εγγραφή μη διαθέσιμη</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Οι ρυθμίσεις του DSpace δεν επιτρέπουν την εγγραφή νέων χρηστών. Παρακαλώ επικοινωνήστε με <a href="../contact">το διαχειριστή</a> για ερωτήσεις ή σχόλια.</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">Οι ρυθμίσεις του DSpace δεν επιτρέπουν την εγγραφή νέων χρηστών. Παρακαλώ επικοινωνήστε με <a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Ενημέρωση προφίλ</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">Δημιουργία προφίλ</message>
@@ -324,6 +460,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">Όνομα</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Επίθετο</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">Τηλέφωνο επικοινωνίας</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Language</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Υποβολές</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Μπορείτε να εγγραφείτε σε συλλογές για να λαμβάνετε ημερίσιες ενημερώσεις σχετικά με νέα τεκμήρια. Μπορείτε να εγγραφείτε σε όσες συλλογές επιθυμείτε. Επιπλέον μπορείτε να χρησιμοποιήσετε τη δυνατότητα RSS η οποία είναι διαθέσιμη σε όλες τις συλλογές.</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Συνδρομές Email</message>
@@ -340,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">Ομάδες εξουσιοδότησης στις οποίες ανήκετε</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Στοιχεία</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">Ασφάλεια</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Επιβεβαίωση Email</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Δημιουργία προφίλ</message>
@@ -353,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Ανάκτηση κωδικού</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Ανάκτηση κωδικού</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Ο κωδικός σας έχει αλλαχθεί.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Άκυρη φράση</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Άκυρη φράση</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Άκυρη φράση</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">Το URL που εισάγατε δεν ισχύει. Το URL μπορεί να κόπηκε από το πρόγραμμα email σε πολλαπλές γραμμές, όπως αυτό:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">Αν αυτό ισχύει αντιγράψτε και επικολλήστε το πλήρες URL κατευθείαν στη γραμμή διευθύνσεων του φυλλομετρητή σας, αντί να κάνετε click στο σύνδεσμο. Η γραμμή διευθύνσεων θα πρέπει να περιέχει κάτι σαν:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">Ο λογαριασμός μου</message>
 	<message key="xmlui.EPerson.Navigation.profile">Προφίλ</message>
@@ -380,7 +517,7 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">Εγγραφή νέου χρήστη</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">Δημιουργήστε έναν λογαριασμό για να εγγραφείτε σε συλλογές και να λαμβάνετε ενημερώσεις μέσω email, και να υποβάλετε τεκμήρια στο DSpace.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Κάντε κλικ εδώ για να εγγραφείτε.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Σύνδεση</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Σύνδεση</message>
@@ -389,13 +526,13 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Το όνομα χρήστη ή/και ο κωδικός που εισάγατε δεν ισχύουν.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Κωδικός</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Σύνδεση</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Επιλέξτε μέθοδο σύνδεσης</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">Επιλέξτε μέθοδο σύνδεσης</message>
 	<message key="xmlui.EPerson.LoginChooser.head1">Επιλέξτε μέθοδο σύνδεσης</message>
 	<message key="xmlui.EPerson.LoginChooser.para1">Σύνδεση μέσω:</message>
-	<message key="au.edu.mq.melcoe.mams.dspace.eperson.ShibAuthentication.title">Shibboleth</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth Authentication</message>
 	<message key="org.dspace.eperson.LDAPAuthentication.title">LDAP</message>
 	<message key="org.dspace.eperson.PasswordAuthentication.title">Κωδικός</message>
 	<message key="org.dspace.eperson.X509Authentication.title">Πιστοποιητικό</message>
@@ -405,26 +542,26 @@
 	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Δεν ήταν δυνατή η επιβεβαίωση λόγω εσφαλμένων στοιχείων.</message>
 	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Δεν βρέθηκε χρήστης με αυτά τα στοιχεία.</message>
 	<message key="xmlui.EPerson.FailedAuthentication.title">Αποτυχία επικύρωσης</message>
-	<message key="xmlui.EPerson.FailedAuthentication.trail">Αποτυχία επικύρωσης</message>
-	<message key="xmlui.EPerson.FailedAuthentication.h1">Αποτυχία επικύρωσης</message>
-	
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Αποτυχία επικύρωσης</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Αποτυχία επικύρωσης</message>
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">Δεν βρέθηκε μέθοδος σύνδεσης χρήστη</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">Δεν βρέθηκε μέθοδος σύνδεσης χρήστη. Παρακαλώ επικοινωνήστε με το διαχειστή του συστήματος.</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">Απέτυχε η σύνδεση με Shibboleth</message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">Η σύνδεση μέσω Shibboleth δεν είναι διαθέσιμη αυτή τη στιγμή. Παρακαλώ επικοινωνήστε με το διαχειριστή του συστήματος.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">Το προφίλ ενημερώθηκε</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">Ενημέρωση προφίλ</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">Το προφίλ ενημερώθηκε</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">Οι πληροφορίες του προφίλ σας έχουν ενημερωθεί.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">Η εγγραφή ολοκληρώθηκε</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">Η εγγραφή ολοκληρώθηκε</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">Είστε πλέον εγγεγραμμένος στο DSpace. Μπορείτε να εγγραφείτε σε συλλογές έτσι ώστε να λαμβάνετε ενημερώσεις μέσω email σχετικά με νέα τεκμήρια.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">Ανάκτηση κωδικού</message>
 	<message key="xmlui.EPerson.ResetPassword.head">Ανάκτηση κωδικού</message>
@@ -435,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">Επαναφορά κωδικού</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Επιλέξτε έναν κωδικό με μήκος μεγαλύτερο απο 6 χαρακτήρες</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Επαναπληκτρολογήστε τον κωδικό σας για επιβεβαίωση</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">Απώλεια κωδικού</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">Απώλεια κωδικού</message>
@@ -444,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Εισάγετε τη διεύθυνση με την οποία εγγραφήκατε.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Η διεύθυνση Email δεν βρέθηκε.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Αποστολή μηνύματος</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Εγγραφή νέου χρήστη</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">Το Email χρησιμοποιείται</message>
@@ -457,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">Αυτή η διεύθυνση θα επιβεβαιωθεί και θα χρησιμοποιηθεί σαν όνομα χρήστη.</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Δεν ήταν δυνατή η αποστολή email σε αυτή τη διεύθυνση.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">Εγγραφή</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">Στάλθηκε email επιβεβαίωσης</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">Στάλθηκε email επιβεβαίωσης</message>
@@ -469,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -485,7 +622,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">Πήγαινε στο Dspace μου</message>
 	<message key="xmlui.Submission.general.submission.title">Υποβολή τεκμηρίου</message>
 	<message key="xmlui.Submission.general.submission.trail">Υποβολή τεκμηρίου</message>
-	<message key="xmlui.Submission.general.submission.head">Υποβολή τεκμηρίου</message>	
+	<message key="xmlui.Submission.general.submission.head">Υποβολή τεκμηρίου</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Προηγούμενο</message>
 	<message key="xmlui.Submission.general.submission.save">Αποθήκευση &amp; Έξοδος</message>
 	<message key="xmlui.Submission.general.submission.next">Επόμενο &gt;</message>
@@ -497,25 +634,25 @@
 	<message key="xmlui.Submission.general.showsimple">Εμφάνιση απλής εγγραφής</message>
 	<message key="xmlui.Submission.general.default.title">Υποβολή</message>
 	<message key="xmlui.Submission.general.default.trail">Υποβολή</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Υποβάλλετε ένα νέο τεκμήριο σε αυτή τη συλλογή</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Υποβολές</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Υποβολές &amp; Ροή</message>
 	<message key="xmlui.Submission.Submissions.trail">Υποβολές</message>
 	<message key="xmlui.Submission.Submissions.head">Υποβολές &amp; εργασίες ροής</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Χωρίς τίτλο</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">email: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Εργασίες ροής</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Αυτές οι εργασίες είναι τεκμήρια τα οποία περιμένουν επιβεβαίωση πριν προστεθούν στο καταθετήριο. Υπάρχουν δύο ουρές εργασιών, μία για εργασίες που επιλέξατε να αναλάβετε και μία για τις εργασίες τις οποίες δεν έχετε επιλέξει να αναλάβετε και δεν τις έχει αναλάβει κάποιος άλλος ακόμα.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Εργασίες που έχετε αναλάβει</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Εργασία</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Τεκμήριο</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Συλλογή</message>
@@ -534,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Αυτές είναι μη ολοκληρωμένες υποβολές τεκμηρίων. Μπορείτε επίσης να </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">ξεκινήσετε μια νέα υποβολή</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Τίτλος</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Συλλογή</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Υποβάλλων</message>
@@ -558,16 +695,26 @@
 	<message key="xmlui.Submission.Submissions.status_6">Η υποβολή είναι υπό επεξεργασία</message>
 	<message key="xmlui.Submission.Submissions.status_7">Η υποβολή έχει αρχειοθετηθεί</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Κατάσταση: άγνωστη</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Αρχικές ερωτήσεις</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Περιγραφή</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Ανέβασμα</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Ανέβασμα</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Αναθεώρηση</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-	<message key="xmlui.Submission.submit.progressbar.license">Άδειες</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Άδειες</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Ολοκληρώθηκε</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Συνέχιση</message>
 
@@ -584,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Αποθήκευση, συνέχιση αργότερα</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Αφαίρεση της υποβολής</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Αρχικές ερωτήσεις</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Σημαντική σημείωση: </message>
@@ -593,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Πολλαπλοί τίτλοι</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Το τεκμήριο έχει περισσότερους από έναν τίτλους, <i>π.χ. έναν μεταφρασμένο τίτλο</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Το τεκμήριο έχει περισσότερους από έναν τίτλους, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Αν το πλαίσιο πάνω δεν είναι επιλεγμένο οι ακόλουθοι τίτλοι θα αφαιρεθούν από το τεκμήριο: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Εκδόθηκε</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Αυτό το τεκμήριο έχει εκδοθεί ή διανεμηθείδημόσια δημοσίως στο παρελθόν</message>
@@ -601,30 +748,80 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Ημερομηνία δημοσίευσης</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Αναφορά</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Εκδότης</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">Περιγραφή τεκμηρίου</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Σφάλμα: Άγνωστος τύπος πεδίου</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Αυτό το πεδίο είναι απαραίτητο</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Επίθετο, <i>π.χ. Μακρίδου</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Όνομα/ονόματα + "Δρ.", <i>π.χ. Ελίζα Δρ.</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Επίθετο, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Όνομα/ονόματα + "Δρ.", <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Έτος</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Μήνας</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Μέρα</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">Όνομα σειράς</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Αριθμός</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Ανέβασμα αρχείου(-ων)</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Αρχείο</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Παρακαλώ εισάγετε την πλήρη διαδρομή που αντιστοιχεί στη θέση του αρχείου στον υπολογιστή σας. Αν κάνετε κλίκ στο "Πλοήγηση", ένα νέο παράθυρο θα σας επιτρέψει να διαλέξετε το αρχείο στον υπολογιστή σας.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Το τεκμήριο πρέπει να περιέχει τουλάχιστον ένα αρχείο.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Περιγραφή αρχείου</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Αν επιθυμείτε μπορείτε να παρέχετε μια σύντομη περιγραφή του αρχείου, για παράδειγμα "<i>Κύριο άρθρο</i>", ή "<i>Αποτελέσματα πειραματικών δεδομένων</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">There was a problem uploading your file.  Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only.  Please try again.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Περιγραφή αρχείου</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Αν επιθυμείτε μπορείτε να παρέχετε μια σύντομη περιγραφή του αρχείου, για παράδειγμα "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Ανέβασμα αρχείου &amp; προσθήκη άλλου</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Αρχεία που ανέβηκαν</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Αρχικά</message>
-	<message key="xmlui.Submission.submit.UploadStep.column1"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
 	<message key="xmlui.Submission.submit.UploadStep.column2">Αρχείο</message>
 	<message key="xmlui.Submission.submit.UploadStep.column3">Μέγεθος</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Περιγραφή</message>
@@ -638,19 +835,54 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Επεξεργασία</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">Checksum αρxείου:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Αφαίρεση επιλεγμένων αρχείων</message>
-	
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Επεξεργασία αρχείου</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Αρχείο</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Περιγραφή αρχείου</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Αν επιθυμείτε μπορείτε να προσθέσετε μια σύντομη περιγραφή για τα περιεχόμενα, για παράδειγμα, "<i>Κύριο άρθρο</i>", ή "<i>Αποτελέσματα πειραματικών δεδομένων</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Επιλέξτε τον τύπο του αρχείου από τη λίστα που ακολουθεί, για παράδειγμα"<i>Adobe PDF</i>" ή "<i>Microsoft Word</i>." <strong>Αν ο τύπος του αρχείου δεν είναι στη λίστα</strong>, παρακαλώ περιγράψτε τον στο πλαίσιο κειμένου κάτω από τη λίστα.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Αν επιθυμείτε μπορείτε να προσθέσετε μια σύντομη περιγραφή για τα περιεχόμενα, για παράδειγμα, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Επιλέξτε τον τύπο του αρχείου από τη λίστα που ακολουθεί, για παράδειγμα"<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Τύπος που ανιχνεύθηκε</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Επιλεγμένος τύπος</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Ο τύπος δεν είναι στη λίστα</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Αν ο τύπος του αρχείου δεν είναι στη λίστα πάνω, <strong>επιλέξτε "format not in list"</strong> και περιγράωτε τον τύπο του αρχείου στο πλαίσιο κειμένου που ακολουθεί.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Αν ο τύπος του αρχείου δεν είναι στη λίστα πάνω, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Άλλος τύπος</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Το όνομα της εφαρμογής με την οποία δημιουργήσατε το αρχείο, και την έκδοσή του (για παράδειγμα, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Αναθεώρηση υποβολής</message>
@@ -667,18 +899,21 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">άγνωστο</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">γνωστό</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">υποστηριζόμενο</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Άδεια Creative Commons</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">Αν επιθυμείτε μπορείτε να προσθέσετε την άδεια <a href="http://creativecommons.org/">Creative Commons</a> στο τεκμήριό σας. <strong>Η άδειες Creative Commons καθορίζουν τι θα μπορούν να κάνουν με την εργασία σας όσοι την διαβάζουν.</strong> Αν θέλετε να επιλέξετε μία άδεια Creative Commons κάντε κλικ στο κουμπί κάτω. Θα μεταφερθείτε στη σελίδα της Creative Commons, όπου θα σας παρουσιαστούν διάφορες επιλογές παροχής αδειών.  Αφού επιλέξετε άδεια, θα επιστρέψετε σε αυτή τη σελίδα.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Μετάβαση στην ιστοσελίδα της Creative Commons για να επιλέξετε άδεια</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Άδεια</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">Αφαίρεση της άδειας Creative Commons</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">δεν επιλέχθηκαν άδειες creative commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Άδεια Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Αν επιθυμείτε μπορείτε να προσθέσετε την άδεια <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Μετάβαση στην ιστοσελίδα της Creative Commons για να επιλέξετε άδεια</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Άδεια</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">δεν επιλέχθηκαν άδειες creative commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Άδεια διανομής</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Απομένει ένα τελευταίο βήμα:</strong> Για να μπορεί το DSpace να αναπαράγει, μεταφράσει και διανήμει την υποβολή σας παγκοσμίως, πρέπει να συμφωνήσετε με τους ακόλουθους όρους.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Χορηγήστε την προκαθοριμένη άδεια επιλέγοντας 'Χορηγώ την άδεια', και μετά πατώντας 'Ολοκλήρωση υποβολής'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Εάν έχετε απορίες σχετικά με την άδεια επικοινωνήστε με τους διαχειριστές του συστήματος.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Άδεια διανομής</message>
@@ -688,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">Η υποβολή αφαιρέθηκε</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">Η υποβολή σας ακυρώθηκε, και τα ημιτελή στοιχεία αφαιρέθηκαν από το σύστημα.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Πήγαινε στη Σελίδα Υποβολών</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Πήγαινε στη Σελίδα Υποβολών</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Η υποβολή ολοκληρώθηκε</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">Η υποβολή σας θα περάσει από τις διαδικασίες αναθεώρησης για αυτή τη συλλογή. Θα λάβετε ενημέρωση e-mail όταν η υποβολή σας εισαχθεί στη συλλογή, ή σε περίπτωση προβλήματος με την υποβολή σας. Μπορείτε να ελέγξετε την κατάσταση της υποβολής σας στη σελίδα των υποβολών σας.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Πήγαινε στη Σελίδα Υποβολών</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Υποβάλτε ένα νέο τεκμήριο</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Η υποβολή ολοκληρώθηκε</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Η υποβολή σας θα περάσει από τις διαδικασίες αναθεώρησης για αυτή τη συλλογή. Θα λάβετε ενημέρωση e-mail όταν η υποβολή σας εισαχθεί στη συλλογή, ή σε περίπτωση προβλήματος με την υποβολή σας. Μπορείτε να ελέγξετε την κατάσταση της υποβολής σας στη σελίδα των υποβολών σας.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Πήγαινε στη Σελίδα Υποβολών</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Υποβάλτε ένα νέο τεκμήριο</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Ενέργειες που μπορείτε να εκτελέσετε σε αυτή την εργασία:</message>
@@ -706,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Έγκριση τεκμηρίου</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Όταν επεξεργαστείτε αυτό το τεκμήριο, χρησιμοποιείστε αυτή την επιλογή για να το υποβάλλετε στο αρχείο.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Υποβολή στο καταθετήριο</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Αν αναθεωρήσατε το τεκμήριο και πιστεύετε οτι <strong>δεν είναι</strong> κατάλληλο για προσθήκη στη συλλογή, επιλέξτε "Απόρριψη τεκμηρίου". Θα σας ζητηθεί να εισάγετε το λόγο για τον οποίο κρίνατε το τεκμήριο ακατάλληλο, και κατά πόσο ο υποβάλλων μπορεί να αλλάξει κάτι και να επαναλλάβει την υποβολή του τεκμηρίου.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Αν αναθεωρήσατε το τεκμήριο και πιστεύετε οτι <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Απόρριψη τεκμηρίου</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Επιλέξτε αυτή την επιλογή για να αλλά τα μεταδεδομένα του τεκμηρίου.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Επεξεργασία μεταδεδομένων</message>
@@ -719,18 +954,22 @@
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Ο λόγος πρέπει να είναι συμπληρωμένος</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Απόρριψη τεκμηρίου</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Ο χρήστης εισάχθηκε με επιτυχία.</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Ο χρήστης εισάχθηκε με επιτυχία.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Τα στοιχεία του χρήστη επεξεργάστηκαν με επιτυχία.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Ένα μήνυμα email στάλθηκε στον χρήστη περιέχοντας ένα σύνδεσμο με τον οποίο θα μπορέσει να ορίσει ένα νέο κωδικό πρόσβασης.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Οι χρήστες διαγράφηκαν με επιτυχία.</message>
@@ -749,16 +988,18 @@
 	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Νεα μεταδεδομένα προστέθηκαν.</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Το τεκμήριο αποσύρθηκε.</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Το τεκμήριο εγκαταστάθηκε ξανά.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">The item has been moved.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">The selected destination collection could not be found.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Το νέο bitstream ανέβηκε με επιτυχία.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Σφάλμα κατά το ανέβασμα του αρχείου.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Το bitstream ενημερώθηκε.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Τα επιλεγμένα bitstreams διαγράφηκαν.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">Τα τεκμήρια "αντιγράφησαν" επιτυχώς.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Τα τεκμήρια "αφαιρέθηκαν" επιτυχώς.</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Διαχείριση E-people</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Επεξεργασία</message>
@@ -770,9 +1011,10 @@
 	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Δημιουργία υπο-κοινότητας</message>
 	<message key="xmlui.administrative.Navigation.context_create_community">Δημιουργία κοινότητας</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">Εξαγωγή τεκμηρίου</message>
-	<message key="xmlui.administrative.Navigation.context_export_collection">Εξαγωγή συλλογής</message>
-	<message key="xmlui.administrative.Navigation.context_export_community">Εξαγωγή κοινότητας</message>
-	
+        <message key="xmlui.administrative.Navigation.context_export_collection">Εξαγωγή συλλογής</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Εξαγωγή κοινότητας</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Export Metadata</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Διαχείριση</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">Έλεγχος πρόσβασης</message>
@@ -782,15 +1024,20 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Μητρώα</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Μεταδεδομένα</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Μορφότυπα</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Τεκμήρια</message>
-	<message key="xmlui.administrative.Navigation.administrative_withdrawn">Αποσυρμένα τεκμήρια</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Πίνακας ελέγχου</message>
-	<message key="xmlui.administrative.Navigation.statistics">Στατιστικά</message>
-	
-	<!-- my account items -->
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Αποσυρμένα τεκμήρια</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Πίνακας ελέγχου</message>
+    <message key="xmlui.administrative.Navigation.statistics">Στατιστικά</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
+
+    <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Οι εξαγωγές μου</message>
-		
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Αρχείο Εξαγωγών</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">Το ID του τεκμηρίου δεν ισχύει.</message>
@@ -802,11 +1049,11 @@
 	<message key="xmlui.administrative.ItemExport.item.success">Το τεκμήριο εξήχθει με επιτυχία. Θα λάβετε ένα e-mail όταν το αρχείο είναι έτοιμο για λήψη. Μπορείτε επίσης να χρησιμοποιήσετε το σύνδεσμο 'Οι εξαγωγές μου' για να δείτε μια λίστα με τις διαθέσιμες λήψεις σας.</message>
 	<message key="xmlui.administrative.ItemExport.collection.success">Η συλλογή εξήχθει με επιτυχία. Θα λάβετε ένα e-mail όταν το αρχείο είναι έτοιμο για λήψη. Μπορείτε επίσης να χρησιμοποιήσετε το σύνδεσμο 'Οι εξαγωγές μου' για να δείτε μια λίστα με τις διαθέσιμες λήψεις σας.</message>
 	<message key="xmlui.administrative.ItemExport.community.success">Η κοινότητα εξήχθει με επιτυχία. Θα λάβετε ένα e-mail όταν το αρχείο είναι έτοιμο για λήψη. Μπορείτε επίσης να χρησιμοποιήσετε το σύνδεσμο 'Οι εξαγωγές μου' για να δείτε μια λίστα με τις διαθέσιμες λήψεις σας.</message>
-	<message key="xmlui.administrative.ItemExport.available.head">Διαθέσιμες εξαγωγές για λήψη:</message>	
-	
-	
-	
-	<!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
+	<message key="xmlui.administrative.ItemExport.available.head">Διαθέσιμες εξαγωγές για λήψη:</message>
+
+
+
+    <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Διαχείριση E-people</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Διαχείριση E-person</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Ενέργειες</message>
@@ -818,14 +1065,14 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Η αναζήτηση στους χρήστες γίνεται με ταίριασμα μέρους του ονόματος ή του email</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Ακολουθεί η λίστα με τους χρήστες που ταιριάζουν στην αναζήτησή σας. Επιλέξτε τον χρήστη που επιθυμείτε να διαγράψετε και πατήστε το κουμπί διαγραφής για να συνεχίσετε ή πατήστε πάνω στο όνομα και το email για να τα επεξεργαστείτε.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Αποτελέσματα αναζήτησης</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Όνομα</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Διαγραφή χρήστη</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Η αναζήτησή σας δεν παρήγαγε αποτελέσματα...</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Προσθήκη χρήστη</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Προσθήκη χρήστη</message>
@@ -839,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Απαιτείται πιστοποιητικό</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Μπορεί να συνδεθεί</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Δημιουργία χρήστη</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Επεξεργασία E-Person</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Επεξεργασία E-Person</message>
@@ -856,19 +1103,19 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Μπορείτε να διαγράψετε μόνιμα αυτό το χρήστη από το σύστημα ή να ανακτήσετε τον κωδικό του. Όταν ανακτάτε τον κωδικό ενός χρήστη, ο χρήστης λαμβάνει ένα  email το οποίο περιέχει ένα ειδικό link με το οποίο μπορεί να επιλέξει νέο κωδικό.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Διαγραφή του E-Person</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Σύνδεση ως E-Person</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Αυτός ο χρήστης δεν γίνεται να διαγραφεί λόγω των παρακάτω περιορισμών:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">και</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">Ο χρήστης υπέβαλε ένα ή περισσότερα τεκμήρια</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">Ο χρήστης έχει μια ενεργή ροή υποβολής</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">Ο χρήστης έχει μια υποβολή η οποία είναι σε αναμονή ελέγχου</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">Ο χρήστης έχει έναν μη αναγνωρίσιμο περιορισμό στο σύστημα</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Ομάδες στις οποίες ανήκει ο χρήστης:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(μέσω της ομάδας: {0})</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">κανένα</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Επιβεβαίωση διαγραφής E-Person</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Επιβεβαίωση διαγραφής</message>
@@ -893,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Αναζήτηση σε ομάδες</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Αναζήτηση σε ομάδες βάση μέρους του ονόματός τους</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Αποτελέσματα αναζήτησης</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Όνομα</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Μέλη</message>
@@ -915,6 +1162,7 @@
 	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Προσθήκη</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Αφαίρεση</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Αυτή η ομάδα είναι συσχετισμένη με τη συλλογή: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">This group is associated with community: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_name">Αλλαγή ονόματος ομάδας: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Αυτή η ομαδα σχετίζεται με μια συγκεκριμένη συλλογή και το όνομα δεν μπορεί να τροποποιηθεί.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_search">Αναζήτηση μελών για προσθήκη: </message>
@@ -935,13 +1183,13 @@
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Όνομα</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">ομάδα: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">ομάδα: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Αυτή η ομάδα δεν έχει μέλη.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[εκρεμμούν]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Αφαίρεσε μέλη</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Αφαίρεσε μέλη</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Επιβεβαίωση διαγραφής ομάδας</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Επιβεβαίωση διαγραφής</message>
@@ -951,11 +1199,11 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Όνομα</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Χρήστες</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Ομάδες</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Μητρώο τύπων</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Μητρώο μεταδεδομένων</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Μητρώο μεταδεδομένων</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Διαγραφή τύπων Bitstream</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Διαγραφή τύπων bitstream</message>
@@ -969,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Διαγραφή πεδίων</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Διαγραφή πεδίων</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Επιβεβαίωση διαγραφής</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Είστε <b>απόλυτα</b> σίγουροι ότι θέλετε να διαγράψετε αυτά τα πεδία; Αν υπάρχουν τεκμήρια τα οποία περιέχουν μεταδεδομένα για αυτά τα πεδία, τα πεδία δεν μπορούν να διαγραφούν. Πρέπει να είστε σίγουροι οτι κανένα τεκμήριο δεν χρησιμοποιεί αυτά τα πεδία.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Είστε <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ΠΡΟΕΙΔΟΠΟΙΗΣΗ: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Αυτή η ενέργεια θα προκαλέσει σφάλμα αν οποιοδήποτε τεκμήριο περιέχει μεταδεδομένα για αυτά τα πεδία.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -980,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Διαγραφή σχήματος</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Διαγραφή σχήματος</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Επιβεβαίωση διαγραφής</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Είστε <b>απόλυτα</b> σίγουροι οτι θέλετε να διαγράψετε αυτό το σχήμα; Αν οποιοδήποτε τεκμήριο περιέχει μεταδεδομένα των πεδίων που περιέχονται στο σχήμα, το σχήμα δεν μπορεί να διαγραφεί. Πρέπει να επιβεβαιώσετε οτι κανένα τεκμήριο δεν περιέχει μεταδεδομένα από αυτό το σχήμα.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Είστε <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ΠΡΟΕΙΔΟΠΟΙΗΣΗ: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Θα προκληθεί σφάλμα εάν κάποιο τεκμήριο περιέχει μεταδεδομένα από αυτό το σχήμα.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1047,7 +1295,7 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Όνομα</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Τύπος MIME</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Βαθμός υποστήριξης</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>εσωτερικός</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Άγνωστος</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Γνωστός</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Υποστηρίζεται</message>
@@ -1081,14 +1329,14 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Scope Note</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Μετακίνηση στο σχήμα: </message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Μετακίνησε πεδία</message>
-	
-	
-	
-	
+
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">Εξουσιοδότηση</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Λίστα πολιτικών</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Διαχειριστείτε πολιτικές εξουσιοδότησης</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Διαχειριστείτε πολιτικές εξουσιοδότησης</message>
@@ -1101,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Πατήστε εδώ για να μεταβείτε στο εργαλείο σύνθετων πολιτικών εξουσιοδότησης</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Εξουσιοδοτήσεις Κοινότητας/Συλλογής</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Κάντε κλικ σε μία κοινότητα ή συλλογή για να επεξεργαστείτε τις πολιτικές της.</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Επεξεργασία πολιτικών</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Λίστα πολιτικών</message>
@@ -1112,13 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Κάντε click εδώ για να προσθέσετε μια νέα πολιτική. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Προσθήκη</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Ενέργεια</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Ομάδα</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Διαγραφή επιλεγμένων</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Επεξεργασία</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Επεξεργασία πολιτικών τεκμηρίου</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Λίστα πολιτικών</message>
@@ -1131,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Προσθήκη μιας νέας πολιτικής τεκμηρίου</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Προσθέστε μια νέα πολιτική</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Προσθήκη νέας πολιτικής Bitstream</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Δεν βρέθηκαν πολιτικές για το αντικείμενο.</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Επεξεργασία πολιτικής</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Επεξεργασία πολιτικής</message>
@@ -1146,32 +1397,50 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Όνομα</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Ενέργειες για αυτόν τον πόρο</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Όρισε</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">τρέχων</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Αποτελέσματα αναζήτησης</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Επέλεξε ομάδα</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Αναζήτησε για ομάδα</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Αναζήτηση</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Επιλέξτε ενέργεια</message>
-    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Αναζήτηση</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Επιλέξτε ενέργεια</message>
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Προηγμένη διαχείριση πολιτικών</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Προηγμένες εξουσιοδοτήσεις</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Προηγμένη διαχείρηση πολιτικών</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Allows wildcard additions to and clearing of policies for types of content within specific collection(s). WARNING - removing READ permissions from items will make them not viewable!</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Για όλες τις επιλεγμένες ομάδες...</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...χορήγησε την άδεια να εκτελούν την ακόλουθη ενέργεια...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...χορήγησε την άδεια να εκτελούν την ακόλουθη ενέργεια...</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...για τους ακόλουθους τύπους αντικειμένων...</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...μέσα στις ακόλουθες συλλογές.</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...μέσα στις ακόλουθες συλλογές.</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Ομάδα</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Ενέργεια</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Τύπος περιεχομένου</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Συλλογή</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Πρόσθεσε πολιτικές</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Καθάρισε πολιτικές</message>
-	
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Επιβεβαίωση διαγραφής πολιτικής</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Επιβεβαίωση διαγραφής</message>
@@ -1180,15 +1449,53 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Ενέργεια</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Ομάδα</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Τεκμήρια</message>
+	<message key="xmlui.administrative.item.general.template_head">Edit Template Item for Collection: {0}</message>
 	<message key="xmlui.administrative.item.general.option_head">Επεξεργασία τεκμηρίου</message>
 	<message key="xmlui.administrative.item.general.option_status">Κατάσταση</message>
 	<message key="xmlui.administrative.item.general.option_bitstreams">Bitstreams</message>
 	<message key="xmlui.administrative.item.general.option_metadata">Μεταδεδομένα</message>
 	<message key="xmlui.administrative.item.general.option_view">Προβολή</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">Curate</message>
+        <message key="xmlui.administrative.item.general.option_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">Ανέβασε Bitstream</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Ανέβασε bitstream</message>
@@ -1198,14 +1505,14 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Αρχεία μεταδεδομένων</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Μικρογραφίες</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Άδειες</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">Άδειες Creative Commons</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Αρχείο</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Παρακαλώ εισάγετε το όνομα του αρχείου στον υπολογιστή σας που αντιστοιχεί στο τεκμήριο. Αν πατήσετε το κουμπί "πλοήγηση", θα εμφανιστεί ένα παράθυρο μέσα από το οποίο θα μπορείτε να διαλέξετε το αρχείο στον υπολογιστή σας.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Περιγραφή</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Επιπλέον, εισάγετε μια σύντομη περιγραφή για το αρχείο, για παράδειγμα "<i>Κύριο άρθρο</i>", ή "<i>Αποτελέσματα πειραματικών δεδομένων</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Επιπλέον, εισάγετε μια σύντομη περιγραφή για το αρχείο, για παράδειγμα "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Ανέβασε</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Πρέπει να ορίσετε δικαιώματα ADD &amp; WRITE σε τουλάχιστον ένα bundle για να είστε σε θέση να προσθέσετε bitstreams.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Επιβεβαίωση διαγραφής</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Επιβεβαίωση διαγραφής</message>
@@ -1214,8 +1521,8 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Όνομα</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Περιγραφή</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Τύπος</message>
-	
-	<!-- org.dspace.app.xmlui.administrative.item.ConfrimItemForm -->
+
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Επιβεβαίωση</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Επιβεβαίωση</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Τροποποίση τεκμηρίου: {0}</message>
@@ -1227,6 +1534,19 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Γλώσσα</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Απόσυρση</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Επανεγκατάσταση</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Move item: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Collection</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Select the collection you wish to move this item to.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Select a collection...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Move</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Inherit policies</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Inherit the default policies of the destination collection</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">Επεξεργασία Bitstream</message>
@@ -1237,31 +1557,39 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">ναι</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">όχι</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Περιγραφή</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Επιπλέον, εισάγετε μια σύντομη περιγραφή για το αρχείο, για παράδειγμα "<i>Κύριο άρθρο</i>", ή "<i>Αποτελέσματα πειραματικών δεδομένων</i>".</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Επιλέξτε τον τύπο του αρχείου από τη λίστα που ακολουθεί, για παράδειγμα"<i>Adobe PDF</i>" ή "<i>Microsoft Word</i>", <b>Ή</b> αν ο τύπος του αρχείου δεν είναι στη λίστα, παρακαλώ περιγράψτε τον στο πλαίσιο που ακολουθεί.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Επιπλέον, εισάγετε μια σύντομη περιγραφή για το αρχείο, για παράδειγμα "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Επιλέξτε τον τύπο του αρχείου από τη λίστα που ακολουθεί, για παράδειγμα"<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Επιλεγμένος τύπος</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Ο τύπος δεν είναι στη λίστα</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Εάν ο τύπος δεν είναι στην επάνω λίστα, <strong>επιλέξτε "ο τύπος δεν είναι στη λίστα"</strong> και περιγράψτε στο πλαίσιο που ακολουθεί.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Εάν ο τύπος δεν είναι στην επάνω λίστα, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Άλλος τύπος</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Η εφαρμογή με την οποία δημιουργήθηκε το αρχείο και η έκδοσή της (Για παράδειγμα, "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Bitstreams τεκμηρίου</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Bitstreams τεκμηρίου</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Όνομα</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Περιγραφή</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Τύπος</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Προβολή</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (πρωτεύον) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">προβολή</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Ανέβασε έναν νέο bitstream</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Διέγραψε bitstreams</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Χρειάζεστε δικαιώματα ADD &amp; WRITE σε αυτό το τεκμήριο και τα bundles του για να μπορέσετε να προσθέσετε νέαbitstreams.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Χρειάζεστε δικαιώματα REMOVE σε αυτό το τεκμήριο και τα bundles του για να μπορείτε να διαγράψετε bitstreams.</message>
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Μεταδεδομένα τεκμηρίου</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Μεταδεδομένα τεκμηρίου</message>
@@ -1289,40 +1617,100 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Εξουσιοδοτήσεις τεκμηρίου</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Αποσυρμένο αντικείμενο από το καταθετήριο</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Επαναφέρετε το τεκμήριο στο καταθετήριο</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Move item to another collection</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Εξάλειψε πλήρως το τεκμήριο</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Επεξεργασία εξουσιοδοτήσεων</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Απόσυρε...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Αποκαταστήστε...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Move...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Διαγράψτε μόνιμα</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">μη διαθέσιμο</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(διαχειριστές συστήματος μόνο)</message>
-	
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(collection administrators only)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(you are not allowed to perform this action)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Προβολή τεκμηρίου</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Προβολή τεκμηρίου</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Task</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Αναζήτηση τεκμηρίου</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Αναζήτηση τεκμηρίου</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Εσωτερικό ID τεκμηρίου /Προσδιοριστής τεκμηρίου</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Δεν ήταν δυνατή η εύρεση του αναγνωριστικού.</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">Αναζήτηση</message>
-	
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">changes</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">No changes were detected</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">New item</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Upload successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Upload failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unknown metadata element in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Number of changes exceeds maximum allowed. Limit changes or alter bulkedit.gui-item-limit in dspace.cfg</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Upload CSV</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Successfully processed</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Changes applied to item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Added: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Removed: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Added to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Removed from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Mapped to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Unmapped from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Add: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Remove: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Add to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Remove from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Map to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Un-map from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Changes pending for item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Apply changes</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Pending changes are listed below for review</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Χαρτογράφος τεκμηρίων</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Χαρτογράφος τεκμηρίων</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Χαρτογράφος τεκμηρίων - Χαρτογράφησε τεκμήρια από άλλες συλλογές</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Συλλογή: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Αυτό είναι το εργαλείο χαρτογράφησης τεκμηρίων το οποίο επιτρέπει σε διαχειριστές συλλογών να αντιγράψουν τεκμήρια από άλλες συλλογές μέσα σε αυτή τη συλλογή. Μπορείτε να αναζητήσετε τεκμήρια από άλλες συλλογές και να τα αντιγράψετε, ή να πλοηγηθείτε στη λίστα των ήδη αντεγραμμένων τεκμηρίων.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Στατιστικά</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} από {1}</strong> τεκμήρια σε αυτή τη συλλογή έχουν αντιγραφεί από άλλες συλλογές</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Αναζήτηση</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Αναζήτηση τεκμηρίων</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Πλοήγηση σε αντεγραμμένα τεκμήρια</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Απαιτείται άδεια πρόσθεσης (ADD) στη συλλογή)</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Αναζήτηση τεκμηρίων</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Αναζήτηση τεκμηρίων</message>
@@ -1332,7 +1720,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Συλλογή</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Συγγραφέας</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Τίτλος</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Πλοήγηση σε αντεγραμμένα τεκμήρια</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Πλοήγηση σε αντεγραμμένα τεκμήρια</message>
@@ -1343,13 +1731,14 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Συγγραφέας</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Τίτλος</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Χρειάζεστε το δικαίωμα αφαίρεσης(REMOVE) σε αυτή τη συλλογή για να είστε σε θέση να αφαιρείτε τεκμήρια από αυτή τη συλλογή.</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">Συλλογές</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Επεξεργασία μεταδεδομένων</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Ανάθεση ρόλων</message>	
-	
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">Συλλογές</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Επεξεργασία μεταδεδομένων</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Ανάθεση ρόλων</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Επεξεργασία ρόλων συλλογών</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Ρόλοι</message>
@@ -1370,12 +1759,21 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Συσχετισμένη ομάδα</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Διαχειριστές</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Workflow steps</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Βήμα Έγκριση/Απόριψη</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Βήμα Έγκριση/Απόριψη/Επεξεργασία μεταδεδομένων</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Βήμα Επεξεργασία Μεταδεδομένων</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Υποβάλλοντες</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Προεπιλεγμένα δικαιώματα ανάγνωσης</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(διαχειριστές συστήματος μόνο)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curate Collection: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curate Collection</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Επιβεβαίωση διαγραφής</message>
@@ -1385,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Οποιαδήποτε τεκμήρια και ημιτελείς υποβολές σε αυτή τη συλλογή που δεν περιέχονται σε άλλες συλλογές</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Τα περιεχόμενα αυτών των τεκμηρίων</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Όλες τις σχετιζόμενες πολιτικές</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Επιβεβαίωση διαγραφής ρόλου</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Επιβεβαίωση</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Επιβεβαίωση διαγραφής του ρόλου {0}</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Είστε σίγουροι οτι θέλετε να διαγράψετε αυτόν τον ρόλο; Η διαγραφή αυτής της ομάδας θα δώσει δικαιώματα ανάγνωσης σε όλους τους χρήστες για όλα τα τεκμήρια που θα υποβληθούν σε αυτή τη συλλογή από εδώ και μπρος. Παρακαλώ σημειώστε οτι αυτή η αλλαγή δεν λειτουργεί αναδρομικά. Η πρόσβαση στα υπάρχοντα τεκμήρια θα παραμείνει περιορισμένη στα μέλη που όριζε ο ρόλος που πρόκειται να διαγράψετε.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Είστε σίγουροι οτι θέλετε να διαγράψετε αυτόν τον ρόλο; Όλες οι αλλαγές και τροποποιήσεις που έγιναν στην ομάδα {0} θα χαθούν και θα πρέπει να δημιουργηθούν εξ'αρχής.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Επεξεργασία μεταδεδομένων συλλογής</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Μεταδεδομένα</message>
@@ -1412,13 +1810,107 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Αφαίρεση λογότυπου</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Διαγραφή συλλογής</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Αποθήκευση ενημερώσεων</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(μόνο διαχειριστές συστήματος)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Δημιουργία συλλογής</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Δημιουργία συλλογής</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Εισαγωγή μεταδεδομένων για μια νέα συλλογή της {0}</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Δημιουργία</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Collection Harvesting Settings</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Content Source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Content source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">This is a standard DSpace collection</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">This collection harvests its content from an external source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Save</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Harvesting Options</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadata Format</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">The url of the target repository's OAI provider service</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">The persistent identifier used by the OAI provider to designate the target collection</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Test Settings</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadata format</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Last Harvest Result</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">This collection has not yet been harvested.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Current harvest status</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Collection ready for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Collection is currently being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Collection is in queue for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Unexpected error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (full replication).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Change Settings</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Import Now</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Reset and Reimport Collection</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Harvest Scheduler Controls</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Actions</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Start Harvester</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Reset Harvest Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Resume</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pause</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Collections set up for harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Active harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Queued harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Internal errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Generator Settings</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE source</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Settings</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Communities</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Edit Metadata</message>
+	<message key="xmlui.administrative.community.general.options_roles">Assign Roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.community.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Edit Community Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edit Community: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">none</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Create...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections.  In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">This community uses custom default access settings. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Default read for incoming items and bitstreams is currently set to Anonymous.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Edit authorization policies directly.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Associated group</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administrators</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curate Community: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curate Community</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Επιβεβαίωση διαγραφής</message>
@@ -1429,7 +1921,13 @@
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Οποιαδήποτε τεκμήρια και ημιτελείς υποβολές σε αυτή την κοινότητα που δεν περιέχονται σε άλλες κοινότητες</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Τα περιεχόμενα αυτών των τεκμηρίων</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Όλες οι σχετιζόμενες πολιτικές εξουσιοδότησης</message>
-	
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirm role deletion</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirm</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirm deletion for role {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Are you sure you want to delete this role? All changes and customizations made to the {0} group will be lost and would have to be created anew.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Επεξεργαστείτε μεταδεδομένα κοινότητας</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Μεταδεδομένα</message>
@@ -1444,7 +1942,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Τρέχων λογότυπο</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Αφαιρέστε το λογότυπο</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Διαγράψτε την κοινότητα</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Δημιουργία κοινότητας</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Δημιουργία κοινότητας</message>
@@ -1475,7 +1973,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Δεσμευμένη μνήμη</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Χρησιμοποιούμενη μνήμη</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Ελεύθερη μνήμη</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">Ρυθμίσεις DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">Φάκελος εγκατάστασης DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">Διεύθυνση εγκατάστασης DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Όνομα host</message>
@@ -1491,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Παραλήπτης σχολίων</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">E-mail Γενικού διαχειριστή συστήματος</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Προειδοποιήσεις συστήματος</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Προειδοποίηση για συστήματα διαχείρησης φόρτου</strong>: Οι προειδοποιήσεις συστήματος είναι αποτελεσματικές για τον κόμβο στον οποίο ενεργοποιούνται. Πρέπει να είστε σίγουροι οτι κάθε κόμβος είναι σε θέση να λάβει την εντολή ενεργοποίησης προειδοποίησης.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Προειδοποιητικό μήνυμα</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Το σύστημα θα κλείσει για συντήρηση. Παρακαλούμε αποθηκεύστε την εργασία σας και αποσυνδεθείτε.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Αντίστροφη μέτρηση</message>
@@ -1501,11 +2008,11 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 Λεπτά</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 Ώρα</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Κράτησε τον τρέχοντα μετρητή</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Διαχείριση συνεδριών</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Συνέχισε να επιτρέπεις εξουσιοδοτημένες συνεδρίες</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Απέτρεψε νεες συνδέσεις χρηστών αλλά διατήρησε τις υπάρχουσες</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Απέτρεψε τις συνδέσεις και διέκοψε τις ήδη υπάρχουσες</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Σημείωση:</strong> Οι διαχειριστές εξαιρούνται από τη διαχείριση συνδέσεων.</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Διαχείριση συνεδριών</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Συνέχισε να επιτρέπεις εξουσιοδοτημένες συνεδρίες</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Απέτρεψε νεες συνδέσεις χρηστών αλλά διατήρησε τις υπάρχουσες</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Απέτρεψε τις συνδέσεις και διέκοψε τις ήδη υπάρχουσες</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Ενεργοποίησε</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Απενεργοποίησε</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Τρέχουσες Δραστηριότητες ({0} μέγιστες σελίδες)</message>
@@ -1518,14 +2025,14 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Διεύθυνση IP</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-Agent</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Ανώνυμος {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Ανώνυμος {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Εκτός από εσάς, δεν προβλήθηκαν άλλες σελίδες στις προηγούμενες {0} σελίδες.</message>
-	
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">Χρησιμοποιήστε τις καρτέλες επάνω για να επιλέξετε τις πληροφορίες που θα εμφανίζονται</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Σε {0} Λεπτά</strong>: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Μη εξουσιοδοτημένος</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">Μη εξουσιοδοτημένος</message>
@@ -1534,17 +2041,108 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">διαχειριστές συστήματος</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Είσοδος σαν άλλος χρήστης</message>
-	
-	
-	
-	
-	
-	
-	
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Statistics</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">Total Visits</message>
+    <message key="xmlui.statistics.visits.month">Total Visits Per Month</message>
+    <message key="xmlui.statistics.visits.views">Views</message>
+    <message key="xmlui.statistics.visits.countries">Top country views</message>
+    <message key="xmlui.statistics.visits.cities">Top cities views</message>
+    <message key="xmlui.statistics.visits.bitstreams">File Visits</message>
+    <message key="xmlui.statistics.Navigation.title">Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">Statistics</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
+
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -1553,20 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Αυτός ο ιστότοπος χρησιμοποιεί το Manakin, τη νέα διεπιφάνεια για το DSpace που δημιουργήθηκε από το Texas A&amp;M University 
-			Libraries. Η διεπιφάνεια μπορεί να τροποποιηθεί εκτενώς μέσω Manakin Aspects και θέματα βασισμένα σε XSL. 
-			Για περισσότερες πληροφορίες:
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> και
-			<a href="http://dspace.org">http://dspace.org</a>                            
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Επικοινωνήστε μαζί μας</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Send Feedback</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">Ιδρυματικό Καταθετήριο DSpace</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Προφίλ: </message>
@@ -1577,15 +2175,15 @@
 	<message key="xmlui.dri2xhtml.structural.search-advanced">Σύνθετη αναζήτηση</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-community">Αυτή η κοινότητα</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">Αυτή η συλλογή</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">Προηγούμενη σελίδα</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">Αποτελέσματα {0}-{1} από {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">Επόμενη σελίδα</message>
 
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Original License</message>
-	
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -1598,7 +2196,7 @@
 		στο dri2xhtml έτσι ώστε να πραγματοποιεί την απαιτούμενη λειτουργία, 
 		ή να δημιουργήσετε ένα νέο πρότυπο για το προφίλ που χρησιμοποιείτε
     </message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Προεπισκόπηση</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Τίτλος</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Συγγραφέας</message>
@@ -1608,22 +2206,25 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Ημερομηνία</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Εκδότης</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Θέμα</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Αρχεία σε αυτό το τεκμήριο</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Αρχεία</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Μέγεθος</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Τύπος</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Προβολή</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Προβολή/<wbr/>Άνοιγμα</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Προβολή/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Δεν υπάρχουν αρχεία που να σχετίζονται με αυτό το τεκμήριο.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Οι παρακάτω άδειες σχετίζονται με αυτό το τεκμήριο:</message>
-		
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		Το summaryView για μια συλλογή δεν χρησιμοποιείται ή δεν έχει υλοποιηθεί. Αυτό μπορεί να διορθωθεί
 		με υπέρβαση του προτύπου με το όνομα collectionSummaryView στο dri2xhtml.
@@ -1632,13 +2233,12 @@
 		Το summaryView για μια κοινότητα δεν χρησιμοποιείται ή δεν έχει υλοποιηθεί. Αυτό μπορεί να διορθωθεί
 		με υπέρβαση του προτύπου με το όνομα collectionSummaryView στο dri2xhtml.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Λογότυπο συλλογής</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Λογότυπο κοινότητας</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Χωρίς Λογότυπο</message>		
-	<message key="xmlui.dri2xhtml.METS-1.0.news">Νέα</message>	
-	<message key="xmlui.dri2xhtml.METS-1.0.copyright">Copyright και άδεια</message>			
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Χωρίς Λογότυπο</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Νέα</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
@@ -1646,95 +2246,250 @@
 		Όταν χρησιμοποιείτε QDC, θα πρέπει να χρησιμοποιείτε το QDC crosswalk για τα τεκμήρια του DSpace
 		και είτε το DIM ή το MODS για την επεξεργασία των κοινοτήτων και των συλλογών.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Στοιχεία Dublin Core</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Όροι Dublin Core</message>
-	
-	
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Προεπισκόπηση</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Ημερομηνία</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Τίτλος</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Συγγραφέας</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
-	
-	<!--###### File Format MIME Type Mappings ######-->
-	
-	<!-- Application-based formats -->
-	<message key="xmlui.dri2xhtml.mimetype.application/marc">Εγγραφή MARC</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/octet-stream">άγνωστο</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
-	
-	<!-- Audio-based formats -->
-	<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/flac">Ήχος FLAC</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/m4a">Ήχος AAC</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">Ήχος AAC</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">Ήχος mp3</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">Ήχος AIFF</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">Ήχος MPEG</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">Ήχος WMA</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">Ήχος WMV</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">Ήχος WAV</message>
-	
-	<!-- Image-based formats -->
-	<message key="xmlui.dri2xhtml.mimetype.image/gif">Εικόνα GIF</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/jp2">Εικόνα JPEG 2000</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/jpeg">Εικόνα JPEG</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/png">Εικόνα PNG</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/tiff">Εικόνα TIFF</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Εικόνα BMP</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
-	
-	<!-- Text-based formats -->
-	<message key="xmlui.dri2xhtml.mimetype.text/css">Αρχείο CSS</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/csv">Αρχείο CSV</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/plain">Αρχείο Κειμένου</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/richtext">Αρχείο RTF</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
-	
-	<!-- Video-based formats -->
-	<message key="xmlui.dri2xhtml.mimetype.video/avi">Βίντεο AVI</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mpeg">Βίντεο MPEG</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Βίντεο MPEG-2</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mp4">Βίντεο MPEG-4</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/quicktime">Βίντεο QuickTime</message>
 
+  <!--###### File Format MIME Type Mappings ######-->
+
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">Εγγραφή MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">άγνωστο</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">Ήχος FLAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">Ήχος AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">Ήχος AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">Ήχος mp3</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">Ήχος AIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">Ήχος MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">Ήχος WMA</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">Ήχος WMV</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">Ήχος WAV</message>
+
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">Εικόνα GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">Εικόνα JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">Εικόνα JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">Εικόνα PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">Εικόνα TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Εικόνα BMP</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">Αρχείο CSS</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">Αρχείο CSV</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Αρχείο Κειμένου</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">Αρχείο RTF</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">Βίντεο AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">Βίντεο MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Βίντεο MPEG-2</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">Βίντεο MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Βίντεο QuickTime</message>
+
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Confidence was never recorded for this value</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">No reasonable confidence value was returned from the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">The authority recommends this submission be rejected</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">The authority encountered an internal failure</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">There are no matching answers in the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">There are multiple matching authority values of equal validity</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">Value is singular and valid but has not been seen and accepted by a human so it is still uncertain</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">This authority value has been confirmed as accurate by an interactive user</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Unlock the authority key value for manual editing, or toggle it locked again</message>
+
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">DSpace Value Lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Accept</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Add</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancel</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">See More Results</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Results @1@ to @2@ of @3@ for "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
+
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up Publisher</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non-authority value: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in "Last, First" format</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Last name, e.g. "Smith"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">First name(s) e.g. "Fred"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Name Authority author lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Local value "@1@" (not in Naming Authority)</message>
+
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>
-
- 	  	 

--- a/src/main/webapp/i18n/messages_el.xml
+++ b/src/main/webapp/i18n/messages_el.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="el">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_es.xml
+++ b/src/main/webapp/i18n/messages_es.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--

--- a/src/main/webapp/i18n/messages_es.xml
+++ b/src/main/webapp/i18n/messages_es.xml
@@ -1,47 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-    
-                                      -->
-<catalogue xml:lang="en" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
-       		xmlui.<Aspect>.<Java Class>.<name>
-       		There are a few exceptions to this naming format,
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
+		There are a few exceptions to this naming format,
 		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
 		2) Some general keys which are specific to a particular aspect
 		   may be found at xmlui.<Aspect> without specifying a
-		   particular java class.        -->
-  <!--  messages from V1.5 Translated by Francisco Javier Herrero Vicente (fherrero@uji.es) at Universitat Jaume I de Castellon (http://www.uji.es/)-->    
-    <!--  modifications to v1.5 and messages from V1.6 and V1.7 translated by Alvaro López (alopez@arvo.es) at Arvo Consultores (http://www.arvo.es/)   -->
-    <!--  v1.8, V4 & V5 messages translated by Eva Braña (ebrana@arvo.es) and Emilio Lorenzo (elorenzo@arvo.es) at Arvo Consultores (http://www.arvo.es/)   -->
-	           
-<!-- General keys -->
-<message key="xmlui.general.dspace_home">DSpace Principal</message>
-<message key="xmlui.general.search">Búsquedas</message>
-<message key="xmlui.general.go">Ir</message>
-<message key="xmlui.general.go_home">Ir a página principal DSpace</message>
-<message key="xmlui.general.save">Guardar</message>
-<message key="xmlui.general.cancel">Cancelar</message>
-<message key="xmlui.general.return">Volver</message>
-<message key="xmlui.general.update">Modificar</message>
-<message key="xmlui.general.delete">Borrar</message>
-<message key="xmlui.general.next">Siguiente</message>
-<message key="xmlui.general.untitled">Sin título</message>
-<message key="xmlui.general.perform">Realizar</message>
-<message key="xmlui.general.queue">Encolar</message>
+		   particular java class.
+		-->
+
+	<!-- General keys -->
+	<message key="xmlui.general.dspace_home">DSpace Principal</message>
+	<message key="xmlui.general.search">Búsquedas</message>
+	<message key="xmlui.general.go">Ir</message>
+	<message key="xmlui.general.go_home">Ir a página principal DSpace</message>
+	<message key="xmlui.general.save">Guardar</message>
+	<message key="xmlui.general.cancel">Cancelar</message>
+	<message key="xmlui.general.return">Volver</message>
+	<message key="xmlui.general.update">Modificar</message>
+	<message key="xmlui.general.delete">Borrar</message>
+	<message key="xmlui.general.next">Siguiente</message>
+	<message key="xmlui.general.untitled">Sin título</message>
+        <message key="xmlui.general.perform">Realizar</message>
+        <message key="xmlui.general.queue">Encolar</message>
 
         <!-- Keys which are used by exception2dri.xsl on error pages -->
-<message key="xmlui.error.contact_msg">Por favor, contacte con el administrador si quiere informar de este error. Si es posible, proporcione detalles adicionales de lo que estaba haciendo cuando ocurrió el error.</message>
-<message key="xmlui.error.contact">Contactar con el administrador</message>
-<message key="xmlui.error.show_stack">Mostrar la pila de errores asociada</message>
+        <message key="xmlui.error.contact_msg">Por favor, contacte con el administrador si quiere informar de este error. Si es posible, proporcione detalles adicionales de lo que estaba haciendo cuando ocurrió el error.</message>
+        <message key="xmlui.error.contact">Contactar con el administrador</message>
+        <message key="xmlui.error.show_stack">Mostrar la pila de errores asociada</message>
 
 	<!--
 		Page not found keys
@@ -49,31 +39,31 @@
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
-<message key="xmlui.PageNotFound.title">Página no encontrada</message>
-<message key="xmlui.PageNotFound.head">Página no encontrada</message>
-<message key="xmlui.PageNotFound.para1">La página a la que está intentando acceder no se ha encontrado en el servidor</message>
+	<message key="xmlui.PageNotFound.title">Página no encontrada</message>
+	<message key="xmlui.PageNotFound.head">Página no encontrada</message>
+	<message key="xmlui.PageNotFound.para1">La página a la que está intentando acceder no se ha encontrado en el servidor</message>
 
 
 	<!--
 	   The "utils" non-aspect
        -->
-<message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Solo los administradores pueden acceder como otro usuario.</message>
-<message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Solo usuarios autenticados que sean administradores pueden acceder como otro usuario.</message>
-<message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">No puede realizar el acceso como otro administrador.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Solo los administradores pueden acceder como otro usuario.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Solo usuarios autenticados que sean administradores pueden acceder como otro usuario.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">No puede realizar el acceso como otro administrador.</message>
 
 
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
 	-->
-<message key="xmlui.feed.general_description">El repositorio digital DSpace captura, almacena, indexa, preserva y distribuye materiales de investigación en formato digital.</message>
-<message key="xmlui.feed.header">RSS Feeds</message>
-<message key="xmlui.feed.logo_title">Imagen</message>
-<message key="xmlui.feed.untitled">Sin título</message>
+	<message key="xmlui.feed.general_description">El repositorio digital DSpace captura, almacena, indexa, preserva y distribuye materiales de investigación en formato digital.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
+	<message key="xmlui.feed.logo_title">Imagen</message>
+	<message key="xmlui.feed.untitled">Sin título</message>
 
 	<!--
 		Default notice header
 	 	-->
-<message key="xmlui.general.notice.default_head">Aviso</message>
+	<message key="xmlui.general.notice.default_head">Aviso</message>
 
 
 
@@ -90,332 +80,352 @@
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultados de la búsqueda en la comunidad: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultados de la búsqueda en la colección: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultados de la búsqueda</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Su petición "{0}" produjo {1} resultados</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunidades o colecciones que coinciden con la petición</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Ítems que coinciden con la petición</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La búsqueda no produjo resultados</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultados de la búsqueda en la comunidad: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultados de la búsqueda en la colección: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultados de la búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Su petición "{0}" produjo {1} resultados</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunidades o colecciones que coinciden con la petición</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Ítems que coinciden con la petición</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La búsqueda no produjo resultados</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Todo DSpace</message>
 
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">título</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">fecha de publicación</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">fecha de envío</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinencia</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordenar ítems por</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en orden</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendente</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendente</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultados/página</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">título</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">fecha de publicación</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">fecha de envío</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinencia</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordenar ítems por</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en orden</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendente</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendente</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultados/página</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Búsqueda avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Búsqueda avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Búsqueda avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Ámbito de búsqueda</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limite la búsqueda a una comunidad o colección.</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunción</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipo de búsqueda</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Buscar por</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Título</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resumen</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Serie</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Idioma (ISO)</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Palabra clave</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Búsqueda avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Búsqueda avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Búsqueda avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Ámbito de búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limite la búsqueda a una comunidad o colección.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunción</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipo de búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Buscar por</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Título</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resumen</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Serie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Idioma (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Palabra clave</message>
 
    <!--  some common other possibilities for Advanced Search Fields -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contribuidor/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Creador/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripción</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relación</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Otro/a colaborador/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Asesor/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departamento</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contribuidor/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Creador/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descripción</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relación</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Otro/a colaborador/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Asesor/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departamento</message>
 
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texto completo</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">Y</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">O</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NO</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texto completo</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">Y</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">O</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NO</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introducir las primeras letras:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Listar ítems que empiezan con estas letras</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Saltar a un punto del índice:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Elegir mes)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Elegir año)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O introducir un año:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Listar ítems  de un determinado año.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Lo sentimos, no hay resultados para esta búsqueda.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordenar por:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Orden:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultados:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autores/Ítem:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">O introducir las primeras letras:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Listar ítems que empiezan con estas letras</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Saltar a un punto del índice:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Elegir mes)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Elegir año)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">O introducir un año:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Listar ítems  de un determinado año.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Lo sentimos, no hay resultados para esta búsqueda.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordenar por:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Orden:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultados:</message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autores/Ítem:</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Todos</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Todos</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">título</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">fecha de publicación</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">fecha de envío</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">título</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">fecha de publicación</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">fecha de envío</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendente</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendente</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendente</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendente</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nombre de los autores</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nombre de los autores</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Listar {0} por autor {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Listar {0} por autor</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Listar {0} por autor {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Listar {0} por autor</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Listar{0} por tema {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Listar {0} por tema</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Listar{0} por tema {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Listar {0} por tema</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Listar {0} por título {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Listar {0} por título</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Listar {0} por título {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Listar {0} por título</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Listar {0} por fecha de publicación {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Listar {0} fecha de publicación</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Listar {0} por fecha de publicación {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Listar {0} fecha de publicación</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Listar {0} por fecha de envío {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Listar {0} por fecha de envío</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Listar {0} por fecha de envío {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Listar {0} por fecha de envío</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Ámbito de búsqueda</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Búsqueda en esta colección:</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Listar por</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títulos</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autores</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Fechas</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Búsqueda avanzada</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Envíos recientes</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Ámbito de búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Búsqueda en esta colección:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Listar por</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autores</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Fechas</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Búsqueda avanzada</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Envíos recientes</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Lista de comunidades</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Lista de comunidades</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunidades en DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Elija una comunidad para listar sus colecciones</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Lista de comunidades</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Lista de comunidades</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunidades en DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Elija una comunidad para listar sus colecciones</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Ámbito de búsqueda</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Buscar en esta comunidad y sus colecciones:</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Listar por</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títulos</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autores</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Fechas</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Búsqueda avanzada</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunidades en esta comunidad</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Colecciones en esta comunidad</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Envíos recientes</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Ámbito de búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Buscar en esta comunidad y sus colecciones:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Listar por</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autores</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Fechas</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Búsqueda avanzada</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunidades en esta comunidad</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Colecciones en esta comunidad</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Envíos recientes</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-<message key="xmlui.ArtifactBrowser.Contact.title">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.trail">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.head">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.para1">Puede contactar con el administrador de {0} en:</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulario en línea</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.Contact.email">Correo electrónico</message>
+	<message key="xmlui.ArtifactBrowser.Contact.title">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">Puede contactar con el administrador de {0} en:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulario en línea</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Correo electrónico</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gracias por compartir sus sugerencias sobre DSpace. ¡Tendremos en cuenta sus comentarios!</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Su correo electrónico</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Esta dirección será utilizada para seguimiento de su sugerencia.</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentarios</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Gracias por compartir sus sugerencias sobre DSpace. ¡Tendremos en cuenta sus comentarios!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Su correo electrónico</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Esta dirección será utilizada para seguimiento de su sugerencia.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentarios</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Sugerencias</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Sugerencias</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Sugerencia enviada</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Su comentario ha sido recibido</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Sugerencias</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Sugerencia enviada</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Su comentario ha sido recibido</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Ver ítem</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Este ítem aparece en la(s) siguiente(s) colección(ones)</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostrar el registro sencillo del ítem</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostrar el registro completo del ítem</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Ver ítem</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Este ítem aparece en la(s) siguiente(s) colección(ones)</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostrar el registro sencillo del ítem</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostrar el registro completo del ítem</message>
 
-<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este ítem ha sido retirado y no está disponible</message>
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este ítem ha sido retirado y no está disponible</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Listar</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunidades &amp; Colecciones</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títulos</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autores</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materias</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Por fecha de publicación</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Por fecha de envío</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Esta colección</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Esta comunidad</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Listar</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunidades &amp; Colecciones</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autores</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materias</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Por fecha de publicación</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Por fecha de envío</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Esta colección</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Esta comunidad</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Ámbito de búsqueda</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Búsqueda a texto completo</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Ámbito de búsqueda</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Búsqueda a texto completo</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Este recurso está restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Este recurso está restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Esta comunidad está restringida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Esta colección está restringida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Este ítem está restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Este archivo está restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No tiene los permisos necesarios para acceder al recurso restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No tiene los permisos necesarios para acceder a la comunidad restringida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No tiene los permisos necesarios para acceder a la colección restringida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No tiene los permisos necesarios para acceder al ítem restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No tiene los permisos necesarios para acceder al archivo restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">colección</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunidad</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">archivo</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">ítem</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurso</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconocido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continue en la pantalla de acceso</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Este recurso está restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Este recurso está restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Esta comunidad está restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Esta colección está restringida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Este ítem está restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Este archivo está restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">No tiene los permisos necesarios para acceder al recurso restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">No tiene los permisos necesarios para acceder a la comunidad restringida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">No tiene los permisos necesarios para acceder a la colección restringida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">No tiene los permisos necesarios para acceder al ítem restringido<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">No tiene los permisos necesarios para acceder al archivo restringido<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">colección</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunidad</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">archivo</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">ítem</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurso</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconocido</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continue en la pantalla de acceso</message>
 
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem ha sido retirado  </message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">El ítem seleccionado ha sido retirado y no está disponible</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">El ítem seleccionado es de acceso restringido  y requiere de credenciales para su visualización. </message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Su usuario no dispone de permisos para ver el ítem. Para más información, contacte por favor con el administrador</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem ha sido retirado  </message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">El ítem seleccionado ha sido retirado y no está disponible</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">El ítem seleccionado es de acceso restringido  y requiere de credenciales para su visualización. </message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Su usuario no dispone de permisos para ver el ítem. Para más información, contacte por favor con el administrador</message>
         
 	<!-- Authentication messages used at the top of the login page:  -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Este ítem está restringido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">El ítem al que intenta acceder es un ítem restringido y requiere credenciales para verse. Por favor, identifíquese arriba para acceder al ítem.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Este ítem está restringido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">El ítem al que intenta acceder es un ítem restringido y requiere credenciales para verse. Por favor, identifíquese arriba para acceder al ítem.</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes Mensuales</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resumen Estadístico</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes Mensuales</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resumen Estadístico</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Sin informes disponibles en la actualidad</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">No hay actualmente informes disponibles para este servicio. Compruebe su disponibilidad más adelante.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Sin informes disponibles en la actualidad</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">No hay actualmente informes disponibles para este servicio. Compruebe su disponibilidad más adelante.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-<message key="xmlui.BitstreamReader.auth_header">El archivo está restringido</message>
-<message key="xmlui.BitstreamReader.auth_message">El archivo al que intenta acceder es un archivo restringido y requiere credenciales para verse. Por favor, identifíquese arriba para acceder al archivo.</message>
+	<message key="xmlui.BitstreamReader.auth_header">El archivo está restringido</message>
+	<message key="xmlui.BitstreamReader.auth_message">El archivo al que intenta acceder es un archivo restringido y requiere credenciales para verse. Por favor, identifíquese arriba para acceder al archivo.</message>
 
 	<!-- Export Archive download messages -->
-<message key="xmlui.ItemExportDownloadReader.auth_header">Este archivo de exportación está restringido.</message>
-<message key="xmlui.ItemExportDownloadReader.auth_message">El archivo de exportación al que intenta acceder es un recurso restringido y requiere permisos para ser visualizado. Autentíquese abajo para acceder al archivo de exportación.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Este archivo de exportación está restringido.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">El archivo de exportación al que intenta acceder es un recurso restringido y requiere permisos para ser visualizado. Autentíquese abajo para acceder al archivo de exportación.</message>
 
 
 	<!-- REQUEST COPY -->
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Solicitar una copia del documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Solicitar una copia del documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Solicitar una copia del documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Los usuarios de este sistema, pueden hacer login para ver este documento.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Introducir la siguiente información para solicitar una copia del documento a la persona responsable.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Su dirección de correo electrónico</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Esta dirección de correo electrónico es usada para enviar el documento.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">La dirección de correo electrónico es obligatoria</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Mensaje</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">El mensaje es obligatorio</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Ficheros</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Todos los ficheros (de este documento) en acceso restringido.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Sólo el fichero solicitado.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Nombre</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">El nombre es obligatorio</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Solicitud de copia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Solicitar una copia del documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Solicitar una copia del documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Solicitar una copia del documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Los usuarios de este sistema, pueden hacer login para ver este documento.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Introducir la siguiente información para solicitar una copia del documento a la persona responsable.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Su dirección de correo electrónico</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Esta dirección de correo electrónico es usada para enviar el documento.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">La dirección de correo electrónico es obligatoria</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Mensaje</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">El mensaje es obligatorio</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Ficheros</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Todos los ficheros (de este documento) en acceso restringido.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Sólo el fichero solicitado.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Nombre</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">El nombre es obligatorio</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Solicitud de copia</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Su solicitud ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Su solicitud ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Su solicitud ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Su solicitud ha sido enviada al autor o persona responsable</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Su solicitud ha sido enviada.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Su solicitud ha sido enviada.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Su solicitud ha sido enviada.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Su solicitud ha sido enviada al autor o persona responsable</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI USTED ES EL AUTOR (O UN AUTOR) DEL DOCUMENTO "{0}" use los botones para responder la solicitud del usuario.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Este repositorio proporcionará un modelo de respuesta apropiada, que usted puede editar.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Respuesta inicial al solicitante</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Solicitud de permiso del autor</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Enviar copia</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">No enviar copia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI USTED ES EL AUTOR (O UN AUTOR) DEL DOCUMENTO "{0}" use los botones para responder la solicitud del usuario.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Este repositorio proporcionará un modelo de respuesta apropiada, que usted puede editar.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Respuesta inicial al solicitante</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Solicitud de permiso del autor</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Enviar copia</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">No enviar copia</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Éste es el texto que será enviado al solicitante.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Mensaje</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Asunto</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Enviar</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Atrás</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Éste es el texto que será enviado al solicitante.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Mensaje</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Asunto</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Enviar</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Atrás</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Éste es el texto que será enviado al solicitante (junto con el documento).</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Mensaje</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Asunto</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Enviar</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Atrás</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Solicitud de copia de documento</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Éste es el texto que será enviado al solicitante (junto con el documento).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Mensaje</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Asunto</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Enviar</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Atrás</message>
 	
 	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Solicitud de cambio de permisos</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Solicitud de cambio de permisos</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Solicitud de cambio de permisos</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Puede aprovechar la ocasión para reconsiderar las restricciones de acceso al documento (para evitar tener que responder a estas solicitudes), si no hay ninguna razón para mantenerlo restringido. Para hacerlo, después de insertar su nombre y correo electrónico (para la autenticación), haga click en el botón "Cambio a Acceso Abierto".</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Nombre</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Correo electrónico</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">El nombre es obligatorio</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">La dirección de correo electrónico es obligatoria</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Cambiar a acceso abierto</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Solicitud de cambio de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Solicitud de cambio de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Solicitud de cambio de permisos</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Puede aprovechar la ocasión para reconsiderar las restricciones de acceso al documento (para evitar tener que responder a estas solicitudes), si no hay ninguna razón para mantenerlo restringido. Para hacerlo, después de insertar su nombre y correo electrónico (para la autenticación), haga click en el botón "Cambio a Acceso Abierto".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Nombre</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Correo electrónico</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">El nombre es obligatorio</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">La dirección de correo electrónico es obligatoria</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Cambiar a acceso abierto</message>
 	        
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Solicitud enviada</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Solicitud enviada</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Su solicitud de cambio de permisos ha sido enviada</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Su solicitud ha sido enviada al administrador</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Gracias</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Solicitud enviada</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Solicitud enviada</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Su solicitud de cambio de permisos ha sido enviada</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Su solicitud ha sido enviada al administrador</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Gracias</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Comunicación inicial con el solicitante, para permitirle conocer que su solicitud está siendo procesada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">Para</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Asunto</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Mensaje</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Enviar</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Atrás</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Comunicación inicial con el solicitante, para permitirle conocer que su solicitud está siendo procesada.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">Para</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Asunto</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Mensaje</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Enviar</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Atrás</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Solicitud de copia de documento</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">Éste es el texto que será enviado al solicitante (junto con el documento).</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">Para</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Asunto</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Mensaje</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Enviar</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Atrás</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Solicitud de copia de documento</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">Éste es el texto que será enviado al solicitante (junto con el documento).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">Para</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Asunto</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Mensaje</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Enviar</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Atrás</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Su respuesta ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Su respuesta ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Su respuesta ha sido enviada.</message>
-<message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Su respuesta ha sido enviada.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Su respuesta ha sido enviada.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Su respuesta ha sido enviada.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Su respuesta ha sido enviada.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Su respuesta ha sido enviada.</message>
 
 
 	
@@ -432,163 +442,163 @@
 
 
 	<!-- General keys used by the EPerson aspect -->
-<message key="xmlui.EPerson.trail_new_registration">Registro de usuario nuevo</message>
-<message key="xmlui.EPerson.trail_forgot_password">¿Olvidó la contraseña?</message>
+	<message key="xmlui.EPerson.trail_new_registration">Registro de usuario nuevo</message>
+	<message key="xmlui.EPerson.trail_forgot_password">¿Olvidó la contraseña?</message>
 
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-<message key="xmlui.EPerson.CannotRegister.title">Registro no disponible</message>
-<message key="xmlui.EPerson.CannotRegister.head">Registro no disponible</message>
-<message key="xmlui.EPerson.CannotRegister.para1">La configuración de este repositorio DSpace no permite registro en este contexto. Por favor, contacte con el </message>
+	<message key="xmlui.EPerson.CannotRegister.title">Registro no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Registro no disponible</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">La configuración de este repositorio DSpace no permite registro en este contexto. Por favor, contacte con el <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-<message key="xmlui.EPerson.EditProfile.title_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.title_create">Crear perfil</message>
-<message key="xmlui.EPerson.EditProfile.trail_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.head_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.head_create">Crear perfil</message>
-<message key="xmlui.EPerson.EditProfile.email_address">Dirección de correo electrónico</message>
-<message key="xmlui.EPerson.EditProfile.first_name">Nombre</message>
-<message key="xmlui.EPerson.EditProfile.last_name">Apellido</message>
-<message key="xmlui.EPerson.EditProfile.telephone">Teléfono de contacto</message>
-<message key="xmlui.EPerson.EditProfile.Language">Idioma</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions">Suscripciones</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions_help">Puede suscribirse a colecciones para recibir diariamente un correo con los nuevos ítems añadidos. Puede suscribirse a tantas colecciones como desee. Otra opción es usar el servicio RSS disponible para todas las colecciones.</message>
-<message key="xmlui.EPerson.EditProfile.email_subscriptions">Suscripción de Correo electrónico</message>
-<message key="xmlui.EPerson.EditProfile.select_collection">(Elija una colección)</message>
-<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalmente, puede elegir una contraseña nueva tecleándola en la casilla superior y verificarla en la segunda casilla. Debería tener al menos seis caracteres.</message>
-<message key="xmlui.EPerson.EditProfile.create_password_instructions">Por favor, introduzca una clave en la casilla superior. Confírmela volviendo a teclearla en la segunda casilla. Debería tener al menos seis caracteres.</message>
-<message key="xmlui.EPerson.EditProfile.password">Contraseña</message>
-<message key="xmlui.EPerson.EditProfile.confirm_password">Repita para confirmar</message>
-<message key="xmlui.EPerson.EditProfile.submit_update">Completar el registro</message>
-<message key="xmlui.EPerson.EditProfile.submit_create">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.error_required">Este campo es obligatorio</message>
-<message key="xmlui.EPerson.EditProfile.error_invalid_password">Elija una contraseña de al menos 6 caracteres</message>
-<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Por favor, repita la contraseña para confirmarla</message>
-<message key="xmlui.EPerson.EditProfile.head_auth">Usted pertenece a los siguientes grupos de autorización</message>
-<message key="xmlui.EPerson.EditProfile.head_identify">Identificar</message>
-<message key="xmlui.EPerson.EditProfile.head_security">Seguridad</message>
+	<message key="xmlui.EPerson.EditProfile.title_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Crear perfil</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Crear perfil</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Dirección de correo electrónico</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Nombre</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Apellido</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Teléfono de contacto</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Idioma</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Suscripciones</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Puede suscribirse a colecciones para recibir diariamente un correo con los nuevos ítems añadidos. Puede suscribirse a tantas colecciones como desee. Otra opción es usar el servicio RSS disponible para todas las colecciones.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Suscripción de Correo electrónico</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">(Elija una colección)</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalmente, puede elegir una contraseña nueva tecleándola en la casilla superior y verificarla en la segunda casilla. Debería tener al menos seis caracteres.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Por favor, introduzca una clave en la casilla superior. Confírmela volviendo a teclearla en la segunda casilla. Debería tener al menos seis caracteres.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Contraseña</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Repita para confirmar</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Completar el registro</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Este campo es obligatorio</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Elija una contraseña de al menos 6 caracteres</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Por favor, repita la contraseña para confirmarla</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Usted pertenece a los siguientes grupos de autorización</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identificar</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Seguridad</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifique el correo electrónico</message>
-<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crear perfil</message>
-<message key="xmlui.EPerson.EPersonUtils.register_finished">Terminado</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifique el correo electrónico</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restablecer contraseña</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Terminado</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifique el correo electrónico</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crear perfil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Terminado</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifique el correo electrónico</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Terminado</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-<message key="xmlui.EPerson.ForgotPasswordFinished.title">Restablecer contraseña</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.head">Restablecer contraseña</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Su contraseña ha sido restablecida</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Su contraseña ha sido restablecida</message>
 
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-<message key="xmlui.EPerson.InvalidToken.title">Cadena no válida</message>
-<message key="xmlui.EPerson.InvalidToken.trail">Cadena no válida</message>
-<message key="xmlui.EPerson.InvalidToken.head">Cadena no válida</message>
-<message key="xmlui.EPerson.InvalidToken.para1">La URL que ha indicado no es válida. Es posible que la URL haya sido fragmentada en varias líneas por su correo, como:</message>
-<message key="xmlui.EPerson.InvalidToken.para2">Si este es el caso, deberá copiar y pegar la URL completa directamente en la barra de dirección de su navegador, en lugar de simplemente pulsar el enlace. La barra de dirección deberá contener algo como lo siguiente:</message>
+	<message key="xmlui.EPerson.InvalidToken.title">Cadena no válida</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Cadena no válida</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Cadena no válida</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">La URL que ha indicado no es válida. Es posible que la URL haya sido fragmentada en varias líneas por su correo, como:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Si este es el caso, deberá copiar y pegar la URL completa directamente en la barra de dirección de su navegador, en lugar de simplemente pulsar el enlace. La barra de dirección deberá contener algo como lo siguiente:</message>
 
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-<message key="xmlui.EPerson.Navigation.my_account">Mi cuenta</message>
-<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
-<message key="xmlui.EPerson.Navigation.logout">Salir</message>
-<message key="xmlui.EPerson.Navigation.login">Acceder</message>
-<message key="xmlui.EPerson.Navigation.register">Registro</message>
+	<message key="xmlui.EPerson.Navigation.my_account">Mi cuenta</message>
+	<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
+	<message key="xmlui.EPerson.Navigation.logout">Salir</message>
+	<message key="xmlui.EPerson.Navigation.login">Acceder</message>
+	<message key="xmlui.EPerson.Navigation.register">Registro</message>
 
 	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-<message key="xmlui.EPerson.PasswordLogin.title">Acceder</message>
-<message key="xmlui.EPerson.PasswordLogin.trail">Acceder</message>
-<message key="xmlui.EPerson.PasswordLogin.head1">Acceder a DSpace</message>
-<message key="xmlui.EPerson.PasswordLogin.email_address">Correo electrónico</message>
-<message key="xmlui.EPerson.PasswordLogin.error_bad_login">La dirección de correo electrónico introducida y/o la contraseña no son válidas.</message>
-<message key="xmlui.EPerson.PasswordLogin.password">Contraseña</message>
-<message key="xmlui.EPerson.PasswordLogin.forgot_link">¿Olvidó su contraseña?</message>
-<message key="xmlui.EPerson.PasswordLogin.submit">Acceder</message>
-<message key="xmlui.EPerson.PasswordLogin.head2">Registrar un nuevo usuario</message>
-<message key="xmlui.EPerson.PasswordLogin.para1">Registre una cuenta para suscribirse a las colecciones, para recibir notificación de modificaciones y de nuevas adquisiciones de ítems en DSpace.</message>
-<message key="xmlui.EPerson.PasswordLogin.register_link">Pulse aquí para registrarse.</message>
+	<message key="xmlui.EPerson.PasswordLogin.title">Acceder</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Acceder</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Acceder a DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Correo electrónico</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">La dirección de correo electrónico introducida y/o la contraseña no son válidas.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Contraseña</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">¿Olvidó su contraseña?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Acceder</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Registrar un nuevo usuario</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Registre una cuenta para suscribirse a las colecciones, para recibir notificación de modificaciones y de nuevas adquisiciones de ítems en DSpace.</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Pulse aquí para registrarse.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-<message key="xmlui.EPerson.LDAPLogin.title">Acceder</message>
-<message key="xmlui.EPerson.LDAPLogin.trail">Acceder</message>
-<message key="xmlui.EPerson.LDAPLogin.head1">Acceder a DSpace</message>
-<message key="xmlui.EPerson.LDAPLogin.username">Nombre de usuario</message>
-<message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nombre de usuario o la contraseña no son validos</message>
-<message key="xmlui.EPerson.LDAPLogin.password">Contraseña</message>
-<message key="xmlui.EPerson.LDAPLogin.submit">Acceder</message>
+	<message key="xmlui.EPerson.LDAPLogin.title">Acceder</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Acceder</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Acceder a DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Nombre de usuario</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">El nombre de usuario o la contraseña no son validos</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Contraseña</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Acceder</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-<message key="xmlui.EPerson.LoginChooser.title">Escoger un método de acceso</message>
-<message key="xmlui.EPerson.LoginChooser.trail">Escoger nombre de usuario</message>
-<message key="xmlui.EPerson.LoginChooser.head1">Escoger un método de acceso</message>
-<message key="xmlui.EPerson.LoginChooser.para1">Acceso mediante:</message>
-<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticación mediante Shibboleth</message>
-<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticación mediante LDAP</message>
-<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticación mediante contraseña</message>
-<message key="org.dspace.eperson.X509Authentication.title">Autenticación mediante certificado web</message>
+	<message key="xmlui.EPerson.LoginChooser.title">Escoger un método de acceso</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Escoger nombre de usuario</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Escoger un método de acceso</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Acceso mediante:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticación mediante Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticación mediante LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticación mediante contraseña</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Autenticación mediante certificado web</message>
 
 	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Los credenciales proporcionadas son inválidas.</message>
-<message key="xmlui.EPerson.FailedAuthentication.BadArgs">La autenticación no ha sido posible debido argumentos recibidos inválidos.</message>
-<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No se encontró ningún usuario con los permisos especificados.</message>
-<message key="xmlui.EPerson.FailedAuthentication.title">Autenticación fallida</message>
-<message key="xmlui.EPerson.FailedAuthentication.trail">Autenticación fallida</message>
-<message key="xmlui.EPerson.FailedAuthentication.h1">Autenticación fallida</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Los credenciales proporcionadas son inválidas.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">La autenticación no ha sido posible debido argumentos recibidos inválidos.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">No se encontró ningún usuario con los permisos especificados.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Autenticación fallida</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Autenticación fallida</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Autenticación fallida</message>
 
 	<!-- Login xml files -->
-<message key="xmlui.eperson.noAuthMethod.head">No se ha encontrado método de autenticación</message>
-<message key="xmlui.eperson.noAuthMethod.p1">No se ha encontrado método de autenticación. Por favor, pónganse en contacto con el administrador.</message>
-<message key="xmlui.eperson.shibbLoginFailure.head">La autenticación mediante Shibboleth ha fallado.</message>
-<message key="xmlui.eperson.shibbLoginFailure.p1">La autenticación mediante Shibboleth no esta disponible en este momento. Por favor, pónganse en contacto con el administrador.</message>
+	<message key="xmlui.eperson.noAuthMethod.head">No se ha encontrado método de autenticación</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">No se ha encontrado método de autenticación. Por favor, pónganse en contacto con el administrador.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">La autenticación mediante Shibboleth ha fallado.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">La autenticación mediante Shibboleth no esta disponible en este momento. Por favor, pónganse en contacto con el administrador.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-<message key="xmlui.EPerson.ProfileUpdated.title">Perfil modificado</message>
-<message key="xmlui.EPerson.ProfileUpdated.trail">Modificar perfil</message>
-<message key="xmlui.EPerson.ProfileUpdated.head">Perfil modificado</message>
-<message key="xmlui.EPerson.ProfileUpdated.para1">La información de su perfil ha sido modificada.</message>
+	<message key="xmlui.EPerson.ProfileUpdated.title">Perfil modificado</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Modificar perfil</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Perfil modificado</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">La información de su perfil ha sido modificada.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-<message key="xmlui.EPerson.RegistrationFinished.title">Registro terminado</message>
-<message key="xmlui.EPerson.RegistrationFinished.head">Registro terminado</message>
-<message key="xmlui.EPerson.RegistrationFinished.para1">Ahora está registrado en el sistema DSpace. Puede suscribirse a colecciones para recibir por correo electrónico las modificaciones y las nuevas incorporaciones.</message>
+	<message key="xmlui.EPerson.RegistrationFinished.title">Registro terminado</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Registro terminado</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Ahora está registrado en el sistema DSpace. Puede suscribirse a colecciones para recibir por correo electrónico las modificaciones y las nuevas incorporaciones.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-<message key="xmlui.EPerson.ResetPassword.title">Restablecer contraseña</message>
-<message key="xmlui.EPerson.ResetPassword.head">Restablecer contraseña</message>
-<message key="xmlui.EPerson.ResetPassword.para1">Por favor, introduzca una nueva clave en la casilla superior. Confírmela volviendo a teclearla en la segunda casilla. Debería tener al menos seis caracteres.</message>
-<message key="xmlui.EPerson.ResetPassword.email_address">Dirección de correo electrónico</message>
-<message key="xmlui.EPerson.ResetPassword.new_password">Nueva contraseña</message>
-<message key="xmlui.EPerson.ResetPassword.confirm_password">Repita para confirmar</message>
-<message key="xmlui.EPerson.ResetPassword.submit">Restablecer contraseña</message>
-<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Elija una contraseña de al menos 6 caracteres</message>
-<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Por favor, repita su contraseña para confirmarla</message>
+	<message key="xmlui.EPerson.ResetPassword.title">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Por favor, introduzca una nueva clave en la casilla superior. Confírmela volviendo a teclearla en la segunda casilla. Debería tener al menos seis caracteres.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Dirección de correo electrónico</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Nueva contraseña</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Repita para confirmar</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Elija una contraseña de al menos 6 caracteres</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Por favor, repita su contraseña para confirmarla</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-<message key="xmlui.EPerson.StartForgotPassword.title">¿Olvidó la contraseña?</message>
-<message key="xmlui.EPerson.StartForgotPassword.head">¿Olvidó la contraseña?</message>
-<message key="xmlui.EPerson.StartForgotPassword.para1">Introduzca la dirección de correo electrónico que proporcionó cuando se registró con DSpace. Se le enviará un mensaje a esa dirección con las instrucciones pertinentes.</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address">Dirección de correo electrónico</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduzca la misma dirección con la que se registró.</message>
-<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Dirección de correo electrónico no encontrada.</message>
-<message key="xmlui.EPerson.StartForgotPassword.submit">Enviar información</message>
+	<message key="xmlui.EPerson.StartForgotPassword.title">¿Olvidó la contraseña?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">¿Olvidó la contraseña?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Introduzca la dirección de correo electrónico que proporcionó cuando se registró con DSpace. Se le enviará un mensaje a esa dirección con las instrucciones pertinentes.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Dirección de correo electrónico</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduzca la misma dirección con la que se registró.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Dirección de correo electrónico no encontrada.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Enviar información</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-<message key="xmlui.EPerson.StartRegistration.title">Registro de nuevo usuario</message>
-<message key="xmlui.EPerson.StartRegistration.head1">Dirección de correo electrónico en uso</message>
-<message key="xmlui.EPerson.StartRegistration.para1">Esta dirección de correo está siendo utilizada por otra persona. Si quiere restablecer la contraseña para esta cuenta, pulse el botón de Restablecer contraseña.</message>
-<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restablecer contraseña para:</message>
-<message key="xmlui.EPerson.StartRegistration.submit_reset">Restablecer contraseña</message>
-<message key="xmlui.EPerson.StartRegistration.head2">Registro de nuevo usuario</message>
-<message key="xmlui.EPerson.StartRegistration.para2">Registrar una cuenta para suscribirse a colecciones para recibir por correo electrónico las modificaciones y las nuevas incorporaciones.</message>
-<message key="xmlui.EPerson.StartRegistration.email_address">Dirección de correo electrónico</message>
-<message key="xmlui.EPerson.StartRegistration.email_address_help">Esta dirección será verificada y utilizada como su nombre de acceso.</message>
-<message key="xmlui.EPerson.StartRegistration.error_bad_email">Es imposible enviar un correo electrónico a esta dirección.</message>
-<message key="xmlui.EPerson.StartRegistration.submit_register">Registro</message>
+	<message key="xmlui.EPerson.StartRegistration.title">Registro de nuevo usuario</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Dirección de correo electrónico en uso</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Esta dirección de correo está siendo utilizada por otra persona. Si quiere restablecer la contraseña para esta cuenta, pulse el botón de Restablecer contraseña.</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restablecer contraseña para:</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Restablecer contraseña</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Registro de nuevo usuario</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Registrar una cuenta para suscribirse a colecciones para recibir por correo electrónico las modificaciones y las nuevas incorporaciones.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Dirección de correo electrónico</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Esta dirección será verificada y utilizada como su nombre de acceso.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Es imposible enviar un correo electrónico a esta dirección.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Registro</message>
 
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-<message key="xmlui.EPerson.VerifyEmail.title">Correo de verificación enviado</message>
-<message key="xmlui.EPerson.VerifyEmail.head">Correo de verificación enviado</message>
-<message key="xmlui.EPerson.VerifyEmail.para">Se ha enviado un correo a {0} que contiene una URL especial e instrucciones de registro.</message>
+	<message key="xmlui.EPerson.VerifyEmail.title">Correo de verificación enviado</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Correo de verificación enviado</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">Se ha enviado un correo a {0} que contiene una URL especial e instrucciones de registro.</message>
 
 
 
@@ -608,341 +618,341 @@
 
 
 	<!-- general submission aspect messages -->
-<message key="xmlui.Submission.general.mydspace_home">DSpace Principal</message>
-<message key="xmlui.Submission.general.go_mydspace">Mi DSpace</message>
-<message key="xmlui.Submission.general.submission.title">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.trail">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.head">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
-<message key="xmlui.Submission.general.submission.save">Guardar / Salir</message>
-<message key="xmlui.Submission.general.submission.next">Siguiente &gt;</message>
-<message key="xmlui.Submission.general.submission.complete">Completar el envío</message>
-<message key="xmlui.Submission.general.workflow.title">Envío de ítems</message>
-<message key="xmlui.Submission.general.workflow.trail">Envío de ítems</message>
-<message key="xmlui.Submission.general.workflow.head">Envío de ítems</message>
-<message key="xmlui.Submission.general.showfull">Mostrar el registro completo del ítem</message>
-<message key="xmlui.Submission.general.showsimple">Mostrar el registro sencillo del ítem</message>
-<message key="xmlui.Submission.general.default.title">Envío</message>
-<message key="xmlui.Submission.general.default.trail">Envío</message>
+	<message key="xmlui.Submission.general.mydspace_home">DSpace Principal</message>
+	<message key="xmlui.Submission.general.go_mydspace">Mi DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.trail">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.head">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
+	<message key="xmlui.Submission.general.submission.save">Guardar / Salir</message>
+	<message key="xmlui.Submission.general.submission.next">Siguiente &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Completar el envío</message>
+	<message key="xmlui.Submission.general.workflow.title">Envío de ítems</message>
+	<message key="xmlui.Submission.general.workflow.trail">Envío de ítems</message>
+	<message key="xmlui.Submission.general.workflow.head">Envío de ítems</message>
+	<message key="xmlui.Submission.general.showfull">Mostrar el registro completo del ítem</message>
+	<message key="xmlui.Submission.general.showsimple">Mostrar el registro sencillo del ítem</message>
+	<message key="xmlui.Submission.general.default.title">Envío</message>
+	<message key="xmlui.Submission.general.default.trail">Envío</message>
 
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-<message key="xmlui.Submission.CollectionViewer.link1">Enviar un ítem a esta colección</message>
+	<message key="xmlui.Submission.CollectionViewer.link1">Enviar un ítem a esta colección</message>
 
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
-<message key="xmlui.Submission.Navigation.submissions">Envíos</message>
+	<message key="xmlui.Submission.Navigation.submissions">Envíos</message>
 
 
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
-<message key="xmlui.Submission.Submissions.title">Envíos &amp; Flujos de trabajo</message>
-<message key="xmlui.Submission.Submissions.trail">Envíos</message>
-<message key="xmlui.Submission.Submissions.head">Envíos &amp; tareas del flujo de trabajo</message>
-<message key="xmlui.Submission.Submissions.untitled"><i>Sin título</i></message>
-<message key="xmlui.Submission.Submissions.email">correo electrónico:</message>
+	<message key="xmlui.Submission.Submissions.title">Envíos &amp; Flujos de trabajo</message>
+	<message key="xmlui.Submission.Submissions.trail">Envíos</message>
+	<message key="xmlui.Submission.Submissions.head">Envíos &amp; tareas del flujo de trabajo</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">correo electrónico:</message>
 	<!-- Same transformer, workflow section -->
-<message key="xmlui.Submission.Submissions.workflow_head1">Tareas del flujo de trabajo</message>
-<message key="xmlui.Submission.Submissions.workflow_info1">Estas tareas son ítems que están esperando aprobación antes de ser añadidas al repositorio. Hay dos colas de tareas, una para tareas que ha aceptado y otra para tareas que todavía no han sido asumidas por nadie.</message>
-<message key="xmlui.Submission.Submissions.workflow_head2">Sus tareas</message>
-<message key="xmlui.Submission.Submissions.workflow_column1"> </message>
-<message key="xmlui.Submission.Submissions.workflow_column2">Tarea</message>
-<message key="xmlui.Submission.Submissions.workflow_column3">Ítem</message>
-<message key="xmlui.Submission.Submissions.workflow_column4">Colección</message>
-<message key="xmlui.Submission.Submissions.workflow_column5">Remitente</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_return">Devolver las tareas seleccionadas a la cola</message>
-<message key="xmlui.Submission.Submissions.workflow_info2">No tiene asignada ninguna tarea</message>
-<message key="xmlui.Submission.Submissions.workflow_head3">Tareas en cola</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_take">Asumir las tareas seleccionadas</message>
-<message key="xmlui.Submission.Submissions.workflow_info3">No hay tareas en cola</message>
+	<message key="xmlui.Submission.Submissions.workflow_head1">Tareas del flujo de trabajo</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Estas tareas son ítems que están esperando aprobación antes de ser añadidas al repositorio. Hay dos colas de tareas, una para tareas que ha aceptado y otra para tareas que todavía no han sido asumidas por nadie.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Sus tareas</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"> </message>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Tarea</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Ítem</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Colección</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Remitente</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Devolver las tareas seleccionadas a la cola</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">No tiene asignada ninguna tarea</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Tareas en cola</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Asumir las tareas seleccionadas</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">No hay tareas en cola</message>
 	<!-- Same transformer, submissions section -->
-<message key="xmlui.Submission.Submissions.submit_head1">Envíos</message>
-<message key="xmlui.Submission.Submissions.submit_info1a">Debería </message>
-<message key="xmlui.Submission.Submissions.submit_info1b"> comenzar un nuevo envío</message>
-<message key="xmlui.Submission.Submissions.submit_info1c">El proceso de envío consiste en cumplimentar el formulario de metadatos y depositar el fichero(s) que compone(n) el ítem digital. Cada comunidad o colección puede tener su propia política de envíos.</message>
-<message key="xmlui.Submission.Submissions.submit_head2">Envíos no terminados</message>
-<message key="xmlui.Submission.Submissions.submit_info2a">Estos son los envíos parciales de ítems que no han sido completados. Podría</message>
-<message key="xmlui.Submission.Submissions.submit_info2b"> comenzar otro envío</message>
-<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-<message key="xmlui.Submission.Submissions.submit_column1"></message>
-<message key="xmlui.Submission.Submissions.submit_column2">Título</message>
-<message key="xmlui.Submission.Submissions.submit_column3">Colección</message>
-<message key="xmlui.Submission.Submissions.submit_column4">Remitente</message>
-<message key="xmlui.Submission.Submissions.submit_head3">Autoría</message>
-<message key="xmlui.Submission.Submissions.submit_info3">No hay envíos incompletos.</message>
-<message key="xmlui.Submission.Submissions.submit_head4">Supervisando:</message>
-<message key="xmlui.Submission.Submissions.submit_submit_remove">Eliminar los envíos seleccionados</message>
+	<message key="xmlui.Submission.Submissions.submit_head1">Envíos</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Debería </message>
+	<message key="xmlui.Submission.Submissions.submit_info1b"> comenzar un nuevo envío</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">El proceso de envío consiste en cumplimentar el formulario de metadatos y depositar el fichero(s) que compone(n) el ítem digital. Cada comunidad o colección puede tener su propia política de envíos.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Envíos no terminados</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Estos son los envíos parciales de ítems que no han sido completados. Podría</message>
+	<message key="xmlui.Submission.Submissions.submit_info2b"> comenzar otro envío</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Título</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Colección</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Remitente</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Autoría</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">No hay envíos incompletos.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Supervisando:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Eliminar los envíos seleccionados</message>
 	<!-- Same transformer, inprogress section -->
-<message key="xmlui.Submission.Submissions.progress_head1">Envíos en revisión</message>
-<message key="xmlui.Submission.Submissions.progress_info1">Estos son los envíos completados que están siendo revisados por los responsables de la colección.</message>
-<message key="xmlui.Submission.Submissions.progress_column1">Título</message>
-<message key="xmlui.Submission.Submissions.progress_column2">Colección</message>
-<message key="xmlui.Submission.Submissions.progress_column3">Estado</message>
+	<message key="xmlui.Submission.Submissions.progress_head1">Envíos en revisión</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Estos son los envíos completados que están siendo revisados por los responsables de la colección.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Título</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Colección</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Estado</message>
 	<!-- Same transformer, workflow status -->
-<message key="xmlui.Submission.Submissions.status_0">Enviados</message>
-<message key="xmlui.Submission.Submissions.status_1">En espera de revisión</message>
-<message key="xmlui.Submission.Submissions.status_2">En revisión</message>
-<message key="xmlui.Submission.Submissions.status_3">En espera de revisión del editor</message>
-<message key="xmlui.Submission.Submissions.status_4">En edición</message>
-<message key="xmlui.Submission.Submissions.status_5">En espera de la revisión final del editor</message>
-<message key="xmlui.Submission.Submissions.status_6">En edición</message>
-<message key="xmlui.Submission.Submissions.status_7">Envío archivado</message>
-<message key="xmlui.Submission.Submissions.status_unknown">Estado desconocido</message>
+	<message key="xmlui.Submission.Submissions.status_0">Enviados</message>
+	<message key="xmlui.Submission.Submissions.status_1">En espera de revisión</message>
+	<message key="xmlui.Submission.Submissions.status_2">En revisión</message>
+	<message key="xmlui.Submission.Submissions.status_3">En espera de revisión del editor</message>
+	<message key="xmlui.Submission.Submissions.status_4">En edición</message>
+	<message key="xmlui.Submission.Submissions.status_5">En espera de la revisión final del editor</message>
+	<message key="xmlui.Submission.Submissions.status_6">En edición</message>
+	<message key="xmlui.Submission.Submissions.status_7">Envío archivado</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Estado desconocido</message>
         <!-- Same transformer, completed submissions section -->
-<message key="xmlui.Submission.Submissions.completed.head">Envíos Archivados</message>
-<message key="xmlui.Submission.Submissions.completed.info">Estos son sus envíos aceptados en Dspace</message>
-<message key="xmlui.Submission.Submissions.completed.column1">Fecha de aceptación</message>
-<message key="xmlui.Submission.Submissions.completed.column2">Título</message>
-<message key="xmlui.Submission.Submissions.completed.column3">Colección</message>
-<message key="xmlui.Submission.Submissions.completed.limit">Solo se muestran 50 de sus envíos archivados</message>
-<message key="xmlui.Submission.Submissions.completed.displayall">Mostrar todos mis envíos archivados.</message>
+        <message key="xmlui.Submission.Submissions.completed.head">Envíos Archivados</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Estos son sus envíos aceptados en Dspace</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Fecha de aceptación</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Título</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Colección</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Solo se muestran 50 de sus envíos archivados</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Mostrar todos mis envíos archivados.</message>
 
 	<!-- submission progress bar messages -->
-<message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntas iniciales</message>
-<message key="xmlui.Submission.submit.progressbar.describe">Describir</message>
-<message key="xmlui.Submission.submit.progressbar.access">Acceder</message>
-<message key="xmlui.Submission.submit.progressbar.upload">Subir  </message>
-<message key="xmlui.Submission.submit.progressbar.verify">Revisar</message>
-<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-<message key="xmlui.Submission.submit.progressbar.CClicense">Licencia CC</message>
-<message key="xmlui.Submission.submit.progressbar.license">Licencia</message>
-<message key="xmlui.Submission.submit.progressbar.complete">Completar</message>
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntas iniciales</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Describir</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Acceder</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Subir  </message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Revisar</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">Licencia CC</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Licencia</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Completar</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Reanudar</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Reanudar</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-<message key="xmlui.Submission.submit.SelectCollection.head">Seleccione una colección...</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection">Colección</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccione la colección a la que quiere enviar un ítem.</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccione una colección...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.head">Seleccione una colección...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Colección</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccione la colección a la que quiere enviar un ítem.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccione una colección...</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">¿Guardar o cancelar el envío?</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">¿Desea eliminar el envío, o prefiere guardarlo para continuar trabajando en él más tarde? También puede volver donde dejó el proceso de envío si pulsó Cancelar por error.</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continuar el envío</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Guardar para continuar más tarde</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Eliminar el envío</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">¿Guardar o cancelar el envío?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">¿Desea eliminar el envío, o prefiere guardarlo para continuar trabajando en él más tarde? También puede volver donde dejó el proceso de envío si pulsó Cancelar por error.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continuar el envío</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Guardar para continuar más tarde</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Eliminar el envío</message>
 
 
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntas iniciales</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota importante:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.and">y</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Múltiples títulos</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">El ítem tiene más de un título, <i>p.ej. un título traducido</i></message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la casilla contigua está desmarcada, entonces el título(s) será eliminado del ítem:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicado</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">El ítem ha sido publicado o públicamente distribuido antes</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la casilla contigua está desmarcada, entonces el elemento será eliminado del ítem:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Fecha de publicación</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntas iniciales</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota importante:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and">y</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Múltiples títulos</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">El ítem tiene más de un título, <i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la casilla contigua está desmarcada, entonces el título(s) será eliminado del ítem:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicado</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">El ítem ha sido publicado o públicamente distribuido antes</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la casilla contigua está desmarcada, entonces el elemento será eliminado del ítem:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Fecha de publicación</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-<message key="xmlui.Submission.submit.DescribeStep.head">Describir el ítem</message>
-<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: Tipo de campo desconocido</message>
-<message key="xmlui.Submission.submit.DescribeStep.required_field">Este campo es obligatorio</message>
-<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Apellido, <i>p.ej. Pérez</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nombre(s), <i>p.ej. Manuel</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.year">Año</message>
-<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
-<message key="xmlui.Submission.submit.DescribeStep.day">Día</message>
-<message key="xmlui.Submission.submit.DescribeStep.series_name">Nombre de la serie</message>
-<message key="xmlui.Submission.submit.DescribeStep.report_no">Informe No.</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Categorías temáticas</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Categorías temáticas</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtrar materias</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtrar</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Espere mientras se carga el vocabulario controlado.</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Hubo algún error en la carga del vocabulario controlado, por favor, inténtelo de nuevo más adelante.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.head">Describir el ítem</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Error: Tipo de campo desconocido</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Este campo es obligatorio</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Apellido, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nombre(s), <i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Año</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Día</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nombre de la serie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Informe No.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Categorías temáticas</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Categorías temáticas</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtrar materias</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtrar</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Espere mientras se carga el vocabulario controlado.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Hubo algún error en la carga del vocabulario controlado, por favor, inténtelo de nuevo más adelante.</message>
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
-<message key="xmlui.Submission.submit.AccessStep.head">Ajuste de Accesos</message>
-<message key="xmlui.Submission.submit.AccessStep.access_settings">Visible a un grupo de usuarios (no se requiere para usuarios Anónimos</message>
-<message key="xmlui.Submission.submit.AccessStep.open_access">El Ítem será visible una vez se acepte en el archivo</message>
-<message key="xmlui.Submission.submit.AccessStep.embargo">Embargo hasta una fecha específica</message>
-<message key="xmlui.Submission.submit.AccessStep.embargo_visible">Visible/Embargado</message>
-<message key="xmlui.Submission.submit.AccessStep.name">Nombre de la Política</message>
-<message key="xmlui.Submission.submit.AccessStep.name_help">Una descripción corta de la política (hasta 30 caracteres). Se podría mostrar a los usuarios,  p.ej. "Sólo personal". Opcional, pero recomendado.</message>
-<message key="xmlui.Submission.submit.AccessStep.description">Descripción</message>
-<message key="xmlui.Submission.submit.AccessStep.reason">Motivo del embargo</message>
-<message key="xmlui.Submission.submit.AccessStep.reason_help">La razón del embargo, para uso interno normalmente. Opcional.</message>
-<message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirmar privilegios &amp; añadir más</message>
-<message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Grupos</message>
-<message key="xmlui.Submission.submit.AccessStep.error_format_date">Error en el formato de la fecha</message>
-<message key="xmlui.Submission.submit.AccessStep.error_missing_date">Si selecciona Embargo, se requiere especificar fecha</message>
-<message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Ya existen privilegios idénticos para este grupo y esta acción.</message>
-<message key="xmlui.Submission.submit.AccessStep.table_policies">Lista de privilegios</message>
-<message key="xmlui.Submission.submit.AccessStep.policies_help">Las políticas listadas en esta sección anulan las políticas de la colección a la que Vd. está enviando. Si desea fijar un embargo, pero la colección destino permite acceso a cualquier usuario, debe determinar una política que permita el acceso a los usuarios anónimos sólo a partir de determinada fecha.</message>
-<message key="xmlui.Submission.submit.AccessStep.no_policies">No se han fijado políticas de grupo para este ítem. </message>
-<message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
-<message key="xmlui.Submission.submit.AccessStep.private_settings">Ítem privado</message>
-<message key="xmlui.Submission.submit.AccessStep.private_settings_help">Si selecciona, el ítem no se incluirá en los resultados de las búsquedas</message>
-<message key="xmlui.Submission.submit.AccessStep.private_settings_label">Privado</message>
-<message key="xmlui.Submission.submit.AccessStep.column0">Nombre</message>
-<message key="xmlui.Submission.submit.AccessStep.column1">Acción</message>
-<message key="xmlui.Submission.submit.AccessStep.column2">Grupo</message>
-<message key="xmlui.Submission.submit.AccessStep.column3">Fecha de comienzo</message>
-<message key="xmlui.Submission.submit.AccessStep.column4">Fecha de Finalización</message>
-<message key="xmlui.Submission.submit.AccessStep.table_edit_button">Editar</message>
-<message key="xmlui.Submission.submit.AccessStep.table_delete_button">Eliminar</message>
-<message key="xmlui.administrative.authorization.AccessStep.label_date_help">El primer día en se permite el acceso. Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
-<message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nombre: {0}; acción: {1}, grupo: {2}, fecha de comienzo: {3}, fecha finalización: {4}</message>
-<message key="xmlui.Submission.submit.AccessStep.review_public_item">El ítem se encontrará en las búsquedas</message>
-<message key="xmlui.Submission.submit.AccessStep.review_private_item">El ítem no se encontrará en las búsquedas</message>
+    <message key="xmlui.Submission.submit.AccessStep.head">Ajuste de Accesos</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible a un grupo de usuarios (no se requiere para usuarios Anónimos</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">El Ítem será visible una vez se acepte en el archivo</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo hasta una fecha específica</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Visible/Embargado</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Nombre de la Política</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">Una descripción corta de la política (hasta 30 caracteres). Se podría mostrar a los usuarios,  p.ej. "Sólo personal". Opcional, pero recomendado.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Descripción</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Motivo del embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">La razón del embargo, para uso interno normalmente. Opcional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirmar privilegios &amp; añadir más</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Grupos</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error en el formato de la fecha</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Si selecciona Embargo, se requiere especificar fecha</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Ya existen privilegios idénticos para este grupo y esta acción.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Lista de privilegios</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Las políticas listadas en esta sección anulan las políticas de la colección a la que Vd. está enviando. Si desea fijar un embargo, pero la colección destino permite acceso a cualquier usuario, debe determinar una política que permita el acceso a los usuarios anónimos sólo a partir de determinada fecha.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No se han fijado políticas de grupo para este ítem. </message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Ítem privado</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Si selecciona, el ítem no se incluirá en los resultados de las búsquedas</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Privado</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Nombre</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Acción</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Grupo</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Fecha de comienzo</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">Fecha de Finalización</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Editar</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Eliminar</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">El primer día en se permite el acceso. Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nombre: {0}; acción: {1}, grupo: {2}, fecha de comienzo: {3}, fecha finalización: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">El ítem se encontrará en las búsquedas</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">El ítem no se encontrará en las búsquedas</message>
 
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
-<message key="xmlui.Submission.submit.EditPolicyStep.head">Editar Política</message>
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Editar Política</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-<message key="xmlui.Submission.submit.UploadStep.head">Subir fichero(s)</message>
-<message key="xmlui.Submission.submit.UploadStep.file">Fichero</message>
-<message key="xmlui.Submission.submit.UploadStep.file_help">Por favor, introduzca la ruta completa del fichero en su ordenador que corresponda con el ítem. Si pincha en "Examinar...", se abrirá una ventana que le permitirá seleccionar un fichero de su ordenador.</message>
-<message key="xmlui.Submission.submit.UploadStep.file_error">El ítem debe contener al menos un fichero.</message>
-<message key="xmlui.Submission.submit.UploadStep.upload_error">Hubo un problema subiendo su fichero. Bien el nombre del fichero era incorrecto, o hubo un problema de red  que impidió que el fichero nos llegase correctamente, o ha adjuntado un fichero cuyo formato solo se permite para usos internos del sistema. Por favor, inténtelo de nuevo.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_error">El fichero no ha sido subido pues parece contener un virus. Contacte por favor con el administrador</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Hubo un problema al intentar comprobar la existencia de virus en el fichero. Por favor, contacte con el administrador del sistema.</message>
-<message key="xmlui.Submission.submit.UploadStep.description">Descripción del fichero</message>
-<message key="xmlui.Submission.submit.UploadStep.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Artículo principal</i>", o "<i>Lectura de los datos del documento</i>".</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_upload">Subir fichero y añadir otro más</message>
-<message key="xmlui.Submission.submit.UploadStep.head2">Ficheros Subidos</message>
-<message key="xmlui.Submission.submit.UploadStep.column0">Primario</message>
-<message key="xmlui.Submission.submit.UploadStep.column1"></message>
-<message key="xmlui.Submission.submit.UploadStep.column2">Fichero</message>
-<message key="xmlui.Submission.submit.UploadStep.column3">Tamaño</message>
-<message key="xmlui.Submission.submit.UploadStep.column4">Descripción</message>
-<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
-<message key="xmlui.Submission.submit.UploadStep.column6"></message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconocido</message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_format">formato desconocido</message>
-<message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
-<message key="xmlui.Submission.submit.UploadStep.known">(Conocido)</message>
-<message key="xmlui.Submission.submit.UploadStep.unsupported">(No Soportado)</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editar</message>
-<message key="xmlui.Submission.submit.UploadStep.checksum">Verificación de fichero:</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_remove">Eliminar los ficheros seleccionados</message>
+	<message key="xmlui.Submission.submit.UploadStep.head">Subir fichero(s)</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Fichero</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Por favor, introduzca la ruta completa del fichero en su ordenador que corresponda con el ítem. Si pincha en "Examinar...", se abrirá una ventana que le permitirá seleccionar un fichero de su ordenador.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">El ítem debe contener al menos un fichero.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Hubo un problema subiendo su fichero. Bien el nombre del fichero era incorrecto, o hubo un problema de red  que impidió que el fichero nos llegase correctamente, o ha adjuntado un fichero cuyo formato solo se permite para usos internos del sistema. Por favor, inténtelo de nuevo.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">El fichero no ha sido subido pues parece contener un virus. Contacte por favor con el administrador</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Hubo un problema al intentar comprobar la existencia de virus en el fichero. Por favor, contacte con el administrador del sistema.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Descripción del fichero</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Subir fichero y añadir otro más</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Ficheros Subidos</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Primario</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Fichero</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Tamaño</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Descripción</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconocido</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">formato desconocido</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Conocido)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(No Soportado)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editar</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Verificación de fichero:</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Eliminar los ficheros seleccionados</message>
 
 
 
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Subir Fichero(s)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fichero</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Por favor, introduzca el path completo del fichero que corresponda a su ítem. Si pulsa "Ver.." aparecerá una nueva ventana desde la que podrá seleccionar el fichero.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">El ítem debe contener al menos un fichero.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Hubo un problema subiendo su fichero. Bien el nombre del fichero era incorrecto, o hubo un problema de red  que impidió que el fichero nos llegase correctamente, o ha adjuntado un fichero cuyo formato solo se permite para usos internos del sistema. Por favor, inténtelo de nuevo.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">No se ha subido el fichero ya que parece contener un virus. Por favor, contacte con el administrador del sistema.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Hubo un problema al intentar comprobar la existencia de virus en el fichero. Por favor, contacte con el administrador del sistema.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Descripción del fichero</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, describa brevemente el fichero, por ejemplo "<i>Artículo principal</i>", r "<i>Datos Experimentales</i>".</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Subir Fichero &amp; añadir otro</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Ficheros Subidos</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primario</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Fichero</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Tamaño</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Descripción</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formato</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"> </message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Desconocido</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">formato desconocido</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Compatible)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Conocido)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(No Soportado)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Editar</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Verificación de fichero:</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Eliminar los ficheros seleccionados</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Privilegios</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Subir Fichero(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fichero</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Por favor, introduzca el path completo del fichero que corresponda a su ítem. Si pulsa "Ver.." aparecerá una nueva ventana desde la que podrá seleccionar el fichero.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">El ítem debe contener al menos un fichero.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Hubo un problema subiendo su fichero. Bien el nombre del fichero era incorrecto, o hubo un problema de red  que impidió que el fichero nos llegase correctamente, o ha adjuntado un fichero cuyo formato solo se permite para usos internos del sistema. Por favor, inténtelo de nuevo.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">No se ha subido el fichero ya que parece contener un virus. Por favor, contacte con el administrador del sistema.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Hubo un problema al intentar comprobar la existencia de virus en el fichero. Por favor, contacte con el administrador del sistema.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Descripción del fichero</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, describa brevemente el fichero, por ejemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Subir Fichero &amp; añadir otro</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Ficheros Subidos</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primario</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Fichero</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Tamaño</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Descripción</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formato</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"> </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Desconocido</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">formato desconocido</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Compatible)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Conocido)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(No Soportado)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Editar</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Verificación de fichero:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Eliminar los ficheros seleccionados</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Privilegios</message>
 
 
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-<message key="xmlui.Submission.submit.EditFileStep.head">Editar fichero</message>
-<message key="xmlui.Submission.submit.EditFileStep.file">Fichero</message>
-<message key="xmlui.Submission.submit.EditFileStep.description">Descripción del fichero</message>
-<message key="xmlui.Submission.submit.EditFileStep.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Artículo principal</i>", o "<i>Lectura de los datos del documento</i>".</message>
-<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccione en la lista el formato del archivo, por ejemplo "<i>Adobe PDF</i>" o "<i>Microsoft Word</i>". Si el formato no está en la lista, por favor, describa el formato del archivo en la casilla bajo la lista.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato detectado</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_selected">Formato elegido</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_default">El formato no está en la lista</message>
-<message key="xmlui.Submission.submit.EditFileStep.info2">Si el formato no está en la lista, <strong>seleccione "El formato no está en la lista" </strong> y descríbalo en la casilla inferior.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user">Otro formato</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user_help">El nombre y versión de la aplicación que utilizó para crear el fichero (por ejemplo, "<i>ACMESoft SuperApp versión 1.5</i>").</message>
+	<message key="xmlui.Submission.submit.EditFileStep.head">Editar fichero</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Fichero</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Descripción del fichero</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccione en la lista el formato del archivo, por ejemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato detectado</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Formato elegido</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">El formato no está en la lista</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Si el formato no está en la lista, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Otro formato</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">El nombre y versión de la aplicación que utilizó para crear el fichero (por ejemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
-<message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Editar Permisos de Ficheros</message>
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Editar Permisos de Ficheros</message>
 
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-<message key="xmlui.Submission.submit.ReviewStep.head">Revisar envío</message>
-<message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
-<message key="xmlui.Submission.submit.ReviewStep.no">No</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregir alguno de éstos</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Añadir o eliminar un fichero</message>
-<message key="xmlui.Submission.submit.ReviewStep.head1">Preguntas iniciales</message>
-<message key="xmlui.Submission.submit.ReviewStep.head2">Describir página {0}</message>
-<message key="xmlui.Submission.submit.ReviewStep.head3">Ficheros subidos</message>
-<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Múltiples títulos</message>
-<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicado antes de</message>
-<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-<message key="xmlui.Submission.submit.ReviewStep.unknown">desconocido</message>
-<message key="xmlui.Submission.submit.ReviewStep.known">conocido</message>
-<message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head">Revisar envío</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Sí</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">No</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corregir alguno de éstos</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Añadir o eliminar un fichero</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Preguntas iniciales</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Describir página {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Ficheros subidos</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Múltiples títulos</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicado antes de</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">desconocido</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">conocido</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Hubo un error .. {0}</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.head">Licencie su trabajo</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.info1">Puede opcionalmente asignar a su ítem una licencia <a href="http://creativecommons.org/">Creative Commons</a>. Las licencias Creative Commons determinan qué pueden hacer los lectores con su trabajo.</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Elija licencia</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Acceder a Creative Commons para elegir una licencia</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.license">Tipo de Licencia</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Seleccione o modifique la licencia...</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Sin licencia Creative Commons</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Pulse Siguiente para salvar sus cambios.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Hubo un error .. {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Licencie su trabajo</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Puede opcionalmente asignar a su ítem una licencia <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Elija licencia</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Acceder a Creative Commons para elegir una licencia</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Tipo de Licencia</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Seleccione o modifique la licencia...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Sin licencia Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Pulse Siguiente para salvar sus cambios.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-<message key="xmlui.Submission.submit.LicenseStep.head">Licencia de distribución</message>
-<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Queda un último paso:</strong> para permitir a DSpace reproducir, traducir y distribuir su envío a través del mundo, necesitamos su conformidad en los siguientes términos.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info2">Conceda la licencia de distribución estándar seleccionando 'Conceder licencia' y pulsando 'Completar envío'.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info3">Si tiene alguna duda sobre la licencia, por favor, contacte con el administrador del sistema.</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licencia de distribución</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Conceder licencia</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_error">Debe conceder la licencia para completar el envío. Si ahora no la puede conceder la licencia, deberá guardar su trabajo y volver más tarde o bien eliminar inmediatamente el envío pulsando Borrar el envío.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.head">Licencia de distribución</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Conceda la licencia de distribución estándar seleccionando 'Conceder licencia' y pulsando 'Completar envío'.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Si tiene alguna duda sobre la licencia, por favor, contacte con el administrador del sistema.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licencia de distribución</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Conceder licencia</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Debe conceder la licencia para completar el envío. Si ahora no la puede conceder la licencia, deberá guardar su trabajo y volver más tarde o bien eliminar inmediatamente el envío pulsando Borrar el envío.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-<message key="xmlui.Submission.submit.RemovedStep.head">Envío eliminado</message>
-<message key="xmlui.Submission.submit.RemovedStep.info1">Su envío ha sido cancelado, y el ítem incompleto ha sido borrado del sistema.</message>
-<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ir a la página de envíos</message>
+	<message key="xmlui.Submission.submit.RemovedStep.head">Envío eliminado</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Su envío ha sido cancelado, y el ítem incompleto ha sido borrado del sistema.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ir a la página de envíos</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-<message key="xmlui.Submission.submit.CompletedStep.head">Envío completado</message>
-<message key="xmlui.Submission.submit.CompletedStep.info1">Su envío pasará por el flujo de trabajo designado para la colección a la que lo está enviando. Recibirá una notificación vía correo electrónico tan pronto como su envío forme parte de la colección, o si por alguna razón hubiera algún problema con el envío. También puede verificar el estado de su envío accediendo a la página 'Mi DSpace'.</message>
-<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ir a la página de envíos</message>
-<message key="xmlui.Submission.submit.CompletedStep.submit_again">Enviar otro ítem</message>
+	<message key="xmlui.Submission.submit.CompletedStep.head">Envío completado</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Su envío pasará por el flujo de trabajo designado para la colección a la que lo está enviando. Recibirá una notificación vía correo electrónico tan pronto como su envío forme parte de la colección, o si por alguna razón hubiera algún problema con el envío. También puede verificar el estado de su envío accediendo a la página 'Mi DSpace'.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ir a la página de envíos</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Enviar otro ítem</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Acciones posibles para esta tarea:</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Asígnese esta tarea.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Asumir tarea</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Dejar esta tarea en la cola para que la asuma otra persona.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Dejar tarea</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si ha revisado el ítem y lo considera adecuado para la colección, seleccione "Aprobar".</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprobar ítem</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Una vez editado el ítem, use esta opción para actualizarlo.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Actualizar en el archivo</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si ha revisado el ítem y ha encontrado que <strong>no</strong> es conveniente incluirlo en la colección, elija "Rechazar". Se le pedirá que explique por qué el ítem no es adecuado, y qué debe cambiar el remitente para reenviarlo</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rechazar ítem</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Elija esta opción para corregir o editar los metadatos del ítem.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editar metadatos</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Para devolver la tarea a la cola de modo que otra persona pueda terminar la tarea de revisión, use esta opción.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Devolver a la cola</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Acciones posibles para esta tarea:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Asígnese esta tarea.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Asumir tarea</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Dejar esta tarea en la cola para que la asuma otra persona.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Dejar tarea</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si ha revisado el ítem y lo considera adecuado para la colección, seleccione "Aprobar".</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprobar ítem</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Una vez editado el ítem, use esta opción para actualizarlo.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Actualizar en el archivo</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si ha revisado el ítem y ha encontrado que <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rechazar ítem</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Elija esta opción para corregir o editar los metadatos del ítem.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editar metadatos</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Para devolver la tarea a la cola de modo que otra persona pueda terminar la tarea de revisión, use esta opción.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Devolver a la cola</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Por favor, indique la razón por la que rechaza el envío. Indique en su mensaje qué deberá cambiar el remitente para reenviarlo.</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motivo</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El campo Motivo es obligatorio</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rechazar ítem</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Por favor, indique la razón por la que rechaza el envío. Indique en su mensaje qué deberá cambiar el remitente para reenviarlo.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motivo</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">El campo Motivo es obligatorio</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rechazar ítem</message>
 
 
 
@@ -955,1091 +965,1091 @@
 
 	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
 
-<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">La tarea se completó satisfactoriamente.</message>
-<message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">La tarea finalizó o falló inesperadamente.  Contacte por favor con el administrador o revise los archivos de errores</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Se encoló la tarea satisfactoriamente.</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">No se pudo encolar la tarea por un error.  Para más información, contacte por favor con el administrador o revise los archivos de errores.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Se añadió el usuario correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Se editó el usuario correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Se ha enviado un mensaje al usuario que contiene un testigo que le permitirá obtener una nueva clave.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">El usuario(s) ha sido borrado correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Los usuarios de la lista no se han eliminado porque hay restricciones para realizar esta acción. Vea la página con los datos del usuario para más información.</message>
-<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">El grupo se modificó correctamente.</message>
-<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Los grupos seleccionados se borraron satisfactoriamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Nuevo esquema creado correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">El esquema(s) ha sido borrado satisfactoriamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Campo de metadato añadido correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">El campo(s) fue movido correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">El campo(s) fue borrado correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Se guardó el formato correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">El formato(s) se borró correctamente.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Los metadatos del ítem fueron correctamente modificados.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_added">Nuevo metadato añadido.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">El ítem ha sido retirado.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_reinstated">El ítem ha sido reintegrado.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_moved">El item ha sido movido.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_move_failed">La colección destino seleccionada no se ha encontrado.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_added">El nuevo archivo se ha cargado satisfactoriamente.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error cargando el archivo.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">El archivo ha sido modificado.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Los archivos seleccionados se han borrado.</message>
-<message key="xmlui.administrative.FlowMapperUtils.map_items">Los ítems han sido correctamente relacionados.</message>
-<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Se ha eliminado correctamente la relación de los ítems.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">La tarea se completó satisfactoriamente.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">La tarea finalizó o falló inesperadamente.  Contacte por favor con el administrador o revise los archivos de errores</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Se encoló la tarea satisfactoriamente.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">No se pudo encolar la tarea por un error.  Para más información, contacte por favor con el administrador o revise los archivos de errores.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Se añadió el usuario correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Se editó el usuario correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Se ha enviado un mensaje al usuario que contiene un testigo que le permitirá obtener una nueva clave.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">El usuario(s) ha sido borrado correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Los usuarios de la lista no se han eliminado porque hay restricciones para realizar esta acción. Vea la página con los datos del usuario para más información.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">El grupo se modificó correctamente.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Los grupos seleccionados se borraron satisfactoriamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Nuevo esquema creado correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">El esquema(s) ha sido borrado satisfactoriamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Campo de metadato añadido correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">El campo(s) fue movido correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">El campo(s) fue borrado correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Se guardó el formato correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">El formato(s) se borró correctamente.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Los metadatos del ítem fueron correctamente modificados.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Nuevo metadato añadido.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">El ítem ha sido retirado.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">El ítem ha sido reintegrado.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">El item ha sido movido.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">La colección destino seleccionada no se ha encontrado.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">El nuevo archivo se ha cargado satisfactoriamente.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Error cargando el archivo.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">El archivo ha sido modificado.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Los archivos seleccionados se han borrado.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Los ítems han sido correctamente relacionados.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Se ha eliminado correctamente la relación de los ítems.</message>
 
 	<!-- general items for all of the eperson classes -->
-<message key="xmlui.administrative.eperson.general.epeople_trail">Administrar usuarios</message>
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Administrar usuarios</message>
 
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
-<message key="xmlui.administrative.Navigation.context_head">Contexto</message>
-<message key="xmlui.administrative.Navigation.context_edit_item">Editar este ítem</message>
-<message key="xmlui.administrative.Navigation.context_edit_collection">Editar Colección</message>
-<message key="xmlui.administrative.Navigation.context_item_mapper">Relacionador de ítems</message>
-<message key="xmlui.administrative.Navigation.context_edit_community">Editar Comunidad</message>
-<message key="xmlui.administrative.Navigation.context_create_collection">Crear colección</message>
-<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crear subcomunidad</message>
-<message key="xmlui.administrative.Navigation.context_create_community">Crear comunidad</message>
-<message key="xmlui.administrative.Navigation.context_export_item">Exportar ítem</message>
-<message key="xmlui.administrative.Navigation.context_export_collection">Exportar colección</message>
-<message key="xmlui.administrative.Navigation.context_export_community">Exportar comunidad</message>
-<message key="xmlui.administrative.Navigation.context_export_metadata">Exportar metadatos</message>
+	<message key="xmlui.administrative.Navigation.context_head">Contexto</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Editar este ítem</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Editar Colección</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Relacionador de ítems</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Editar Comunidad</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Crear colección</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crear subcomunidad</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Crear comunidad</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Exportar ítem</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exportar colección</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exportar comunidad</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Exportar metadatos</message>
 
 	<!-- Site administrator options -->
-<message key="xmlui.administrative.Navigation.administrative_head">Administrativo</message>
-<message key="xmlui.administrative.Navigation.administrative_access_control">Control de acceso</message>
-<message key="xmlui.administrative.Navigation.administrative_people">Personas</message>
-<message key="xmlui.administrative.Navigation.administrative_groups">Grupos</message>
-<message key="xmlui.administrative.Navigation.administrative_authorizations">Autorizaciones</message>
-<message key="xmlui.administrative.Navigation.administrative_registries">Registros</message>
-<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatos</message>
-<message key="xmlui.administrative.Navigation.administrative_format">Formato</message>
-<message key="xmlui.administrative.Navigation.administrative_content">Administración de contenidos</message>
-<message key="xmlui.administrative.Navigation.administrative_items">Ítems</message>
-<message key="xmlui.administrative.Navigation.administrative_withdrawn">Ítems eliminados</message>
-<message key="xmlui.administrative.Navigation.administrative_private">Ítems Privados</message>
-<message key="xmlui.administrative.Navigation.administrative_control_panel">Panel de control</message>
-<message key="xmlui.administrative.Navigation.statistics">Estadísticas</message>
-<message key="xmlui.administrative.Navigation.administrative_batch_import">Importación Batch (ZIP)</message>
-<message key="xmlui.administrative.Navigation.administrative_import_metadata">Importar Metadatos</message>
-<message key="xmlui.administrative.Navigation.administrative_curation">Tareas de Curación</message>
+	<message key="xmlui.administrative.Navigation.administrative_head">Administrativo</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Control de acceso</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Personas</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Grupos</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Autorizaciones</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Registros</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatos</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Formato</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Administración de contenidos</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Ítems</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Ítems eliminados</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Ítems Privados</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Panel de control</message>
+    <message key="xmlui.administrative.Navigation.statistics">Estadísticas</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Importación Batch (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importar Metadatos</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Tareas de Curación</message>
 
     <!-- my account items -->
-<message key="xmlui.administrative.Navigation.account_export">Mis exportaciones</message>
+	<message key="xmlui.administrative.Navigation.account_export">Mis exportaciones</message>
 
 
 	<!-- export item -->
-<message key="xmlui.administrative.ItemExport.head">Exportar Archivo  </message>
-<message key="xmlui.administrative.ItemExport.item.id.error">El código del ítem que ha introducido no es válido.</message>
-<message key="xmlui.administrative.ItemExport.collection.id.error">El identificador de la colección que ha introducido no es válido.</message>
-<message key="xmlui.administrative.ItemExport.community.id.error">El código de la comunidad que ha introducido no es válido.</message>
-<message key="xmlui.administrative.ItemExport.item.not.found">No se ha encontrado el ítem solicitado.</message>
-<message key="xmlui.administrative.ItemExport.collection.not.found">No se ha encontrado la colección solicitada.</message>
-<message key="xmlui.administrative.ItemExport.community.not.found">No se ha encontrado la comunidad solicitada.</message>
-<message key="xmlui.administrative.ItemExport.item.success">Se ha exportado correctamente el ítem. Recibirá un correo electrónico cuando el archivo esté listo  para la descarga.  Puede usar asímismo el  enlace  'Mis Exportaciones' para ver los archivos disponibles.</message>
-<message key="xmlui.administrative.ItemExport.collection.success">La colección se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición.</message>
-<message key="xmlui.administrative.ItemExport.community.success">La comunidad se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición.</message>
-<message key="xmlui.administrative.ItemExport.available.head">Archivos de exportación disponibles para descargar:</message>
+	<message key="xmlui.administrative.ItemExport.head">Exportar Archivo  </message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">El código del ítem que ha introducido no es válido.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">El identificador de la colección que ha introducido no es válido.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">El código de la comunidad que ha introducido no es válido.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">No se ha encontrado el ítem solicitado.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">No se ha encontrado la colección solicitada.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">No se ha encontrado la comunidad solicitada.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Se ha exportado correctamente el ítem. Recibirá un correo electrónico cuando el archivo esté listo  para la descarga.  Puede usar asímismo el  enlace  'Mis Exportaciones' para ver los archivos disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">La colección se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">La comunidad se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Archivos de exportación disponibles para descargar:</message>
 
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Administrar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestión de usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Acciones</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crear un nuevo usuario</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Pulse aquí para añadir un nuevo usuario.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Listar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Pulse aquí para listar todos los usuarios.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Buscar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Los usuarios se buscan por coincidencia parcial de correo electrónico o nombre</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Debajo figura la lista de usuarios que coincide con su patrón de búsqueda. Elija la que quiere borrar y pulse el botón Borrar para continuar o pulse sobre la dirección de correo electrónico o el nombre de un usuario para editarlos.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultados de la búsqueda</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nombre</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Correo electrónico</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Borrar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Su búsqueda no produjo ningún resultado...</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Administrar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestión de usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Acciones</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crear un nuevo usuario</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Pulse aquí para añadir un nuevo usuario.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Listar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Pulse aquí para listar todos los usuarios.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Buscar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Los usuarios se buscan por coincidencia parcial de correo electrónico o nombre</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Debajo figura la lista de usuarios que coincide con su patrón de búsqueda. Elija la que quiere borrar y pulse el botón Borrar para continuar o pulse sobre la dirección de correo electrónico o el nombre de un usuario para editarlos.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultados de la búsqueda</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nombre</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Correo electrónico</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Borrar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Su búsqueda no produjo ningún resultado...</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-<message key="xmlui.administrative.eperson.AddEPersonForm.title">Añadir usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Añadir usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crear un nuevo usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Esta dirección de correo electrónico está siendo usada por otra persona. La dirección de correo electrónico debe ser única.</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Información del nuevo usuario:</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">La dirección de correo electrónico debe ser única</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Se require una dirección de correo electrónico</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nombre es un dato obligatorio</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">El apellido es un dato obligatorio</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Necesita certificado</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Puede acceder</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crear usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Añadir usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Añadir usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crear un nuevo usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Esta dirección de correo electrónico está siendo usada por otra persona. La dirección de correo electrónico debe ser única.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Información del nuevo usuario:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">La dirección de correo electrónico debe ser única</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Se require una dirección de correo electrónico</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">El nombre es un dato obligatorio</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">El apellido es un dato obligatorio</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Necesita certificado</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Puede acceder</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crear usuario</message>
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Editar un usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Esta dirección de correo electrónico está siendo usada por otra persona. La dirección de correo electrónico debe ser única.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Información de {0}:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">La dirección de correo electrónico debe ser única</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Se require una dirección de correo electrónico</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nombre es un dato obligatorio</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">El apellido es un dato obligatorio</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Necesita certificado</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Puede acceder</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restablecer contraseña</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">También puede borrar permanentemente a este usuario del sistema o restablecer su contraseña. Cuando regenera una contraseña, el usuario recibirá un mensaje que contiene un enlace especial que puede seguir para asignar una nueva contraseña.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Borrar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Acceder como usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Editar un usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Esta dirección de correo electrónico está siendo usada por otra persona. La dirección de correo electrónico debe ser única.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Información de {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">La dirección de correo electrónico debe ser única</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Se require una dirección de correo electrónico</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">El nombre es un dato obligatorio</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">El apellido es un dato obligatorio</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Necesita certificado</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Puede acceder</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restablecer contraseña</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">También puede borrar permanentemente a este usuario del sistema o restablecer su contraseña. Cuando regenera una contraseña, el usuario recibirá un mensaje que contiene un enlace especial que puede seguir para asignar una nueva contraseña.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Borrar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Acceder como usuario</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No se puede borrar este usuario debido a las siguientes restricciones:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">y</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">el usuario ha enviado uno o más ítems</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">el usuario tiene un envío de flujo de trabajo activo</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">el usuario tiene una tarea de flujo de trabajo por atender</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">el usuario tiene una restricción sin identificar en el sistema</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No se puede borrar este usuario debido a las siguientes restricciones:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">y</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">el usuario ha enviado uno o más ítems</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">el usuario tiene un envío de flujo de trabajo activo</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">el usuario tiene una tarea de flujo de trabajo por atender</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">el usuario tiene una restricción sin identificar en el sistema</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Este usuario pertenece a los grupos:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(por el grupo: {0})</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">ninguno</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Este usuario pertenece a los grupos:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(por el grupo: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">ninguno</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirmar borrado de usuario</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmar borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmar borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Los siguientes usuarios serán borrados:</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmar borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nombre</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Correo electrónico</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirmar borrado de usuario</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmar borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmar borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Los siguientes usuarios serán borrados:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmar borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nombre</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Correo electrónico</message>
 
 	<!-- general items for all of the group classes -->
-<message key="xmlui.administrative.group.general.group_trail">Administrar grupos</message>
+	<message key="xmlui.administrative.group.general.group_trail">Administrar grupos</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-<message key="xmlui.administrative.group.ManageGroupsMain.title">Administrar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestión de grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Acciones</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crear un nuevo grupo</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Pulse aquí para añadir un grupo nuevo.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Listar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Pulse aquí para listar todos los grupos.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Buscar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Los grupos se buscan por coincidencia parcial del nombre</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultados de la búsqueda</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nombre</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Miembros</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Comunidad / Colección</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ver</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Borrar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Su búsqueda no produjo ningún resultado...</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Administrar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestión de grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Acciones</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crear un nuevo grupo</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Pulse aquí para añadir un grupo nuevo.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Listar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Pulse aquí para listar todos los grupos.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Buscar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Los grupos se buscan por coincidencia parcial del nombre</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultados de la búsqueda</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nombre</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Miembros</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Comunidad / Colección</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ver</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Borrar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Su búsqueda no produjo ningún resultado...</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-<message key="xmlui.administrative.group.EditGroupForm.title">Editor de grupos</message>
-<message key="xmlui.administrative.group.EditGroupForm.trail">Editar grupo</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grupos: {0} (id: {1})</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grupos: nuevo grupo</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Limpiar la búsqueda</message>
-<message key="xmlui.administrative.group.EditGroupForm.member">Miembro</message>
-<message key="xmlui.administrative.group.EditGroupForm.cycle">Ciclo</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending">Pendiente</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: los cambios pendientes no se guardan hasta que pulsa el botón de guardar.</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_add">Añadir</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Eliminar </message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_para">Este grupo está asociado con la colección:</message>
-<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado con la comunidad: </message>
-<message key="xmlui.administrative.group.EditGroupForm.label_name">Cambiar el nombre del grupo:</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Este grupo está asociado con una colección específica y el nombre no puede ser modificado.</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_search">Buscar miembros para añadir:</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuarios...</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupos...</message>
-<message key="xmlui.administrative.group.EditGroupForm.no_results">Su búsqueda no produjo ningún resultado...</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nombre</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Correo electrónico</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nombre</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Miembros</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Colección</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ver</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_head">Miembros</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nombre</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column3">Correo electrónico</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupo: {0}</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_none">Este grupo no tiene ningún miembro.</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendiente]</message>
-<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Eliminar miembros</message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Eliminar miembros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.title">Editor de grupos</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Editar grupo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grupos: {0} (id: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grupos: nuevo grupo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Limpiar la búsqueda</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Miembro</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Ciclo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Pendiente</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: los cambios pendientes no se guardan hasta que pulsa el botón de guardar.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Añadir</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Eliminar </message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Este grupo está asociado con la colección:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado con la comunidad: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Cambiar el nombre del grupo:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Este grupo está asociado con una colección específica y el nombre no puede ser modificado.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Buscar miembros para añadir:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuarios...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupos...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">Su búsqueda no produjo ningún resultado...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nombre</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Correo electrónico</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nombre</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Miembros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Colección</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ver</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Miembros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nombre</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Correo electrónico</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupo: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Este grupo no tiene ningún miembro.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendiente]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Eliminar miembros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Eliminar miembros</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirmar borrado de grupo</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmar borrado</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmar borrado</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Los siguientes grupos serán borrados:</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nombre</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuarios</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupos</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirmar borrado de grupo</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmar borrado</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmar borrado</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Los siguientes grupos serán borrados:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nombre</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuarios</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupos</message>
 
 	<!-- general items for all of the registries classes -->
-<message key="xmlui.administrative.registries.general.format_registry_trail">Registro de Formatos</message>
-<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registro de Metadatos</message>
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Registro de Formatos</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registro de Metadatos</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Borrar formatos de archivo</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Borrar formatos del archivo</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmar borrado</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">¿Está seguro/a de borrar este formato? Cualquier archivo existente con este formato será asociado al formato desconocido.</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipo MIME</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nombre</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Borrar formatos de archivo</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Borrar formatos del archivo</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmar borrado</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">¿Está seguro/a de borrar este formato? Cualquier archivo existente con este formato será asociado al formato desconocido.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nombre</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Borrar campos</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Borrar campos</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">¿Está <b>absolutamente</b> seguro/a de querer borrar estos campos? Si algún ítem contiene metadatos en estos campos, se producirá un error advirtiéndole de fallo en el borrado. Debe asegurarse de que no hay ítems en el sistema que utilicen estos campos.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVISO:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Esto producirá un error si algún ítem contiene metadatos en estos campos.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nombre</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Borrar campos</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Borrar campos</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">¿Está <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVISO:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Esto producirá un error si algún ítem contiene metadatos en estos campos.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nombre</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota de alcance</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Borrado Esquema</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Borrado Esquema</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmar borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">¿Está <b>absolutamente</b> seguro/a de querer borrar este esquema? Si algún ítem contiene metadatos los campos contenidos en este esquema, se producirá un error advirtiéndole del fallo en el borrado. Debe asegurarse de que no hay ítems en el sistema que utilicen campos contenidos en este esquema.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVISO:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Esto producirá un error si algún ítem contiene metadatos en cualquiera de los campos del esquema.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espacio de Nombres</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nombre</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Borrado Esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Borrado Esquema</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmar borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">¿Está <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVISO:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Esto producirá un error si algún ítem contiene metadatos en cualquiera de los campos del esquema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espacio de Nombres</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nombre</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Formato del archivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Formato del archivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nuevo formato de archivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Formato del archivo: {0}</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Proporcione metadatos descriptivos sobre el formato del archivo indicado abajo. Mientras que los nombres de los formatos deben ser únicos, los MIME-Types no necesariamente. Debe mantener distintas entradas de formato para diferentes versiones de Microsoft Word, incluso aunque el MIME-Type sea el mismo para ellos.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nombre</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nombre único para este formato (p.ej. Microsoft Word XP o Microsoft Word 2000)</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El nombre del campo es necesario.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipo MIME</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">El MIME-type asociado a este formato no debe ser único.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripción</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivel de soporte</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">El nivel de soporte que su institución concede a este formato.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconocido</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conocido</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Compatible</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Interno</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Los formatos marcados como internos se ocultan al usuario y se utilizan para fines administrativos.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensiones del fichero</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Las extensiones son extensiones de los archivos que se usan automáticamente para identificar los formatos de los archivos cargados. Puede indicar varias extensiones para cada formato.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Formato del archivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Formato del archivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nuevo formato de archivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Formato del archivo: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Proporcione metadatos descriptivos sobre el formato del archivo indicado abajo. Mientras que los nombres de los formatos deben ser únicos, los MIME-Types no necesariamente. Debe mantener distintas entradas de formato para diferentes versiones de Microsoft Word, incluso aunque el MIME-Type sea el mismo para ellos.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nombre</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nombre único para este formato (p.ej. Microsoft Word XP o Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">El nombre del campo es necesario.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">El MIME-type asociado a este formato no debe ser único.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descripción</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivel de soporte</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">El nivel de soporte que su institución concede a este formato.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Desconocido</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Conocido</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Compatible</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Interno</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Los formatos marcados como internos se ocultan al usuario y se utilizan para fines administrativos.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensiones del fichero</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Las extensiones son extensiones de los archivos que se usan automáticamente para identificar los formatos de los archivos cargados. Puede indicar varias extensiones para cada formato.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadatos: "{0}"</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Este es el esquema de "{0}". Puede añadir o modificar campos de metadatos existentes de este esquema. Los campos también pueden ser marcados para borrado o movidos a otro esquema.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Campos de metadatos del esquema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota de alcance</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Sin campos de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Borrar campos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mover campos a otro esquema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Añadir un nuevo campo de metadato</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nombre del campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota de alcance</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notas adicionales sobre este campo de metadato.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Añadir un nuevo campo de metadato</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Modificar campo: {0}</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Modificar campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nombre del campo está ya en uso. Todos los elementos y cualificadores deben ser únicos.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">El elemento del campo es necesario.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">El elemento del campo contiene un carácter extraño, el elemento NO puede contener: puntos, subrayados o espacios.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">El elemento del campo es demasiado largo, debe ser menor de 32 caracteres.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El cualificador del campo es demasiado largo, debe ser menor de 32 caracteres.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El cualificador del campo contiene un carácter extraño, el cualificador NO puede contener: puntos, subrayados o espacios.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadatos: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Este es el esquema de "{0}". Puede añadir o modificar campos de metadatos existentes de este esquema. Los campos también pueden ser marcados para borrado o movidos a otro esquema.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Campos de metadatos del esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Sin campos de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Borrar campos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mover campos a otro esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Añadir un nuevo campo de metadato</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nombre del campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notas adicionales sobre este campo de metadato.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Añadir un nuevo campo de metadato</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Modificar campo: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Modificar campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Error</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">El nombre del campo está ya en uso. Todos los elementos y cualificadores deben ser únicos.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">El elemento del campo es necesario.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">El elemento del campo contiene un carácter extraño, el elemento NO puede contener: puntos, subrayados o espacios.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">El elemento del campo es demasiado largo, debe ser menor de 32 caracteres.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">El cualificador del campo es demasiado largo, debe ser menor de 32 caracteres.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">El cualificador del campo contiene un carácter extraño, el cualificador NO puede contener: puntos, subrayados o espacios.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
-<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registro de Formatos</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registro de formatos de archivos</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Esta lista de archivos aporta información sobre formatos de archivos conocidos y su nivel de soporte. Puede editar o añadir nuevos formatos de archivo con esta herramienta. Los formatos marcados como 'internos' se ocultan al usuario, y son usados para fines administrativos.</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Añadir un formato de archivo nuevo</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nombre</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipo MIME</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivel de soporte</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconocido</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conocido</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Soporte</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Borrar formatos</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registro de Formatos</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registro de formatos de archivos</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Esta lista de archivos aporta información sobre formatos de archivos conocidos y su nivel de soporte. Puede editar o añadir nuevos formatos de archivo con esta herramienta. Los formatos marcados como 'internos' se ocultan al usuario, y son usados para fines administrativos.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Añadir un formato de archivo nuevo</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nombre</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivel de soporte</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconocido</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conocido</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Soporte</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Borrar formatos</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registro de metadatos</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registro de metadatos</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registro de metadatos mantiene una lista de todos los campos disponibles en el repositorio. Estos campos pueden distribuirse entre múltiples esquemas, sin embargo DSpace necesita el esquema de clasificación de Dublin Core. Puede extender el esquema Dublin Core con campos adicionales o añadir nuevos esquemas al registro.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espacio de Nombres</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nombre</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Borrado Esquema</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Añadir nuevo esquema</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espacio de Nombres</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">El Espacio de Nombres debe establecer una dirección URI para el nuevo esquema.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Este campo es obligatorio</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nombre</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Nombre resumido del esquema, se usará para prefijo de los nombres de campo (p.ej. dc.element.qualifier). El nombre debe tener menos de 32 caracteres y no puede incluir espacios, puntos o subrayados.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Este campo es obligatorio, tener menos de 32 caracteres y no contener espacios, puntos o subrayados.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Añadir un nuevo esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registro de metadatos</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registro de metadatos</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">El registro de metadatos mantiene una lista de todos los campos disponibles en el repositorio. Estos campos pueden distribuirse entre múltiples esquemas, sin embargo DSpace necesita el esquema de clasificación de Dublin Core. Puede extender el esquema Dublin Core con campos adicionales o añadir nuevos esquemas al registro.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espacio de Nombres</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nombre</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Borrado Esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Añadir nuevo esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espacio de Nombres</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">El Espacio de Nombres debe establecer una dirección URI para el nuevo esquema.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Este campo es obligatorio</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nombre</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Nombre resumido del esquema, se usará para prefijo de los nombres de campo (p.ej. dc.element.qualifier). El nombre debe tener menos de 32 caracteres y no puede incluir espacios, puntos o subrayados.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Este campo es obligatorio, tener menos de 32 caracteres y no contener espacios, puntos o subrayados.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Añadir un nuevo esquema</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-<message key="xmlui.administrative.registries.MoveMetadataField.title">Mover campos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mover campos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mover campos de metadatos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para1">Elija un esquema destino donde se moverán estos campos. Si el esquema destino contiene campos con nombres idénticos, estos campos no serán movidos.</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nombre</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota de alcance</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mover al esquema:</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mover campos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Mover campos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mover campos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mover campos de metadatos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Elija un esquema destino donde se moverán estos campos. Si el esquema destino contiene campos con nombres idénticos, estos campos no serán movidos.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nombre</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mover al esquema:</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mover campos</message>
 
 
 
 
 	<!-- general authorization keywords -->
-<message key="xmlui.administrative.authorization.general.authorize_trail">Autorización</message>
-<message key="xmlui.administrative.authorization.general.policyList_trail">Lista de privilegios</message>
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorización</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Lista de privilegios</message>
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administrar privilegios de autorización</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administrar privilegios de autorización</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autorizaciones de ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">El ID que ha indicado no puede relacionarse con ningún ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Buscar un ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Los ítems se buscan por handle o por ID interno</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Encontrar</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Herramienta avanzada de autorizaciones</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Pulse aquí para la herramienta de administración de privilegios</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorizaciones de comunidades/colecciones</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Pulse en una comunidad o colección para editar sus privilegios.</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administrar privilegios de autorización</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administrar privilegios de autorización</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autorizaciones de ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">El ID que ha indicado no puede relacionarse con ningún ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Buscar un ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Los ítems se buscan por handle o por ID interno</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Encontrar</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Herramienta avanzada de autorizaciones</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Pulse aquí para la herramienta de administración de privilegios</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorizaciones de comunidades/colecciones</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Pulse en una comunidad o colección para editar sus privilegios.</message>
 
 
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
-<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Editar privilegios</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Lista de privilegios</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilegios para la colección "{0}" ({1},ID: {2})</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegios para la comunidad "{0}" ({1},ID: {2})</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Pulse aquí para añadir un nuevo privilegio.</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Añadir</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nombre</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acción</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupo</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Fecha de comienzo</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Fecha de Finalización</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Borrar los seleccionados</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editar</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Editar privilegios</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Lista de privilegios</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilegios para la colección "{0}" ({1},ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegios para la comunidad "{0}" ({1},ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Pulse aquí para añadir un nuevo privilegio.</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Añadir</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nombre</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acción</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupo</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Fecha de comienzo</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Fecha de Finalización</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Borrar los seleccionados</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editar</message>
 
 
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
-<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editar privilegios del ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Lista de privilegios</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilegios para el ítem {0} (ID={1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Con este editor puede ver y modificar los privilegios de un ítem, además editar los privilegios de cada componente individual de un ítem: bloques y archivos. Brevemente, un ítem es un contenedor de bloques, y los bloques son contenedores de archivos. Los contenedores habitualmente tienen privilegios de AÑADIR/BORRAR/LEER/ESCRIBIR, mientras que los archivos sólo tienen privilegios de LEER/BORRAR.</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Nótese que hay un bloque extra para cada ítem, que es el que contiene el texto de la licencia para el ítem.</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilegios de ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilegios del bloque {0} ({1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Archivo{0} ({1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Añadir un nuevo privilegio para el ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Añadir un nuevo privilegio para el bloque</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Añadir un nuevo privilegio para el archivo</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editar privilegios del ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Lista de privilegios</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilegios para el ítem {0} (ID={1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Con este editor puede ver y modificar los privilegios de un ítem, además editar los privilegios de cada componente individual de un ítem: bloques y archivos. Brevemente, un ítem es un contenedor de bloques, y los bloques son contenedores de archivos. Los contenedores habitualmente tienen privilegios de AÑADIR/BORRAR/LEER/ESCRIBIR, mientras que los archivos sólo tienen privilegios de LEER/BORRAR.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Nótese que hay un bloque extra para cada ítem, que es el que contiene el texto de la licencia para el ítem.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilegios de ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilegios del bloque {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Archivo{0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Añadir un nuevo privilegio para el ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Añadir un nuevo privilegio para el bloque</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Añadir un nuevo privilegio para el archivo</message>
 
-<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No se encontraron privilegios asociados a este objeto</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">No se encontraron privilegios asociados a este objeto</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
-<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editar privilegio</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editar privilegio</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crear nuevo privilegio para {0} {1}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editar privilegio {0} para {1} {2}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No se seleccionó ningún grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No se seleccionó ninguna acción</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nombre</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Acciones para este recurso</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editar privilegio</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editar privilegio</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crear nuevo privilegio para {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editar privilegio {0} para {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No se seleccionó ningún grupo</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No se seleccionó ninguna acción</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nombre</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Acciones para este recurso</message>
 
-<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conjunto</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultados de la búsqueda</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Elija un grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Buscar un grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Buscar</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Elija la acción</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conjunto</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultados de la búsqueda</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Elija un grupo</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Buscar un grupo</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Buscar</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Elija la acción</message>
 
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nombre</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Descripción</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Fecha de Comienzo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Fecha de Finalización</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Fecha inválida</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Ya existen privilegios idénticos para este grupo y esta acción.</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nombre</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Descripción</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Fecha de Comienzo</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Fecha de Finalización</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Fecha inválida</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Ya existen privilegios idénticos para este grupo y esta acción.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
 
     <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor de privilegios avanzado</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizaciones avanzadas</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor de privilegios avanzado</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Le permite añadir y quitar privilegios a tipos de contenidos de una colección. CUIDADO: ¡borrar el permiso LEER de algún ítem puede ocultarlos!</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Para todos los grupos marcados...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...concede la capacidad de llevar a cabo la siguiente acción...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...para todos los siguientes tipos de objetos...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...en todas las colecciones siguientes.</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupo</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acción</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipo de contenido</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Colección</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Añadir privilegios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilegios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestor de privilegios avanzado</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizaciones avanzadas</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Gestor de privilegios avanzado</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Le permite añadir y quitar privilegios a tipos de contenidos de una colección. CUIDADO: ¡borrar el permiso LEER de algún ítem puede ocultarlos!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Para todos los grupos marcados...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...concede la capacidad de llevar a cabo la siguiente acción...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...para todos los siguientes tipos de objetos...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...en todas las colecciones siguientes.</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupo</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acción</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipo de contenido</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Colección</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Añadir privilegios</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilegios</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Formatos aceptados: yyyy, yyyy-mm, yyyy-mm-dd</message>
 
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nombre</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Descripción</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Fecha de comienzo</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Fecha de finalización</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Fecha inválida</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Seleccione al menos un grupo</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Seleccione al menos una colección</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nombre</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Descripción</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Fecha de comienzo</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Fecha de finalización</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Fecha inválida</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Seleccione al menos un grupo</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Seleccione al menos una colección</message>
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmar borrado de privilegios</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmar borrado</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmar borrado</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Los siguientes privilegios serán eliminados:</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acción</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupo</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmar borrado de privilegios</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmar borrado</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmar borrado</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Los siguientes privilegios serán eliminados:</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acción</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupo</message>
 
 
     <!-- Batch Import Tool -->
     <!-- org.dspace.app.xmlui.administrative.batchimport -->
-<message key="xmlui.administrative.batchimport.general.select_collection">Seleccione un colección..</message>
-<message key="xmlui.administrative.batchimport.general.collection">Colección</message>
-<message key="xmlui.administrative.batchimport.general.collection_help">Seleccione la colección a la que desea enviar un ítem.</message>
-<message key="xmlui.administrative.batchimport.general.collection_default">Seleccione un colección..</message>
+    <message key="xmlui.administrative.batchimport.general.select_collection">Seleccione un colección..</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Colección</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Seleccione la colección a la que desea enviar un ítem.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Seleccione un colección..</message>
 
-<message key="xmlui.administrative.batchimport.general.title">Importar carga Batch (ZIP)</message>
-<message key="xmlui.administrative.batchimport.general.head1">Importar carga Batch (ZIP)</message>
-<message key="xmlui.administrative.batchimport.general.trail">Importar carga Batch (ZIP)</message>
-<message key="xmlui.administrative.batchimport.general.changes">cambios</message>
-<message key="xmlui.administrative.batchimport.general.no_changes">No se detectaron cambios</message>
-<message key="xmlui.administrative.batchimport.general.new_item">Nuevo ítem</message>
-<message key="xmlui.administrative.batchimport.flow.upload_successful">Subida exitosa</message>
-<message key="xmlui.administrative.batchimport.flow.upload_failed">Subida fallida o no se seleccionó fichero</message>
-<message key="xmlui.administrative.batchimport.flow.upload_badschema">Esquema de metadatos desconocido en la cabecera</message>
-<message key="xmlui.administrative.batchimport.flow.upload_badelement">Opcionalmente, proporcione una breve descripción del fichero, por ejemplo "<i>Artículo principal</i>", o "<i>Datos experimentales leídos</i>".</message>
-<message key="xmlui.administrative.batchimport.flow.import_successful">Importación exitosa</message>
-<message key="xmlui.administrative.batchimport.flow.import_failed">Importación fallida</message>
-<message key="xmlui.administrative.batchimport.flow.failed_no_collection">No se ha especificado la Colección de destino</message>
-
-    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
-<message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Subir un ZIP SimpleArchiveFormat </message>
+    <message key="xmlui.administrative.batchimport.general.title">Importar carga Batch (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Importar carga Batch (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Importar carga Batch (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">cambios</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No se detectaron cambios</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">Nuevo ítem</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Subida exitosa</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Subida fallida o no se seleccionó fichero</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Esquema de metadatos desconocido en la cabecera</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Opcionalmente, proporcione una breve descripción del fichero, por ejemplo "</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Importación exitosa</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Importación fallida</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No se ha especificado la Colección de destino</message>
 
     <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
-<message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Procesado exitosamente</message>
-<message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Cambios aplicados al ítem</message>
-<message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Añadido: </message>
-<message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Retirado:</message>
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Subir un ZIP SimpleArchiveFormat </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Procesado exitosamente</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Cambios aplicados al ítem</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Añadido: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Retirado:</message>
 
     <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
-<message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Añadir: </message>
-<message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Retirar:</message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Añadir: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Retirar:</message>
 
 	<!-- general edit item messages -->
-<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
-<message key="xmlui.administrative.item.general.template_head">Editar plantilla de ítem para la Colección: {0}</message>
-<message key="xmlui.administrative.item.general.option_head">Editar ítem</message>
-<message key="xmlui.administrative.item.general.option_status">Estado del ítem</message>
-<message key="xmlui.administrative.item.general.option_bitstreams">Archivos del ítem</message>
-<message key="xmlui.administrative.item.general.option_metadata">Metadatos del ítem</message>
-<message key="xmlui.administrative.item.general.option_view">Ver ítem</message>
-<message key="xmlui.administrative.item.general.option_curate">Curar</message>
-<message key="xmlui.administrative.item.general.option_queue">Encolar</message>
+	<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
+	<message key="xmlui.administrative.item.general.template_head">Editar plantilla de ítem para la Colección: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Editar ítem</message>
+	<message key="xmlui.administrative.item.general.option_status">Estado del ítem</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Archivos del ítem</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Metadatos del ítem</message>
+	<message key="xmlui.administrative.item.general.option_view">Ver ítem</message>
+        <message key="xmlui.administrative.item.general.option_curate">Curar</message>
+        <message key="xmlui.administrative.item.general.option_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-<message key="xmlui.administrative.item.AddBitstreamForm.title">Subir archivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.trail">Subir archivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.head1">Subir un nuevo archivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bloque</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Ficheros de contenido (por defecto)</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Ficheros de metadatos</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturas</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licencias</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licencias Creative Commons</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fichero</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Por favor, introduzca la ruta completa del fichero en su ordenador que corresponda con el ítem. Si pincha en "Examinar...", se abrirá una ventana que le permitirá seleccionar un fichero de su ordenador.</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripción</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Artículo principal</i>", o "<i>Lectura de los datos del documento</i>".</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Subir  </message>
-<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Necesita los privilegios AÑADIR y ESCRIBIR  en al menos un bloque para poder cargar nuevos archivos.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Subir archivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Subir archivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Subir un nuevo archivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bloque</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Ficheros de contenido (por defecto)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Ficheros de metadatos</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturas</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licencias</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licencias Creative Commons</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fichero</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Por favor, introduzca la ruta completa del fichero en su ordenador que corresponda con el ítem. Si pincha en "Examinar...", se abrirá una ventana que le permitirá seleccionar un fichero de su ordenador.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descripción</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Subir  </message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Necesita los privilegios AÑADIR y ESCRIBIR  en al menos un bloque para poder cargar nuevos archivos.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmar borrado</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmar borrado</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmar borrado(s)</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">¿Está seguro/a de querer borrar estos ficheros?:</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nombre</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripción</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formato</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmar borrado</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmar borrado</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmar borrado(s)</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">¿Está seguro/a de querer borrar estos ficheros?:</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nombre</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descripción</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formato</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirmar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirmar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modificar el ítem: {0}</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">¿Está seguro/a de querer borrar completamente este ítem? Cuidado: no quedará ningún rastro de él.</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">¿Está seguro/a de querer retirar este ítem del repositorio?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">¿Está seguro/a de querer reintegrar este ítem a la base de datos?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column1">Campo</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column3">Idioma</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retirar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Reintegrar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Hacerlo Privado</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Hacerlo Público</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirmar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirmar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modificar el ítem: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">¿Está seguro/a de querer borrar completamente este ítem? Cuidado: no quedará ningún rastro de él.</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">¿Está seguro/a de querer retirar este ítem del repositorio?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">¿Está seguro/a de querer reintegrar este ítem a la base de datos?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Campo</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Idioma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retirar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Reintegrar</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Hacerlo Privado</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Hacerlo Público</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-<message key="xmlui.administrative.item.MoveItemForm.title">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.trail">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.head1">Mover ítem: {0}</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection">Colección</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_help">Seleccione la colección a la cual desea mover el ítem.</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_default">Seleccione una colección...</message>
-<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Heredar privilegios</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Heredar los privilegios por defecto de la colección destino</message>
+	<message key="xmlui.administrative.item.MoveItemForm.title">Mover</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Mover</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Mover ítem: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Colección</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Seleccione la colección a la cual desea mover el ítem.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Seleccione una colección...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Heredar privilegios</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Heredar los privilegios por defecto de la colección destino</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-<message key="xmlui.administrative.item.EditBitstreamForm.title">Editar archivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editar archivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editar archivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fichero</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Archivo principal</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Sí</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">No</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripción</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccione en la lista el formato del archivo, por ejemplo "<i>Adobe PDF</i>" o "<i>Microsoft Word</i>". Si el formato no está en la lista, por favor, describa el formato del archivo en la casilla bajo la lista.</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Formato elegido</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_default">El formato no está en la lista</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el formato no está en la lista, <strong>seleccione "El formato no está en la lista" </strong> y descríbalo en la casilla inferior.</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Otro formato</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_help">El nombre y versión de la aplicación que utilizó para crear el fichero (por ejemplo, "<i>ACMESoft SuperApp versión 1.5</i>").</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nombre del fichero</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renombrar este fichero. Nótese que se cambiará la URL mostrada, pero los enlaces antiguos se seguirán resolviendo mientras no cambie el ID.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Editar archivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editar archivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editar archivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fichero</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Archivo principal</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Sí</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">No</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descripción</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Si lo desea, puede describir brevemente el contenido de este fichero, por ejemplo "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccione en la lista el formato del archivo, por ejemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Formato elegido</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">El formato no está en la lista</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si el formato no está en la lista, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Otro formato</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">El nombre y versión de la aplicación que utilizó para crear el fichero (por ejemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nombre del fichero</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renombrar este fichero. Nótese que se cambiará la URL mostrada, pero los enlaces antiguos se seguirán resolviendo mientras no cambie el ID.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Archivos del ítem</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Archivos del ítem</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Archivos</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nombre</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripción</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ver</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Orden</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Archivos del ítem</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Archivos del ítem</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Archivos</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nombre</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descripción</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ver</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Orden</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bloque: {0}</strong></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ver</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un nuevo archivo</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Borrar archivos</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Actualizar el orden de los bitstreams</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Necesita los privilegios AÑADIR y ESCRIBIR sobre el ítem y los bloques para poder cargar nuevos archivos.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Sólo los administradores de Dspace pueden borrar ficheros.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Anterior:</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Subir</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Bajar</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ver</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un nuevo archivo</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Borrar archivos</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Actualizar el orden de los bitstreams</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Necesita los privilegios AÑADIR y ESCRIBIR sobre el ítem y los bloques para poder cargar nuevos archivos.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Sólo los administradores de Dspace pueden borrar ficheros.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Anterior:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Subir</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Bajar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadatos del ítem</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadatos del ítem</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Añadir nuevo metadato</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nombre</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Idioma</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Añadir nuevo metadato</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.para1">ADVERTENCIA: Estos cambios no se validan de ningún modo. Es responsabilidad suya introducir los datos en el formato correcto. Si no está seguro, por favor NO haga cambios.</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatos</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Eliminar </message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nombre</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Idioma</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadatos del ítem</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadatos del ítem</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Añadir nuevo metadato</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nombre</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Idioma</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Añadir nuevo metadato</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">ADVERTENCIA: Estos cambios no se validan de ningún modo. Es responsabilidad suya introducir los datos en el formato correcto. Si no está seguro, por favor NO haga cambios.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatos</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Eliminar </message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nombre</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Idioma</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
-<message key="xmlui.administrative.item.EditItemStatusForm.title">Estado del ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estado del ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.para1">Bienvenido a la página de gestión de ítems. Desde aquí podrá retirar, reintegrar o borrar el ítem. También podrá modificarlo o añadir nuevos metadatos/archivos en las otras pestañas.</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_id">ID interno del ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Última modificación</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_in">En las colecciones</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Página del ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editar privilegios de autorización del ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirar el item del repositorio</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Reintegrar el ítem en el repositorio</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mover el ítem a otra colección</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Borrar completamente el ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorizaciones....</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirar...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Reintegrar...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mover...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Borrar permanentemente</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(sólo administradores del sistema)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(sólo administradores de colección)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(no tiene permisos para realizar esta acción)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_private">Poner Privado al Ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_public">Poner Público al ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Hacerlo Privado...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Hacerlo Público..</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Estado del ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estado del ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Bienvenido a la página de gestión de ítems. Desde aquí podrá retirar, reintegrar o borrar el ítem. También podrá modificarlo o añadir nuevos metadatos/archivos en las otras pestañas.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">ID interno del ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Última modificación</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">En las colecciones</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Página del ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editar privilegios de autorización del ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirar el item del repositorio</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Reintegrar el ítem en el repositorio</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mover el ítem a otra colección</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Borrar completamente el ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorizaciones....</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirar...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Reintegrar...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mover...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Borrar permanentemente</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(sólo administradores del sistema)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(sólo administradores de colección)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(no tiene permisos para realizar esta acción)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Poner Privado al Ítem</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Poner Público al ítem</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Hacerlo Privado...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Hacerlo Público..</message>
 
 
 
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
-<message key="xmlui.administrative.item.ViewItem.title">Ver ítem</message>
-<message key="xmlui.administrative.item.ViewItem.trail">Ver ítem</message>
+	<message key="xmlui.administrative.item.ViewItem.title">Ver ítem</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Ver ítem</message>
         <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-<message key="xmlui.administrative.item.CurateItemForm.main_head">Curar Ítem: {0}</message>
-<message key="xmlui.administrative.item.CurateItemForm.title">Curar Ítem</message>
-<message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
-<message key="xmlui.administrative.item.CurateItemForm.label_name">Tarea</message>
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curar Ítem: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curar Ítem</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Tarea</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
-<message key="xmlui.administrative.item.FindItemForm.title">Encontrar ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.head1">Encontrar ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_label">ID interno del ítem/Handle del ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_error">Imposible resolver el identificador.</message>
-<message key="xmlui.administrative.item.FindItemForm.find">Encontrar</message>
+	<message key="xmlui.administrative.item.FindItemForm.title">Encontrar ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Encontrar ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">ID interno del ítem/Handle del ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Imposible resolver el identificador.</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Encontrar</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport -->
-<message key="xmlui.administrative.metadataimport.general.title">Importar Metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.head1">Importar Metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.trail">Importar Metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.changes">cambios</message>
-<message key="xmlui.administrative.metadataimport.general.no_changes">No se detectaron cambios</message>
-<message key="xmlui.administrative.metadataimport.general.new_item">Nuevo ítem</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_successful">Subida de fichero satisfactoria</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_failed">Fallo en la subida de fichero</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badschema">Esquema de metadatos desconocido en la cabecera</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badelement">Elemento de metadatos desconocido en la cabecera</message>
-<message key="xmlui.administrative.metadataimport.flow.import_successful">Importación exitosa</message>
-<message key="xmlui.administrative.metadataimport.flow.import_failed">Fallo en la importación</message>
-<message key="xmlui.administrative.metadataimport.flow.over_limit">Se ha excedido el número máximo de cambios permitidos. Limítelos o cambie el parámetro bulkedit.gui-item-limit en dspace.cfg</message>
+        <message key="xmlui.administrative.metadataimport.general.title">Importar Metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Importar Metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Importar Metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">cambios</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">No se detectaron cambios</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Nuevo ítem</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Subida de fichero satisfactoria</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Fallo en la subida de fichero</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Esquema de metadatos desconocido en la cabecera</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Elemento de metadatos desconocido en la cabecera</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Importación exitosa</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Fallo en la importación</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Se ha excedido el número máximo de cambios permitidos. Limítelos o cambie el parámetro bulkedit.gui-item-limit en dspace.cfg</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Subir CSV</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Subir CSV</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Procesado exitoso</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Cambios aplicados al ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Añadido: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Eliminado: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Añadido a la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado de la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Relacionado a la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Des-relacionado de la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ítem Borrado</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ítem retirado</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ítem Reintegrado</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Procesado exitoso</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Cambios aplicados al ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Añadido: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Eliminado: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Añadido a la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado de la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Relacionado a la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Des-relacionado de la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ítem Borrado</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ítem retirado</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ítem Reintegrado</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Añadir: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Eliminar:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Añadir a la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Eliminar de la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Relacionar a la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Des-Relacionar de la colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Cambios pendientes del ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Aplicar cambios</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Los cambios pendientes se muestran a continuación para su revisión</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Borrar ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Retirar Ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reintegrar Ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Añadir: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Eliminar:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Añadir a la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Eliminar de la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Relacionar a la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Des-Relacionar de la colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Cambios pendientes del ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Aplicar cambios</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Los cambios pendientes se muestran a continuación para su revisión</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Borrar ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Retirar Ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reintegrar Ítem</message>
 
 	<!-- general mapper messages -->
-<message key="xmlui.administrative.mapper.general.mapper_trail">Relacionador de ítems</message>
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Relacionador de ítems</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
-<message key="xmlui.administrative.mapper.MapperMain.title">Relacionador de ítems</message>
-<message key="xmlui.administrative.mapper.MapperMain.head1">Relacionador de ítems - Relaciona ítems de otras colecciones</message>
-<message key="xmlui.administrative.mapper.MapperMain.para1">Colección: "<strong>{0}</strong>"</message>
-<message key="xmlui.administrative.mapper.MapperMain.para2">Esta es la herramienta relacionadora de ítems que permite a los administradores de colecciones relacionar ítems de otras colecciones en ésta. Puede buscar ítems de otra colección y relacionarlos, o ver la lista de ítems relacionados.</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadísticas</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} de {1}</strong> ítems en esta colección están relacionados con otras colecciones</message>
-<message key="xmlui.administrative.mapper.MapperMain.search_label">Buscar</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_search">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.MapperMain.no_add">(Necesita el privilegio ADD en la colección)</message>
+	<message key="xmlui.administrative.mapper.MapperMain.title">Relacionador de ítems</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Relacionador de ítems - Relaciona ítems de otras colecciones</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Colección: "<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Esta es la herramienta relacionadora de ítems que permite a los administradores de colecciones relacionar ítems de otras colecciones en ésta. Puede buscar ítems de otra colección y relacionarlos, o ver la lista de ítems relacionados.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estadísticas</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Buscar</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Necesita el privilegio ADD en la colección)</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
-<message key="xmlui.administrative.mapper.SearchItemForm.title">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.trail">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.head1">Buscar ítems coincidiendo: "{0}"</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Relacionar los ítems marcados</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column2">Colección</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column4">Título</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Buscar ítems coincidiendo: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Relacionar los ítems marcados</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Colección</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Título</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-<message key="xmlui.administrative.mapper.BrowseItemForm.title">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Lista de ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desrelacionar ítems seleccionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Colección</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Título</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Necesita el privilegio BORRAR en esta colección para desrelacionar los ítems.</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Lista de ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desrelacionar ítems seleccionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Colección</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Título</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Necesita el privilegio BORRAR en esta colección para desrelacionar los ítems.</message>
 
 	<!-- General tags for collection management -->
-<message key="xmlui.administrative.collection.general.collection_trail">Colecciones</message>
-<message key="xmlui.administrative.collection.general.options_metadata">Editar metadatos</message>
-<message key="xmlui.administrative.collection.general.options_roles">Asignar roles</message>
-<message key="xmlui.administrative.collection.general.options_curate">Curar</message>
-<message key="xmlui.administrative.collection.general.options_queue">Encolar</message>
+	<message key="xmlui.administrative.collection.general.collection_trail">Colecciones</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Editar metadatos</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Asignar roles</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editar roles de la colección</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Roles</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editar colección: {0}</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">ninguno</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crear...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringir...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Los administradores de la colección deciden quién puede enviar ítems a la colección, retirarlos, editar los metadatos (después del envío) y añadir (relacionar) ítems existentes de otras colecciones a esta colección (dependiendo de la autorización de esta colección).</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Las personas responsables de este paso podrán aceptar o rechazar envíos pendientes. Sin embargo, no podrán editar los metadatos del envío.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Las personas responsables de este paso podrán editar los metadatos de los envíos pendientes y aceptar o rechazar los envíos.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Las personas responsables de este paso podrán editar los metadatos de los envíos pendientes pero no podrán rechazar los envíos.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Usuarios y grupos que tienen permiso de envío de ítems nuevos a esta colección</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuarios y grupos que pueden leer los nuevos ítems enviados a esta colección. Los cambios en este rol no son retroactivos y los antiguos ítems permanecerán visibles para aquellos que hayan tenido acceso en el momento de su incorporación.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Esta colección usa una configuración de acceso personalizada.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">El permiso por defecto de lectura de los ítems y archivos está actualmente asignado a Anónimo.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editar directamente los privilegios de autorización.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grupo asociado</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradores</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Pasos del flujo de trabajo</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa Aceptar/Rechazar</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa Aceptar/Rechazar/Editar metadatos</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editar metadatos</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Publicadores</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Acceso por defecto de lectura</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(sólo administradores de sistema)</nobr></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br></br>(Grupo de nivel Repositorio, solo administradores del sistema)</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(No tiene permisos para configurar esto)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editar roles de la colección</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Roles</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editar colección: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">ninguno</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crear...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restringir...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Los administradores de la colección deciden quién puede enviar ítems a la colección, retirarlos, editar los metadatos (después del envío) y añadir (relacionar) ítems existentes de otras colecciones a esta colección (dependiendo de la autorización de esta colección).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Las personas responsables de este paso podrán aceptar o rechazar envíos pendientes. Sin embargo, no podrán editar los metadatos del envío.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Las personas responsables de este paso podrán editar los metadatos de los envíos pendientes y aceptar o rechazar los envíos.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Las personas responsables de este paso podrán editar los metadatos de los envíos pendientes pero no podrán rechazar los envíos.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Usuarios y grupos que tienen permiso de envío de ítems nuevos a esta colección</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuarios y grupos que pueden leer los nuevos ítems enviados a esta colección. Los cambios en este rol no son retroactivos y los antiguos ítems permanecerán visibles para aquellos que hayan tenido acceso en el momento de su incorporación.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Esta colección usa una configuración de acceso personalizada.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">El permiso por defecto de lectura de los ítems y archivos está actualmente asignado a Anónimo.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editar directamente los privilegios de autorización.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grupo asociado</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"/>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradores</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Pasos del flujo de trabajo</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa Aceptar/Rechazar</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa Aceptar/Rechazar/Editar metadatos</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editar metadatos</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Publicadores</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Acceso por defecto de lectura</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar Colección: {0}</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar Colección</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Tarea</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar Colección: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar Colección</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Tarea</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmar borrado</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirmar borrado de la colección {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">¿Está seguro/a de querer borrar la colección {0}? Esto borrará:</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Ítems y los envíos pendientes de esta colección que no estén contenidos en otras colecciones</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contenido de estos ítems</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Todos los privilegios de autorización asociados</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmar borrado</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirmar borrado de la colección {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">¿Está seguro/a de querer borrar la colección {0}? Esto borrará:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Ítems y los envíos pendientes de esta colección que no estén contenidos en otras colecciones</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">El contenido de estos ítems</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Todos los privilegios de autorización asociados</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmar borrado del rol</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmar borrado del rol {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">¿Está seguro/a de querer borrar este rol? Borrar este grupo dará permiso de LEER a todos los ítems enviados a esta colección de ahora en adelante. Por favor, tenga en cuenta que este cambio no es retroactivo, así que los ítems enviados bajo privilegios anteriores se restringirán a los miembros definidos en el grupo que va a borrar.</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">¿Está seguro/a de querer borrar este rol? Todos los cambios y personalizaciones hechas al grupo {0} se perderán y tendrán que ser creadas de nuevo.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmar borrado del rol</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmar borrado del rol {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">¿Está seguro/a de querer borrar este rol? Borrar este grupo dará permiso de LEER a todos los ítems enviados a esta colección de ahora en adelante. Por favor, tenga en cuenta que este cambio no es retroactivo, así que los ítems enviados bajo privilegios anteriores se restringirán a los miembros definidos en el grupo que va a borrar.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">¿Está seguro/a de querer borrar este rol? Todos los cambios y personalizaciones hechas al grupo {0} se perderán y tendrán que ser creadas de nuevo.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editar metadatos de la Colección</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatos</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar colección: {0}</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nombre</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descripción breve:</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novedades (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licencia</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Origen</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Subir nuevo logo</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla de ítem</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crear...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editar...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Eliminar logo</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Borrar colección</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Guardar cambios</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(sólo administradores de sistema)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editar metadatos de la Colección</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatos</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar colección: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nombre</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descripción breve:</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novedades (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licencia</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Origen</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Subir nuevo logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Plantilla de ítem</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crear...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editar...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Eliminar logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Borrar colección</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Guardar cambios</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crear colección</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crear colección</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduzca metadatos para una nueva colección de {0}</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crear</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crear colección</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crear colección</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduzca metadatos para una nueva colección de {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crear</message>
 
 	<!-- General to the harvesting options under collection -->
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Parámetros de Recolección de Colección</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Recolectando</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Origen del Contenido</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Origen del Contenido</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Esta es una colección DSpace estándar</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Esta colección recolecta sus contenidos de una fuente externa</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Guardar</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Parámetros de Recolección de Colección</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Recolectando</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Origen del Contenido</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Origen del Contenido</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Esta es una colección DSpace estándar</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Esta colección recolecta sus contenidos de una fuente externa</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Guardar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Localización de la colección recolectada</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opciones de recolección</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Proveedor OAI</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Formato de Metadatos</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">La URL del repositorio OAI proveedor del servicio</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Debe proporcionar un set id de la colección objetivo.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">El identificador persistente usado por el proveedor OAI para designar la colección objetivo</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Debe proporcionar el set id de la colección objetivo.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Contenido recolectándose</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Recolectar solo metadatos.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Recolectar metadatos y referencias a los ficheros (requiere soporte ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Recolectar metadatos y ficheros (requiere soporte ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Probar parámetros</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Localización de la colección recolectada</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opciones de recolección</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Proveedor OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Formato de Metadatos</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">La URL del repositorio OAI proveedor del servicio</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Debe proporcionar un set id de la colección objetivo.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">El identificador persistente usado por el proveedor OAI para designar la colección objetivo</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Debe proporcionar el set id de la colección objetivo.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Contenido recolectándose</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Recolectar solo metadatos.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Recolectar metadatos y referencias a los ficheros (requiere soporte ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Recolectar metadatos y ficheros (requiere soporte ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Probar parámetros</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Localización de la colección recolectada</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Proveedor OAI</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Contenido recolectándose</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Último resultado de la recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Esta colección aún no ha sido recolectada.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Estado actual de la recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Colección lista para recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Colección siendo recolectada</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Colección en espera de recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Hubo un error OAI en la última recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Hubo un error en la última recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Recolectar solo metadatos.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Recolectar metadatos y referencias a los ficheros.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Recolectar metadatos y ficheros (replicación completa).</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Cambiar parámetros</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importar Ahora</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Restaurar y reimportar la Colección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Localización de la colección recolectada</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Proveedor OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Contenido recolectándose</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Último resultado de la recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Esta colección aún no ha sido recolectada.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Estado actual de la recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Colección lista para recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Colección siendo recolectada</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Colección en espera de recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Hubo un error OAI en la última recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Hubo un error en la última recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Recolectar solo metadatos.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Recolectar metadatos y referencias a los ficheros.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Recolectar metadatos y ficheros (replicación completa).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Cambiar parámetros</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importar Ahora</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Restaurar y reimportar la Colección</message>
 
-<message key="xmlui.administrative.ControlPanel.option_harvest">Recolectando</message>
-<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controles del planificador de Recolección</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_status">Estado</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Acciones</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Arrancar Recolección</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado del recolector</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Reanudar</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Detener</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Detener</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Colecciones listas para recolectar</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_active">Recolecciones activas</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Recolecciones en cola</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Errores OAI</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Errores internos</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Parámetros del Generador</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Origen ORE</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Parámetros del Recolectador</message>
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Recolectando</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controles del planificador de Recolección</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Estado</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Acciones</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Arrancar Recolección</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado del recolector</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Reanudar</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Detener</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Detener</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Colecciones listas para recolectar</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Recolecciones activas</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Recolecciones en cola</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Errores OAI</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Errores internos</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Parámetros del Generador</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Origen ORE</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Parámetros del Recolectador</message>
 
 	<!-- General tags for community management -->
-<message key="xmlui.administrative.community.general.community_trail">Comunidades</message>
-<message key="xmlui.administrative.community.general.options_metadata">Editar metadatos</message>
-<message key="xmlui.administrative.community.general.options_roles">Asignar roles</message>
-<message key="xmlui.administrative.community.general.options_curate">Curar</message>
-<message key="xmlui.administrative.community.general.options_queue">Encolar</message>
+	<message key="xmlui.administrative.community.general.community_trail">Comunidades</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Editar metadatos</message>
+	<message key="xmlui.administrative.community.general.options_roles">Asignar roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.community.general.options_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editar Roles de Comunidad</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editar Comunidad: {0}</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">ninguno</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.create">Crear...</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Los Administradores de Comunidad pueden crear subcomunidades o colecciones, así como gestionar o asignar permisos para esas subcomunidades o colecciones. Además, deciden quién puede enviar items a las colecciones , editar metadatos y añadir (mapear) ítems existentes de otras colecciones (sujetos a autorización).</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Esta comunidad  usa una configuración de acceso personalizada. </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">El permiso por defecto de lectura de los ítems y archivos está actualmente asignado a Anónimo.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editar directamente los privilegios de autorización.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Grupo asociado</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administradores</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(sólo administradores de sistema)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editar Roles de Comunidad</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editar Comunidad: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">ninguno</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Crear...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Los Administradores de Comunidad pueden crear subcomunidades o colecciones, así como gestionar o asignar permisos para esas subcomunidades o colecciones. Además, deciden quién puede enviar items a las colecciones , editar metadatos y añadir (mapear) ítems existentes de otras colecciones (sujetos a autorización).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Esta comunidad  usa una configuración de acceso personalizada. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">El permiso por defecto de lectura de los ítems y archivos está actualmente asignado a Anónimo.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editar directamente los privilegios de autorización.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Grupo asociado</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administradores</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-<message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar Comunidad: {0}</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.title">Curar Comunidad</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.label_name">Tarea</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar Comunidad: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curar Comunidad</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Tarea</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmar borrado</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmar borrado de la comunidad {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">¿Está seguro/a de querer borrar la comunidad {0}? Esto borrará:</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Colecciones de la comunidad no contenidas en otras comunidades.</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Ítems y los envíos pendientes a esta comunidad que no estén contenidos en otras comunidades</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contenido de estos ítems</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Todos los privilegios de autorización asociados</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmar borrado</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmar borrado de la comunidad {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">¿Está seguro/a de querer borrar la comunidad {0}? Esto borrará:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Colecciones de la comunidad no contenidas en otras comunidades.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Ítems y los envíos pendientes a esta comunidad que no estén contenidos en otras comunidades</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">El contenido de estos ítems</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Todos los privilegios de autorización asociados</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirmar borrado del rol</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirmar borrado del rol {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">¿Está seguro de querer borrar este rol? Se perderán todos los cambios y personalizaciones hechos al  grupo {0} y podría tener que recrearlo.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirmar borrado del rol</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirmar borrado del rol {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">¿Está seguro de querer borrar este rol? Se perderán todos los cambios y personalizaciones hechos al  grupo {0} y podría tener que recrearlo.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editar metadatos de la Comunidad</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatos</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editar metadatos de la comunidad {0}</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editar privilegios</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nombre</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descripción breve</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Novedades (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Subir nuevo logo</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Eliminar logo</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Borrar comunidad</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editar metadatos de la Comunidad</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatos</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editar metadatos de la comunidad {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editar privilegios</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nombre</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descripción breve</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introductorio (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Novedades (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Subir nuevo logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Eliminar logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Borrar comunidad</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-<message key="xmlui.administrative.community.CreateCommunityForm.title">Crear comunidad</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crear comunidad</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introducir metadatos para una nueva subcomunidad de {0}</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editar metadatos de una nueva comunidad de primer nivel</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crear</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Crear comunidad</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crear comunidad</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introducir metadatos para una nueva subcomunidad de {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editar metadatos de una nueva comunidad de primer nivel</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crear</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-<message key="xmlui.administrative.ControlPanel.title">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.trail">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.head">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.option_java">Información Java</message>
-<message key="xmlui.administrative.ControlPanel.option_dspace">Configuración de Dspace</message>
-<message key="xmlui.administrative.ControlPanel.option_alerts">Alertas del Sistema</message>
-<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
-<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-<message key="xmlui.administrative.ControlPanel.java_head">Java y sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.java_version">Versión de Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.java_vendor">Proveedor de Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.os_name">Nombre del sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.os_version">Versión del sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.runtime_head">Estadísticas de ejecución</message>
-<message key="xmlui.administrative.ControlPanel.runtime_processors">Procesadores disponibles</message>
-<message key="xmlui.administrative.ControlPanel.runtime_max">Memoria máxima</message>
-<message key="xmlui.administrative.ControlPanel.runtime_total">Memoria asignada</message>
-<message key="xmlui.administrative.ControlPanel.runtime_used">Memoria utilizada</message>
-<message key="xmlui.administrative.ControlPanel.runtime_free">Memoria libre</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_version">Versión de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Directorio Cache de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Directorio de trabajo de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Tamaño del Caché principal  ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Borrar inmediatamente el Caché)</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Tamaño del Caché principal  ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Tamaño del Caché Transitorio  ({0})</message>
-<message key="xmlui.administrative.ControlPanel.dspace_head">Parámetros de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_version">Versión de Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_dir">Directorio de instalación de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_url">URL Base de Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nombre de Host Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_name">Nombre del sitio</message>
-<message key="xmlui.administrative.ControlPanel.db_name">Nombre de la base de datos</message>
-<message key="xmlui.administrative.ControlPanel.db_url">URL de la base de datos</message>
-<message key="xmlui.administrative.ControlPanel.db_driver">Driver JDBC</message>
-<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexiones a la Base de datos en Pool</message>
-<message key="xmlui.administrative.ControlPanel.db_maxwait">Tiempo máximo de espera DB</message>
-<message key="xmlui.administrative.ControlPanel.db_maxidle">Número máximo de conexiones sin usar</message>
-<message key="xmlui.administrative.ControlPanel.mail_server">Servidor SMTP</message>
-<message key="xmlui.administrative.ControlPanel.mail_from_address">Correo remitente</message>
-<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatario de sugerencias</message>
-<message key="xmlui.administrative.ControlPanel.mail_admin">Correo del administrador principal</message>
-<message key="xmlui.administrative.ControlPanel.alerts_head">Alertas del Sistema</message>
-<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Advertencia para sistemas de balanceo de carga</strong>: Las alertas globales son sólo efectivas para el nodo en el que se han activado. Necesita asegurarse de que cada nodo en el grupo recibe el comando de alerta de activación.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaje de alerta</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema se apagará debido a tareas habituales de mantenimiento. Por favor, guarde su trabajo y desconéctese.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Cuenta atrás</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Sin cuenta atrás</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Mantener la actual cuenta atrás</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestionar sesión</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuar permitiendo sesiones autenticadas</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Detener la autenticación pero sin que afecte a las sesiones actuales</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Detener la autenticación y terminar las sesiones actuales</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Nota:</strong> Los administradores principales están exentos de la gestión de sesiones.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activar</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactivar</message>
-<message key="xmlui.administrative.ControlPanel.activity_head">Actividad actual (máximo {0} páginas)</message>
-<message key="xmlui.administrative.ControlPanel.stop_anonymous">PARAR  el registro de la actividad de usuarios anónimos.</message>
-<message key="xmlui.administrative.ControlPanel.start_anonymous">EMPEZAR el registro de la actividad de usuarios anónimos.</message>
-<message key="xmlui.administrative.ControlPanel.stop_bot">PARAR el registro de la actividad de bots.</message>
-<message key="xmlui.administrative.ControlPanel.start_bot">EMPEZAR el registro de la actividad de bots.</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horaria</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuario</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Dirección IP</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_url">Página URL</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
-<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anónimo {0}</message>
-<message key="xmlui.administrative.ControlPanel.activity_none">Sin registrar visualizaciones de páginas</message>
+	<message key="xmlui.administrative.ControlPanel.title">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.head">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Información Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Configuración de Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertas del Sistema</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java y sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Versión de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Proveedor de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nombre del sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura del sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Versión del sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Estadísticas de ejecución</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Procesadores disponibles</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Memoria máxima</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Memoria asignada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Memoria utilizada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Memoria libre</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Versión de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Directorio Cache de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Directorio de trabajo de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Tamaño del Caché principal  ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Borrar inmediatamente el Caché)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Tamaño del Caché principal  ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Tamaño del Caché Transitorio  ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Parámetros de DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Versión de Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Directorio de instalación de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">URL Base de Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nombre de Host Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Nombre del sitio</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nombre de la base de datos</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL de la base de datos</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Driver JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexiones a la Base de datos en Pool</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Tiempo máximo de espera DB</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Número máximo de conexiones sin usar</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Servidor SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Correo remitente</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatario de sugerencias</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Correo del administrador principal</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertas del Sistema</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaje de alerta</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">El sistema se apagará debido a tareas habituales de mantenimiento. Por favor, guarde su trabajo y desconéctese.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Cuenta atrás</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Sin cuenta atrás</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Mantener la actual cuenta atrás</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Gestionar sesión</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuar permitiendo sesiones autenticadas</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Detener la autenticación pero sin que afecte a las sesiones actuales</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Detener la autenticación y terminar las sesiones actuales</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activar</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactivar</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Actividad actual (máximo {0} páginas)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">PARAR  el registro de la actividad de usuarios anónimos.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">EMPEZAR el registro de la actividad de usuarios anónimos.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">PARAR el registro de la actividad de bots.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">EMPEZAR el registro de la actividad de bots.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horaria</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuario</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Dirección IP</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">Página URL</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anónimo {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Sin registrar visualizaciones de páginas</message>
 
-<message key="xmlui.administrative.ControlPanel.select_panel">Utilizar las pestañas de arriba para seleccionar la información que se mostrará</message>
+	<message key="xmlui.administrative.ControlPanel.select_panel">Utilizar las pestañas de arriba para seleccionar la información que se mostrará</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>En {0} minutos</strong>:</message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-<message key="xmlui.administrative.NotAuthorized.title">No autorizado</message>
-<message key="xmlui.administrative.NotAuthorized.trail">No autorizado</message>
-<message key="xmlui.administrative.NotAuthorized.head">Privilegios insuficientes</message>
-<message key="xmlui.administrative.NotAuthorized.para1a">Su cuenta no tiene los privilegios suficientes para realizar la acción solicitada. Si cree que se trata de un error o necesita realizar la acción, por favor contacte con los</message>
-<message key="xmlui.administrative.NotAuthorized.para1b">administradores de sistema</message>
-<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-<message key="xmlui.administrative.NotAuthorized.para2">Acceder como otro usuario</message>
+	<message key="xmlui.administrative.NotAuthorized.title">No autorizado</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">No autorizado</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Privilegios insuficientes</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">Su cuenta no tiene los privilegios suficientes para realizar la acción solicitada. Si cree que se trata de un error o necesita realizar la acción, por favor contacte con los</message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">administradores de sistema</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Acceder como otro usuario</message>
         
         <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-<message key="xmlui.administrative.CurateForm.title">Tareas de Curación de Sistema</message>
-<message key="xmlui.administrative.CurateForm.trail">Tareas de Curación</message>
-<message key="xmlui.administrative.CurateForm.object_label_name">Handle del objeto Dspace</message>
-<message key="xmlui.administrative.CurateForm.object_hint">Truco: Introduzca [prefijo-handle]/0 para ejecutar una tarea en toda su instalación (no todas las tareas permiten esta opción)</message>
-<message key="xmlui.administrative.CurateForm.task_label_name">Tarea</message>
+        <message key="xmlui.administrative.CurateForm.title">Tareas de Curación de Sistema</message>
+        <message key="xmlui.administrative.CurateForm.trail">Tareas de Curación</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle del objeto Dspace</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Truco: Introduzca [prefijo-handle]/0 para ejecutar una tarea en toda su instalación (no todas las tareas permiten esta opción)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Tarea</message>
     <!-- Used by Curate<DSO>Form classes also -->
-<message key="xmlui.administrative.CurateForm.taskgroup_label_name">Elegir de entre los grupos siguientes</message>
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Elegir de entre los grupos siguientes</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2047,65 +2057,66 @@
                      Statistics Aspect
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-<message key="xmlui.statistics.title">Estadísticas</message>
-<message key="xmlui.statistics.search.title">Estadísticas de Búsquedas</message>
-<message key="xmlui.statistics.search.head">Estadísticas de Búsquedas</message>
-<message key="xmlui.statistics.search.head-dso">Estadísticas de Búsquedas para {0}</message>
-<message key="xmlui.statistics.search.error">Se produjo un error al generar las estadísticas de búsqueda. Por favor, inténtelo mas tarde.</message>
-<message key="xmlui.statistics.search.no-results">No se dispone de estadísticas de búsquedas para el período seleccionado.</message>
-<message key="xmlui.statistics.workflow.title">Estadísticas del flujo de trabajo</message>
-<message key="xmlui.statistics.visits.total">Número total de visitas</message>
-<message key="xmlui.statistics.visits.month">Visitas al mes</message>
-<message key="xmlui.statistics.visits.views">Visualizaciones</message>
-<message key="xmlui.statistics.visits.countries">Países con más visualizaciones</message>
-<message key="xmlui.statistics.visits.cities">Ciudades con más visualizaciones</message>
-<message key="xmlui.statistics.visits.bitstreams">Visitas al fichero</message>
-<message key="xmlui.statistics.Navigation.title">Estadísticas</message>
-<message key="xmlui.statistics.Navigation.usage.view">Ver Estadísticas de uso</message>
-<message key="xmlui.statistics.Navigation.search.view">Ver Estadísticas de Búsquedas</message>
-<message key="xmlui.statistics.Navigation.workflow.view">Ver Estadísticas del flujo de trabajo</message>
-<message key="xmlui.statistics.trail">Estadísticas</message>
-<message key="xmlui.statistics.trail-search">Estadísticas de Búsquedas</message>
-<message key="xmlui.statistics.trail-workflow">Estadísticas del flujo de trabajo</message>
-<message key="xmlui.statistics.workflow.no-results">No se dispone de estadísticas del flujo de trabajo para el período seleccionado..</message>
-<message key="xmlui.statistics.workflow.error">Se produjo un error al generar las estadísticas del flujo de trabajo. Por favor, inténtelo mas tarde.</message>
-<message key="xmlui.statistics.workflow.head">Estadísticas del flujo de trabajo</message>
-<message key="xmlui.statistics.workflow.head-dso">Estadísticas del flujo de trabajo para {0}</message>
+    <message key="xmlui.statistics.title">Estadísticas</message>
+    <message key="xmlui.statistics.search.title">Estadísticas de Búsquedas</message>
+    <message key="xmlui.statistics.search.head">Estadísticas de Búsquedas</message>
+    <message key="xmlui.statistics.search.head-dso">Estadísticas de Búsquedas para {0}</message>
+    <message key="xmlui.statistics.search.error">Se produjo un error al generar las estadísticas de búsqueda. Por favor, inténtelo mas tarde.</message>
+    <message key="xmlui.statistics.search.no-results">No se dispone de estadísticas de búsquedas para el período seleccionado.</message>
+    <message key="xmlui.statistics.workflow.title">Estadísticas del flujo de trabajo</message>
+    <message key="xmlui.statistics.visits.total">Número total de visitas</message>
+    <message key="xmlui.statistics.visits.month">Visitas al mes</message>
+    <message key="xmlui.statistics.visits.views">Visualizaciones</message>
+    <message key="xmlui.statistics.visits.countries">Países con más visualizaciones</message>
+    <message key="xmlui.statistics.visits.cities">Ciudades con más visualizaciones</message>
+    <message key="xmlui.statistics.visits.bitstreams">Visitas al fichero</message>
+    <message key="xmlui.statistics.Navigation.title">Estadísticas</message>
+    <message key="xmlui.statistics.Navigation.usage.view">Ver Estadísticas de uso</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">Ver Estadísticas de Búsquedas</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">Ver Estadísticas del flujo de trabajo</message>
+    <message key="xmlui.statistics.trail">Estadísticas</message>
+    <message key="xmlui.statistics.trail-search">Estadísticas de Búsquedas</message>
+    <message key="xmlui.statistics.trail-workflow">Estadísticas del flujo de trabajo</message>
+    <message key="xmlui.statistics.workflow.no-results">No se dispone de estadísticas del flujo de trabajo para el período seleccionado..</message>
+    <message key="xmlui.statistics.workflow.error">Se produjo un error al generar las estadísticas del flujo de trabajo. Por favor, inténtelo mas tarde.</message>
+    <message key="xmlui.statistics.workflow.head">Estadísticas del flujo de trabajo</message>
+    <message key="xmlui.statistics.workflow.head-dso">Estadísticas del flujo de trabajo para {0}</message>
 
 
-<message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Términos de Búsqueda mas usados</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Mes anterior</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">6 meses anteriores</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Año anterior</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Términos de Búsqueda mas usados</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Mes anterior</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">6 meses anteriores</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Año anterior</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Total</message>
 
-<message key="xmlui.statistics.display.table.column-label.search-terms">Término de Búsqueda</message>
-<message key="xmlui.statistics.display.table.column-label.searches">Búsquedas</message>
-<message key="xmlui.statistics.display.table.column-label.percent-total">% del total</message>
-<message key="xmlui.statistics.display.table.column-label.views-search">Páginas Vistas / Búsquedas</message>
-<message key="xmlui.statistics.display.table.column-label.step">Paso</message>
-<message key="xmlui.statistics.display.table.column-label.performed">Realizado</message>
-<message key="xmlui.statistics.display.table.column-label.average">Media</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Pool de Etapa Aceptar/Rechazar</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP1">Etapa Aceptar/Rechazar</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Pool de Etapa de Aceptación/Rechazo/Editar Metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP2">Etapa Aceptar/Rechazar/Editar metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Grupo de Paso de Editar Metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP3">Paso de Editar metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Pool de Etapa Aceptar/Rechazar</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Etapa Aceptar/Rechazar</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Pool de Etapa Aceptar/Rechazar/Editar metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Etapa Aceptar/Rechazar/Editar metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Grupo de Paso de Editar Metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Paso de Editar Metadatos</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Pool de revisión con puntuación</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Revisión con puntuación</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Evaluar por revisión con puntuación</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Configuración de Evaluación de revisión con puntuación</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Pool de revisión por usuario</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Acción de autoasignar por usuario</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Acción de revisión por usario</message>
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Término de Búsqueda</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Búsquedas</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% del total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Páginas Vistas / Búsquedas</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Paso</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Realizado</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Media</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Pool de Etapa Aceptar/Rechazar</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Etapa Aceptar/Rechazar</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Pool de Etapa de Aceptación/Rechazo/Editar Metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Etapa Aceptar/Rechazar/Editar metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Grupo de Paso de Editar Metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Paso de Editar metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Pool de Etapa Aceptar/Rechazar</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Etapa Aceptar/Rechazar</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Pool de Etapa Aceptar/Rechazar/Editar metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Etapa Aceptar/Rechazar/Editar metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Grupo de Paso de Editar Metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Paso de Editar Metadatos</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Pool de revisión con puntuación</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Revisión con puntuación</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Evaluar por revisión con puntuación</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Configuración de Evaluación de revisión con puntuación</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Pool de revisión por usuario</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Acción de autoasignar por usuario</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
 
 
@@ -2115,17 +2126,17 @@
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
-<message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Estadísticas</message>
-<message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">Ver estadísticas Google Analytics</message>
-<message key="xmlui.statisticsGoogleAnalytics.trail">Estadísticas</message>
-<message key="xmlui.statisticsGoogleAnalytics.title">Estadísticas Google Analytics</message>
-        
-<message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Fecha de comienzo</message>
-<message key="xmlui.statisticsGoogleAnalytics.dates.endDate">Fecha de finalización</message>
-<message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Renovar</message>
-        
-<message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Páginas vistas</message>
-<message key="xmlui.statisticsGoogleAnalytics.downloads.title">Descargas de fichero</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Estadísticas</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">Ver estadísticas Google Analytics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Estadísticas</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Estadísticas Google Analytics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Fecha de comienzo</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">Fecha de finalización</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Renovar</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Páginas vistas</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">Descargas de fichero</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2139,115 +2150,114 @@
 
 
 	<!-- structural.xsl -->
-<message key="xmlui.dri2xhtml.structural.footer-promotional">
+	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
 			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-XMLUI, una interfaz para Dspace creada por Texas A&amp;M University Libraries. 
-Para más infomación, visite 
-        
-   <a href="http://di.tamu.edu">http://di.tamu.edu</a> y
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
-<message key="xmlui.dri2xhtml.structural.contact-link">Contacto</message>
-<message key="xmlui.dri2xhtml.structural.feedback-link">Sugerencias</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Contacto</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Sugerencias</message>
 
-<message key="xmlui.dri2xhtml.structural.head-subtitle">Repositorio Dspace </message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Repositorio Dspace </message>
 
-<message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
-<message key="xmlui.dri2xhtml.structural.logout">Logout</message>
-<message key="xmlui.dri2xhtml.structural.login">Login</message>
+	<message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
+	<message key="xmlui.dri2xhtml.structural.logout">Logout</message>
+	<message key="xmlui.dri2xhtml.structural.login">Login</message>
 
-<message key="xmlui.dri2xhtml.structural.search">Buscar en DSpace</message>
-<message key="xmlui.dri2xhtml.structural.search-advanced">Búsqueda avanzada</message>
-<message key="xmlui.dri2xhtml.structural.search-in-community">Esta comunidad</message>
-<message key="xmlui.dri2xhtml.structural.search-in-collection">Esta colección</message>
+	<message key="xmlui.dri2xhtml.structural.search">Buscar en DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Búsqueda avanzada</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Esta comunidad</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">Esta colección</message>
 
-<message key="xmlui.dri2xhtml.structural.pagination-previous">Página anterior</message>
-<message key="xmlui.dri2xhtml.structural.pagination-info">Mostrando ítems {0}-{1} de {2}</message>
-<message key="xmlui.dri2xhtml.structural.pagination-next">Página siguiente</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Página anterior</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Mostrando ítems {0}-{1} de {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Página siguiente</message>
 
-<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-<message key="xmlui.dri2xhtml.structural.link_original_license">Licencia original</message>
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Licencia original</message>
 
 
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Vista previa no disponible</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sin título</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconocido</message>
-<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Vista previa no disponible</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sin título</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor desconocido</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
 Este no es un objeto Dspace conforme con el perfil METS1.0,  por tanto no puede ser interpretado correctamente.   
 Puede reemplazar la plantilla que gestiona el caso general dri2xhtml para mejorar la función necesaria  
  o crear una plantilla que se ajuste al perfil usado.
         
     </message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Vista previa</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-title">Título</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resumen</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripción</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-date">Fecha</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Vista previa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Título</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resumen</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descripción</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Fecha</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Ficheros en el ítem</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Ficheros</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nombre</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaño</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ver</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Descripción</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ver/</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Acceso de lectura disponible para </message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hay ficheros asociados a este ítem.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Ficheros en el ítem</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Ficheros</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nombre</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaño</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ver</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Descripción</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ver/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">No hay ficheros asociados a este ítem.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.license-text">El ítem tiene asociados los siguientes ficheros de licencia:</message>
-<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Excepto si se señala otra cosa, la licencia del ítem se describe como </message>
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">El ítem tiene asociados los siguientes ficheros de licencia:</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Excepto si se señala otra cosa, la licencia del ítem se describe como </message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 La vista resumen de la colección no está actualmente en uso o implementada.  
 Puede solucionarse sobreescribiendo la plantilla dri2xhtml  denominada collectionSummaryView.
 	</message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
 La vista resumen de la comunidad no está actualmente en uso o implementada.
  Puede solucionarse sobreescribiendo la plantilla dri2xhtml  denominada communitySummaryView.
 	</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo de la colección</message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo de la comunidad</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Sin logo</message>
-<message key="xmlui.dri2xhtml.METS-1.0.news">Novedades</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo de la colección</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo de la comunidad</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Sin logo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Novedades</message>
 
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
 Qualified Dublin Core (QDC) no se puede aplicar a las comunidades y colecciones de Dspace en este momento.  
 Cuando se usa QDC para los elementos de DSpace se recomienda el uso de crosswalks QDC
  o bien DIM o MODS para el procesamiento de las comunidades y colecciones.      
 	</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementos Dublin Core</message>
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Términos Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementos Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Términos Dublin Core</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.blocked">Bloqueado</message>
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Bloqueado</message>
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->
-<message key="xmlui.dri2xhtml.pioneer.preview">Vista previa</message>
-<message key="xmlui.dri2xhtml.pioneer.date">Fecha</message>
-<message key="xmlui.dri2xhtml.pioneer.title">Título</message>
-<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
+	<message key="xmlui.dri2xhtml.pioneer.preview">Vista previa</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Fecha</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Título</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
 
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
@@ -2255,89 +2265,89 @@ Cuando se usa QDC para los elementos de DSpace se recomienda el uso de crosswalk
   <!--###### File Format MIME Type Mappings ######-->
 
   <!-- Application-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.application/marc">registro MARC</message>
-<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-<message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Desconocido</message>
-<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">registro MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Desconocido</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
   <!-- Audio-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
 
   <!-- Image-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.image/gif">imagen GIF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jp2">imagen JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jpeg">imagen JPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/png">imagen PNG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/tiff">imagen TIFF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">imagen BMP </message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">imagen GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">imagen JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">imagen JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">imagen PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">imagen TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">imagen BMP </message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
 
   <!-- Text-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.text/css">Fichero CSS</message>
-<message key="xmlui.dri2xhtml.mimetype.text/csv">Fichero CSV</message>
-<message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-<message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-<message key="xmlui.dri2xhtml.mimetype.text/plain">Fichero de texto</message>
-<message key="xmlui.dri2xhtml.mimetype.text/richtext">Fichero RTF</message>
-<message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/css">Fichero CSS</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">Fichero CSV</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Fichero de texto</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">Fichero RTF</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
   <!-- Video-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.video/avi">video AVI</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg">video MPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mp4">video MPEG-4</message>
-<message key="xmlui.dri2xhtml.mimetype.video/quicktime">Video QuickTime</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">video AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">video MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">video MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Video QuickTime</message>
 
   <!-- explanatory messages for choice authority confidence values -->
-<message key="xmlui.authority.confidence.description.cf_unset">Confianza no establecida para este valor</message>
-<message key="xmlui.authority.confidence.description.cf_novalue">No se ha devuelto un valor de confianza razonable por parte de la Autoridad</message>
-<message key="xmlui.authority.confidence.description.cf_rejected">El control de autoridades recomienda que este envío sea rechazado</message>
-<message key="xmlui.authority.confidence.description.cf_failed">El control de autoridades ha encontrado un error interno</message>
-<message key="xmlui.authority.confidence.description.cf_notfound">No hay respuestas coincidentes en la Autoridad</message>
-<message key="xmlui.authority.confidence.description.cf_ambiguous">Hay múltiples valores de autoridad conformes de igual validez</message>
-<message key="xmlui.authority.confidence.description.cf_uncertain">El valor es único y válido, pero no ha sido visto ni aceptado por ningún usuario por lo que es aún incierto</message>
-<message key="xmlui.authority.confidence.description.cf_accepted">Se ha confirmado la validez de este valor de autoridad por un usuario</message>
+  <message key="xmlui.authority.confidence.description.cf_unset">Confianza no establecida para este valor</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">No se ha devuelto un valor de confianza razonable por parte de la Autoridad</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">El control de autoridades recomienda que este envío sea rechazado</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">El control de autoridades ha encontrado un error interno</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">No hay respuestas coincidentes en la Autoridad</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">Hay múltiples valores de autoridad conformes de igual validez</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">El valor es único y válido, pero no ha sido visto ni aceptado por ningún usuario por lo que es aún incierto</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">Se ha confirmado la validez de este valor de autoridad por un usuario</message>
   <!-- help message on "unlock" button in EditItemMetadata display -->
-<message key="xmlui.authority.confidence.unlock.help">Desbloquear el valor de la clave de Autoridad para la edición manual, o cambiarlo para bloquearlo de nuevo</message>
+  <message key="xmlui.authority.confidence.unlock.help">Desbloquear el valor de la clave de Autoridad para la edición manual, o cambiarlo para bloquearlo de nuevo</message>
 
   <!-- Choice Lookup popup window -->
   <!-- NOTE: These messages necessarily use a *different* format for
@@ -2345,412 +2355,141 @@ Cuando se usa QDC para los elementos de DSpace se recomienda el uso de crosswalk
      - JavaScript (AJAX) that completes the lookup popup window.
      - So, positional parameters are @1@, @2@, etc.
     -->
-<message key="xmlui.ChoiceLookupTransformer.title">Valor de la búsqueda Dspace</message>
-<message key="xmlui.ChoiceLookupTransformer.accept">Aceptar</message>
-<message key="xmlui.ChoiceLookupTransformer.add">Añadir</message>
-<message key="xmlui.ChoiceLookupTransformer.cancel">Cancelar</message>
-<message key="xmlui.ChoiceLookupTransformer.more">Ver más resultados</message>
+  <message key="xmlui.ChoiceLookupTransformer.title">Valor de la búsqueda Dspace</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Aceptar</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Añadir</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancelar</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">Ver más resultados</message>
   <!-- params are: start, end, total-count, search-value -->
-<message key="xmlui.ChoiceLookupTransformer.results">Resultados @1@ a @2@ de @3@ para "@4@"</message>
-<message key="xmlui.ChoiceLookupTransformer.fail">No se pudieron cargar los datos de la elección: </message>
-<message key="xmlui.ChoiceLookupTransformer.lookup">Búsqueda</message>
+  <message key="xmlui.ChoiceLookupTransformer.results">Resultados @1@ a @2@ de @3@ para "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">No se pudieron cargar los datos de la elección: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Búsqueda</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nombre del Editor</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Buscar Editor</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nombre del Editor</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Buscar Editor</message>
   <!-- Params are: search-value -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">No es valor de Autoridad: @1@</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">No es valor de Autoridad: @1@</message>
 
   <!-- Choice Lookup - sample config for dc.contributor.author field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nombre en formato "Apellido, Nombre"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Apellido, p.ej. "López"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Nombre(s) p.ej. "Alfredo"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Búsqueda de autores en la Name Authorithy</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local "@1@" (no se encuentra en la Autoridad)</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nombre en formato "Apellido, Nombre"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Apellido, p.ej. "López"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Nombre(s) p.ej. "Alfredo"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Búsqueda de autores en la Name Authorithy</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local "@1@" (no se encuentra en la Autoridad)</message>
 
   <!-- mobile theme -->
-<message key="xmlui.mobile.home_mobile">DSpace Móvil</message>
-<message key="xmlui.mobile.search_all">Buscar TODO</message>
-<message key="xmlui.mobile.browse_all">Listar TODO por</message>
-<message key="xmlui.mobile.browse_date">Fecha</message>
-<message key="xmlui.mobile.browse_author">Autor</message>
-<message key="xmlui.mobile.browse_title">Título</message>
-<message key="xmlui.mobile.browse_subject">Materia</message>
-<message key="xmlui.mobile.related_google_scholar">Relacionado</message>
-<message key="xmlui.mobile.items_in_google_scholar">Ítems en Google Scholar</message>
-<message key="xmlui.mobile.download">Descargar</message>
+  <message key="xmlui.mobile.home_mobile">DSpace Móvil</message>
+  <message key="xmlui.mobile.search_all">Buscar TODO</message>
+  <message key="xmlui.mobile.browse_all">Listar TODO por</message>
+  <message key="xmlui.mobile.browse_date">Fecha</message>
+  <message key="xmlui.mobile.browse_author">Autor</message>
+  <message key="xmlui.mobile.browse_title">Título</message>
+  <message key="xmlui.mobile.browse_subject">Materia</message>
+  <message key="xmlui.mobile.related_google_scholar">Relacionado</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Ítems en Google Scholar</message>
+  <message key="xmlui.mobile.download">Descargar</message>
 
 
     <!-- Versioning -->
-<message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Crear versión de este ítem</message>
-<message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Ver historial de versiones</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Crear versión de este ítem</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Ver historial de versiones</message>
 
-<message key="xmlui.aspect.versioning.VersionItemForm.title">Crear Versión</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.trail">Versión</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.head1">Crear nueva versión del ítem: {0}</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Versión</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Actualizar Versión</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.summary">Motivo de creación de nueva versión</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Crear Versión</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Versión</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Crear nueva versión del ítem: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Versión</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Actualizar Versión</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Motivo de creación de nueva versión</message>
 
-<message key="xmlui.aspect.versioning.VersionUpdateForm.title">Actualizar Versión</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Versión</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Actualizar Versión del ítem: {0}</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Versión</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Actualizar Versión</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Resumen</message>
-
-
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirmar borrado</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirmar borrado</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirmar borrado(s)</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">¿Está seguro de querer borrar estas versiones? </message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">NOTA: Borrando estas versiones, los ítems asociados no podrán ser accedidos.</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Versión</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Ítem</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Fecha</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Resumen</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Actualizar Versión</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Versión</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Actualizar Versión del ítem: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Versión</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Actualizar Versión</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Resumen</message>
 
 
-<message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restaurar Versión</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restaurar Versión</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restaurar Versión</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.para1">¿está seguro de querer restaurar esta versión:</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Versión</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Fecha</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Resumen</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restaurar</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirmar borrado</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirmar borrado</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirmar borrado(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">¿Está seguro de querer borrar estas versiones? </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">NOTA: Borrando estas versiones, los ítems asociados no podrán ser accedidos.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Versión</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Ítem</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Fecha</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Resumen</message>
 
-<message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Historial de Versiones</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Versión</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Ítem</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Fecha</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Resumen</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Acciones</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restaurar</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.update">Actualizar</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Versión seleccionada</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Borrar Versiones</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.return">Volver</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(sólo administradores de colección)</message>
 
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Nota</message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Esta no es la última versión de este ítem. La última versión se encuentra en: </message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Nota</message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Una versión más reciente de este ítem está en el flujo de trabajo.</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restaurar Versión</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restaurar Versión</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restaurar Versión</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">¿está seguro de querer restaurar esta versión:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Versión</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Fecha</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Resumen</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restaurar</message>
 
-<message key="xmlui.aspect.sherpa.submission.consult">Para comprobar los derechos de copia y las políticas de autoarchivo por revista o editor, por favor, consulte </message>
-<message key="xmlui.aspect.sherpa.submission.title">Información del editor</message>
-<message key="xmlui.aspect.sherpa.submission.journal">Revista:</message>
-<message key="xmlui.aspect.sherpa.submission.publisher">Información del editor:</message>
-<message key="xmlui.aspect.sherpa.submission.colour">Color ROMEO:</message>
-<message key="xmlui.aspect.sherpa.submission.more">(Más información)</message>
-<message key="xmlui.aspect.sherpa.submission.green">verde</message>
-<message key="xmlui.aspect.sherpa.submission.blue">azul</message>
-<message key="xmlui.aspect.sherpa.submission.white">blanco</message>
-<message key="xmlui.aspect.sherpa.submission.yellow">amarillo</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Historial de Versiones</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Versión</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Ítem</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Fecha</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Resumen</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Acciones</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restaurar</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Actualizar</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Versión seleccionada</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Borrar Versiones</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Volver</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(sólo administradores de colección)</message>
 
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Nota</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Esta no es la última versión de este ítem. La última versión se encuentra en: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Nota</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Una versión más reciente de este ítem está en el flujo de trabajo.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">Para comprobar los derechos de copia y las políticas de autoarchivo por revista o editor, por favor, consulte <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Información del editor</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Revista:</message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Información del editor:</message>
+    <message key="xmlui.aspect.sherpa.submission.colour">Color ROMEO:</message>
+    <message key="xmlui.aspect.sherpa.submission.more">(Más información)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">verde</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">azul</message>
+    <message key="xmlui.aspect.sherpa.submission.white">blanco</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">amarillo</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
 
-<message key="xmlui.mirage2.itemSummaryView.MetaData">Metadatos</message>
-<message key="xmlui.mirage2.itemSummaryView.Collections">Colecciones</message>
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadatos</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Colecciones</message>
 
-<message key="xmlui.mirage2.discovery.reset">Restaurar</message>
-<message key="xmlui.mirage2.discovery.newFilter">Añadir nuevo filtro</message>
-<message key="xmlui.mirage2.discovery.showAdvancedFilters">Mostrar filtros avanzados</message>
-<message key="xmlui.mirage2.discovery.hideAdvancedFilters">Ocultar filttos avanzados</message>
+    <message key="xmlui.mirage2.discovery.reset">Restaurar</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Añadir nuevo filtro</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Mostrar filtros avanzados</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Ocultar filttos avanzados</message>
 
 
-<message key="xmlui.mirage2.forms.instancedCompositeFields.add">Añadir</message>
-<message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Quitar</message>
-<message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: el campo de entrada con el comportamiento de selección de tipo "suggest" (autocompletado) no está implementado para campos compuestos(como "nombre").</message>
-<message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: el campo de entrada con el comportamiento de selección de tipo "suggest" (autocompletado) no está implementado para campos compuestos(como "nombre").</message>
-<message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Añadir</message>
-<message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Quitar</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Añadir</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Quitar</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: el campo de entrada con el comportamiento de selección de tipo "suggest" (autocompletado) no está implementado para campos compuestos(como "nombre").</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: el campo de entrada con el comportamiento de selección de tipo "suggest" (autocompletado) no está implementado para campos compuestos(como "nombre").</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Añadir</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Quitar</message>
 
-<message key="xmlui.mirage2.page-structure.aboutThisRepository">Sobre este Repositorio</message>
-<message key="xmlui.mirage2.page-structure.toggleNavigation">Cambiar navegación</message>
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">Sobre este Repositorio</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Cambiar navegación</message>
 
-<message key="xmlui.mirage2.page-structure.heroUnit.title">Sobre este Repositorio</message>
-<message key="xmlui.mirage2.page-structure.heroUnit.content">Para añadir contenidos a esta página, edite webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl y añada su propio Título y cuerpo. Si desea añadir más páginas, deberá crear otro bloque xsl:when  y fijar el request-uri con el de la página que esté añadiendo. En la actualidad, las páginas estáticas creadas modificando las XSL solo están disponibles bajo el prefijo URI de page/.</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">Sobre este Repositorio</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">Para añadir contenidos a esta página, edite webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl y añada su propio Título y cuerpo. Si desea añadir más páginas, deberá crear otro bloque xsl:when  y fijar el request-uri con el de la página que esté añadiendo. En la actualidad, las páginas estáticas creadas modificando las XSL solo están disponibles bajo el prefijo URI de page/.</message>
 
-<message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
-<message key="xmlui.mirage2.choice-authority-control.loading">Cargando...</message>
+    <message key="xmlui.mirage2.choice-authority-control.loading">Cargando...</message>
 
-<message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
-
-
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-
-
-
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message> 
-   
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Materia</message> 
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Tipo</message> 
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Fecha</message> 
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Fecha</message> 
- 
-
-
-    <!-- Site Leve Recently Added Content -->
-    
-	<message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Añadido Recientemente</message> 
-
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Más</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Envíos recientes</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Envíos recientes</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Envíos recientes</message>
-
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Clase</message> 
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Editor</message> 
-
-
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Padre</message> 
-	
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Agrupar resultados por</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Ninguno</message> 
-	
-  
-  <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publicación</message> 
-	
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Comunidad</message>
-  <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Colección</message>
-    
- 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Serie</message> 
-
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Visualizar por: Autor</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Visualizar por: Título</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Visualizar por: Materia</message> 
-
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Visualizar por: Resumen</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Visualizar por: Series</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Visualizar por: Patrocinador</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Visualizar por: Identificador</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Visualizar por: Idioma (ISO)</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Visualizar por: Palabra Clave</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Visualizar por: Nombre Científico</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Visualizar por: Colaborador</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Visualizar por: Creador</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Visualizar por: Materia</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Visualizar por: Descripción</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Visualizar por: Relación</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Visualizar por: Mime-Type</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Visualizar por: Otro Colaborador</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Visualizar por: Asesor</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Visualizar por: Departamento</message> 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Visualizar por: Fecha</message> 
-
-
-  	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Título</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Materia</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Fecha</message> 
-
-
- 	<message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Mostrando items {0}-{1}</message> 
-
-	<message key="xmlui.Discovery.AbstractSearch.type_author">Filtrar por: Autor</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message> 
-	<message key="xmlui.Discovery.AbstractSearch.type_subject">Filtrar por: Materia</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Materia</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Materia</message> 
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Fecha</message> 
-
-
-	<message key="xmlui.Discovery.AbstractSearch.startswith">Comienza por</message> 
- <message key="xmlui.Discovery.AbstractSearch.startswith.help">o indique las primeras letras:</message> 
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Opciones de clasificación:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Relevancia</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Título Desc</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Fecha Desc</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Título Asc</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Fecha  Asc</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Resultados por página:</message>
-    
-       <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Añadir filtro</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Aplicar</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Quitar</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Nuevos filtros:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Filtros actuales:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Añadir filtros</message>
-    
-    	<message key="xmlui.discovery.SearchFacetFilter.no-results">Valores del Filtro no encontrados</message> 
-
-	<message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Descubre</message> 
-	<message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... más</message> 
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Buscar</message>
-	<message key="xmlui.discovery.SimpleSearch.search_label">Buscar</message> 
-	<message key="xmlui.Discovery.SimpleSearch.filter_head">Filtros</message> 
-	<message key="xmlui.Discovery.SimpleSearch.filter_help">Use filtros para refinar sus resultados.</message> 
-	
-   <message key="xmlui.Discovery.SimpleSearch.filter.contains">Contiene</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">Es</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
- <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">No contiene</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">No es</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">No es ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Ítems relacionados</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Mostrando ítems relacionados por Título, autor o materia.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Mostrando  {0} de un total de  {1} resultados de la comunidad: {2}. <span class="searchTime">({3} segundos)</span></message>
- <message key="xmlui.Discovery.AbstractSearch.head1_collection">Mostrando  {0} de un total de  {1} resultados de la colección: {2}. <span class="searchTime">({3} segundos)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Mostrando  {0} de un total de  {1} resultados. <span class="searchTime">({3} segundos)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Comunidades o Colecciones correspondientes a su consulta</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Ítems correspondientes a su consulta</message>
-
-   	<message key="xmlui.Discovery.SimpleSearch.did_you_mean">¿Se refiere a: </message>
-
-
-<!-- XML Workflow -->
-
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Acciones posibles para esta tarea:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Asígnese esta tarea.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Asumir tarea</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Dejar esta tarea en la cola para que la asuma otra persona.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Dejar tarea</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Regreso a revisión</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Aceptar/Rechazar Tarea</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Realizar tarea: Aceptar/Rechazar ítem</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Acciones que puede realizar en esta tarea:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Si revisó este ítem y encontró que <strong>no</strong> es apropiado para su incorporación en la colección, seleccione "Rechazar".  Se le preguntarán las razones de su rechazo y si el publicador debe cambiar algo y reenviarlo</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Rechazar ítem</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Si revisó este ítem y encontró que  es apropiado para su incorporación en la colección, seleccione "Aprobar".</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Aprobar ítem</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Realizar tarea: Aceptar/Rechazar/Editar ítem</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Acciones que puede realizar en esta tarea:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Si revisó este ítem y encontró que <strong>no</strong> es apropiado para su incorporación en la colección, seleccione "Rechazar".  Se le preguntarán las razones de su rechazo y si el publicador debe cambiar algo y reenviarlo.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Rechazar ítem</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Si revisó este ítem y encontró que es apropiado para su incorporación en la colección, seleccione "Aprobar".</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Aprobar ítem</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Seleccionar esta opción si quiere cambiar los metadatos del ítem.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Editar metadatos</message>
-
-    <message key="xmlui.XMLWorkflow.step.unknown">Estado desconocido</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Realizar tarea:  Asignar revisor</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Use el cajetín de búsqueda para encontrar un usuario a quien asignar la tarea de revisión.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Buscar por revisor</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Buscar por usuario</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Seleccionar como revisor</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Si Vd. no es la persona adecuada para revisar este ítem, puede declinar la tarea seleccionando "Declinar tarea".</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Declinar tarea</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Revisar envío</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Revisar envío</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Entre la puntuación para este envío</message>
-
-
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Revisión del Flujo de Trabajo</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Revisión del Flujo de Trabajo</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Revisión del Flujo de Trabajo</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Paso</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Ítem</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Colección</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Publicadores</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Devolver ítems al publicador</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Borrar ítems</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Sin resultados</message>
-
-
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Ver el flujo de trabajo de item: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Ver el flujo de trabajo de item</message>
-
-    <message key="xmlui.XMLWorkflow.default.reviewstep">Aceptar/Rechazar</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Aceptar/Rechazar</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Aceptar/Rechazar</message>
-
-    <message key="xmlui.XMLWorkflow.default.editstep">Paso Aceptar/Editar/Rechazar </message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Aceptar/Editar/Rechazar</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">Aceptar/Editar/Rechazar</message>
-
-    <message key="xmlui.XMLWorkflow.default.finaleditstep">Aceptación Final/Editar</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Aceptación Final/Editar</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Aceptación Final/Editar</message>
-
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Paso de Asignación de revisor</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Asignar revisor</message>
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Paso de revisión por un único usuario</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Revisar envío</message>
-
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Puntuación de la revisión</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Puntuación de la revisión</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Puntuación de la revisión</message>
-
-
-    <!--   Sword Client  -->
-    <message key="xmlui.swordclient.Navigation.context_head">Copiado Sword</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">Copiar ítem a otro repositorio</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">Copiado Sword</message>
-    <message key="xmlui.swordclient.general.main_head">Copiar ítem: {0}</message>
-
-
-    <message key="xmlui.swordclient.SelectTarget.title">Destino copia Sword</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">Seleccione destino</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">URL alternativa</message>
-    <message key="xmlui.swordclient.SelectTarget.username">Nombre de usuario</message>
-    <message key="xmlui.swordclient.SelectTarget.password">Contraseña</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">En nombre de</message>
-
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">URL inválida</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">Nombre de usuario inválido</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">Contraseña inválida</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Error recuperando el Documento de Servicio Sword: {0}</message>
-
-    <message key="xmlui.swordclient.SelectCollection.title">Colecciones destino Sword</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">Seleccione colecciones</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">Colección: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">Título: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">Política: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">Mediación: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">Tipo de ficheros: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Formatos de Paquete: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Depositar en este lugar:</message>
-
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">Sub Servicio destino</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Recuperar Documento de SubServicio</message>
-
-    <message key="xmlui.swordclient.SelectPackagingAction.head">Colección:{0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">Título: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">Política: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">Mediación:{0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">Tipo de ficheros</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Formato de Paquete</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Seleccionado formato de paquete no soportado</message>
-
-    <message key="xmlui.swordclient.DepositAction.success">Ítem copiado</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Error del Formato de Paquete</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">Handle inválido</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Ocurrió un error al empaquetar el objeto</message>
-    <message key="xmlui.swordclient.DepositAction.error">Ocurrió un error durante el depósito: {0}</message>
-
-    <message key="xmlui.swordclient.SwordResponse.title">Respuesta Sword</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">Respuesta Sword</message>
-
-
-
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_et.xml
+++ b/src/main/webapp/i18n/messages_et.xml
@@ -1,14 +1,4 @@
-﻿<?xml version="1.0"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="et" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -22,7 +12,7 @@
 		   may be found at xmlui.<Aspect> without specifying a
 		   particular java class.
 		-->
- 
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">DSpace esileht</message>
 	<message key="xmlui.general.search">Otsi</message>
@@ -38,7 +28,7 @@
         <message key="xmlui.general.perform">Esita</message>
         <message key="xmlui.general.queue">Lisa järjekorda</message>
 
-<!-- Keys which are used by exception2dri.xsl on error pages -->
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
         <message key="xmlui.error.contact_msg">Palun saatke teade administraatorile. Võimaluse korral kirjeldage oma tegevust vea ilmnemise eel ja ajal.</message>
         <message key="xmlui.error.contact">Saada teade administraatorile</message>
         <message key="xmlui.error.show_stack">Näita vea kohta</message>
@@ -66,7 +56,7 @@
 		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">DSpace digitaalrepositooriumi süsteem salvestab, säilitab, indekseerib ja levitab digitaalset teadusinformatsiooni. </message>
-       <message key="xmlui.feed.header">RSS uudisvood</message>
+    <message key="xmlui.feed.header">RSS uudisvood</message>
 	<message key="xmlui.feed.logo_title">Kanali logo</message>
 	<message key="xmlui.feed.untitled">Pealkirjata</message>
 
@@ -186,6 +176,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Sirvi {0} lisamisaja järgi</message>
 
 
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Otsingu ulatus</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Kogu TÜ DSpace</message>
@@ -242,17 +252,13 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Tagasiside saadetud</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Sinu kommentaarid jõudsid kohale.</message>
 
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Otsi</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Sisesta otsisõna(d)</message>
-
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Vaata</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Nimetus asub järgmis(t)es kollektsiooni(de)s:</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Näita lihtsat nimetuse kirjet</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Näita täielikku nimetuse kirjet</message>
-	
-              <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">See nimetus ei ole enam kättesaadav.</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">See nimetus ei ole enam kättesaadav.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Sirvi</message>
@@ -292,9 +298,9 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">nimetus</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">allikas</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">tundmatu</message>
-          <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Sisselogimise juurde </message>
-          
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">See nimetus on eemaldatud</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Sisselogimise juurde </message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">See nimetus on eemaldatud</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Valitud nimetus on eemaldatud ega ole enam kättesaadav.</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Ligipääs on piiratud, palun logige sisse</message>
         <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Sellele nimetusele pole Teie kontol õigusi. .</message>
@@ -317,7 +323,8 @@
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Juurdepääs sellele eksportarhiivile on piiratud</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Juurdepääs sellele eksportarhiivile on piiratud ning selle nägemiseks on vaja vastavaid volitusi. Eksportarhiivi avamiseks logi sisse. </message>
 
-<!-- REQUEST COPY -->
+
+	<!-- REQUEST COPY -->
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Telli dokumendi koopia</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Telli dokumendi koopia</message>
@@ -422,7 +429,6 @@
 
 
 	
-
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		                EPerson Aspect
@@ -442,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Registreerimine ei ole saadaval</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Registreerimine ei ole saadaval</message>
-	<message key="xmlui.EPerson.CannotRegister.para1"> DSpace'i ei ole võimalik registreeruda. Küsimuste korral võta ühendust <a href="../contact">lehekülje administraatoriga.</a></message>
+	<message key="xmlui.EPerson.CannotRegister.para1"> DSpace'i ei ole võimalik registreeruda. Küsimuste korral võta ühendust <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Uuenda profiili</message>
@@ -517,7 +523,6 @@
 	<message key="xmlui.EPerson.LDAPLogin.trail">Logi sisse</message>
 	<message key="xmlui.EPerson.LDAPLogin.head1">Logi TÜ DSpace'i -
 	ainult TÜ kasutajatele</message>
-	<message key="xmlui.EPerson.LDAPLogin.title">Logi sisse</message>
 	<message key="xmlui.EPerson.LDAPLogin.username">Kasutajanimi</message>
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Sisestatud kasutajanimi ja/või salasõna on vale(d).</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Salasõna</message>
@@ -612,6 +617,7 @@
 
 
 
+
 	<!-- general submission aspect messages -->
 	<message key="xmlui.Submission.general.mydspace_home">Minu  DSpace esileht</message>
 	<message key="xmlui.Submission.general.go_mydspace">Mine Minu  DSpace esilehele</message>
@@ -630,7 +636,7 @@
 	<message key="xmlui.Submission.general.default.title">Lisamine</message>
 	<message key="xmlui.Submission.general.default.trail">Lisamine</message>
 
-	<!-- org.dspace.app.xmlui.submission.CollectionViewer -->
+	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Lisa kollektsiooni uus nimetus</message>
 
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
@@ -641,13 +647,13 @@
 	<message key="xmlui.Submission.Submissions.title">Nimetuste lisamine</message>
 	<message key="xmlui.Submission.Submissions.trail">Lisatud</message>
 	<message key="xmlui.Submission.Submissions.head">Nimetuste lisamine</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Pealkirjata</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">e-post: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Töövoo toimingud</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Need toimingud hõlmavad nimetusi, mis enne repositooriumisse lisamist vajavad kinnitamist. Toimingutel on kaks järjekorda, ühte kuuluvad kinnitatud ja teise kinnitamata nimetused.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Sinu toimingud</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Toiming</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Nimetus</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Kollektsioon</message>
@@ -666,7 +672,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Sinu lõpetamata lisamised.</message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">Sisesta uus nimetus</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Pealkiri</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Kollektsioon</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Sisestaja</message>
@@ -690,7 +696,7 @@
 	<message key="xmlui.Submission.Submissions.status_6">Nimetus toimetamisel</message>
 	<message key="xmlui.Submission.Submissions.status_7">Nimetus on arhiveeritud</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Olek teadmata</message>
-<!-- Same transformer, completed submissions section -->
+        <!-- Same transformer, completed submissions section -->
         <message key="xmlui.Submission.Submissions.completed.head">Arhiveeritud lisandused</message>
         <message key="xmlui.Submission.Submissions.completed.info">Need on aktepteeritud ja lõpetatud lisamised.</message>
         <message key="xmlui.Submission.Submissions.completed.column1">Aktsepti aeg</message>
@@ -702,12 +708,12 @@
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Lähteküsimused</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Kirjelda</message>
-         <message key="xmlui.Submission.submit.progressbar.access">Ligipääs</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Laadi üles</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Ligipääs</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Laadi üles</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Retsensioon</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-<message key="xmlui.Submission.submit.progressbar.CClicense">CC Litsents</message>
-	<message key="xmlui.Submission.submit.progressbar.license">Litsents</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC Litsents</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Litsents</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Lõpetamine</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
@@ -735,7 +741,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Mitu pealkirja</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Nimetusel on rohkem kui üks pealkiri, <i>nt tõlgitud pealkiri</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Nimetusel on rohkem kui üks pealkiri, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Järgmised nimetused eemaldatakse, kui ülalolev kastike on märgistamata </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Avaldamine</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Nimetus on varem avaldatud või seda on avalikult levitatud.</message>
@@ -748,14 +754,14 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Kirjelda nimetust</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Viga: Tundmatu väljatüüp</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Kohustuslik väli</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Perekonnanimi <i>nt Tamm</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Eesnimi, <i>nt Jüri</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Perekonnanimi <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Eesnimi, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Aasta</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Kuu</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Päev</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">Seeria nimetus</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Number</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Teemad</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Teemad</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Teemad</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Märksõnafilter</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Märksõnafilter</message>
@@ -794,24 +800,25 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Muuda</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Kustuta</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Ajaformaat: yyyy, yyyy-mm, yyyy-mm-dd</message>
-   <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nimetus: {0}; tegevus: {1}, grupp: {2}, algus: {3}, lõpp: {4}</message>
-   <message key="xmlui.Submission.submit.AccessStep.review_public_item">Dokument on otsitav</message>
-   <message key="xmlui.Submission.submit.AccessStep.review_private_item">Dokument ei ole otsitav</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nimetus: {0}; tegevus: {1}, grupp: {2}, algus: {3}, lõpp: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">Dokument on otsitav</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">Dokument ei ole otsitav</message>
 
 
-<!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Muuda reeglit</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Laadi üles fail(e)</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Fail</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Sisesta nimetuse täielik asukoht sinu arvutis. "Sirvi..." vajutamisel avaneb aken arvutist faili valimiseks.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Nimetus peab sisaldama vähemalt ühte faili.</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">Faili üleslaadimisel tekkis probleem.  Sisestatud failinimi oli vale, tekkis ühenduse viga või oli fail markeeritud süsteemisiseseks kasutuseks. Palun proovi uuesti.</message>
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Faili ei laaditud, kuna sisaldab viirust. Palun kontakteeruge administraatoriga.</message>
-  <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Tehniline probleem viirusekontrolliga. Palun kontakteeruge administraatoriga.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Faili kirjeldus</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Soovi korral lisa faili kirjeldus, näiteks" <i>Põhiartikkel</i>", või "<i>Esmane andmeanalüüs</i>".</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Tehniline probleem viirusekontrolliga. Palun kontakteeruge administraatoriga.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Faili kirjeldus</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Soovi korral lisa faili kirjeldus, näiteks" <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Laadi fail üles &amp; lisa järgmine</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Üleslaaditud failid</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Esmane</message>
@@ -820,7 +827,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Suurus</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Kirjeldus</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Formaat</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Tundmatu</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">Tundmatu formaat</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Toetatud)</message>
@@ -829,10 +836,10 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Muuda</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">Kontrollsumma:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Eemalda valitud failid</message>
-	
-	
-	  
-	  <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Laadi fail(e)</message>
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Laadi fail(e)</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fail</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Sisesta nimetuse täielik asukoht sinu arvutis. "Sirvi..." vajutamisel avaneb aken arvutist faili valimiseks</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Nimetus peab sisaldama vähemalt ühte faili.</message>
@@ -840,7 +847,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Faili ei laaditud, kuna sisaldab viirust. Palun kontakteeruge administraatoriga.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Tehniline probleem viirusekontrolliga. Palun pöörduge administraatori poole.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Faili kirjeldus</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Soovi korral lisa faili kirjeldus, näiteks"<i>Põhiartikkel</i> või "<i>Esmane andmeanalüüs</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Soovi korral lisa faili kirjeldus, näiteks"<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Laadi üles &amp; lisa järgmine</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Üleslaaditud failid</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Esmane</message>
@@ -849,7 +856,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Suurus</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Kirjeldus</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formaat</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Tundmatu</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">tundmatu formaat</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Toetatud)</message>
@@ -859,24 +866,24 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Kontrollsumma:</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Kustuta valitud failid</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Reeglid</message>
-    
-    
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Muuda faili</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Fail</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Fiaili kirjeldus</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help"> Soovi korral lisa sisu kirjeldus; näiteks, "<i>Põhiartikkel</i>", or "<i>Esmane andmeanalüüs</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Vali failiformaat allolevast nimekirjast, näiteks "<i>Adobe PDF</i>"või "<i>Microsoft Word</i>." <strong>Kui formaati pole nimekirjas</strong> kirjelda seda vastaval väljal.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help"> Soovi korral lisa sisu kirjeldus; näiteks, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Vali failiformaat allolevast nimekirjast, näiteks "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Kindlakstehtud formaat</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Valitud formaat</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formaati ei ole nimekirjas</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Kui formaati ei ole nimekirjas <strong>vali "formaat ei ole nimekirjas" ülal</strong> ja kirjelda faili vastaval väljal</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Kui formaati ei ole nimekirjas <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Muu formaat</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Kasutatud rakenduse nimi ja versioon (näiteks "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	
-	  <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Muuda failile ligipääsu</message>
-	
+
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Retsensiooni lisamine</message>
@@ -895,19 +902,19 @@
 	<message key="xmlui.Submission.submit.ReviewStep.supported">toetatud</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Ilmnes viga ... {0}</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons Litsents</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">Soovi korral võid oma nimetusele lisada <a href="http://creativecommons.org/">Creative Commons</a> Litsentsi. <strong>Creative Commons litsentsid määravad, mida sinu tööd lugevad inimesed sellega teha tohivad.</strong> Creative Commons litsentsi valimiseks kliki alloleval nupul. Sind suunatakse Creative Commons veebilehele, millest leiad erinevad litsenseerimise võimalused.  Pärast litsentsi valimist suunatakse sind tagasi sellele lehele.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Vali litsents</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Liigu Creative Commons veebilehele litsentsi valimiseks</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Litsents</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Vali või muuda litsentsi ...</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Ilma CC litsentsita</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Salvestamiseks klikake "Järgmine".</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Ilmnes viga ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons Litsents</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Soovi korral võid oma nimetusele lisada <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Vali litsents</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Liigu Creative Commons veebilehele litsentsi valimiseks</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Litsents</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Vali või muuda litsentsi ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Ilma CC litsentsita</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Salvestamiseks klikake "Järgmine".</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Levitamise Litsents</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Viimane samm:</strong> Selleks, et DSpace taastoodaks, tõlgiks ja jagaks sinu poolt lisatud nimetust üle maailma, nõustu järgmiste tingimustega. </message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Vali standardse levitamise litsents "Valin litsentsi" ja vajuta "Lõpeta lisamine"</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Litsentsiga seotud küsimuste korral võta ühendust süsteemi administraatoritega.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Levitamise litsents</message>
@@ -935,7 +942,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Nõustu nimetusega</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Pärast nimetuse toimetamist kasuta seda valikut nimetuse arhiveerimiseks. </message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Arhiveeri</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Vali "Keeldu", kui oled nimetuse retsenseerinud ja see <strong>ei ole</strong> kollektsiooni lisamiseks sobiv. Kirjelda, miks antud nimetus ei sobi ning kas selle lisaja peaks midagi muutma ja uuesti lisama.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Vali "Keeldu", kui oled nimetuse retsenseerinud ja see <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Keeldu nimetusest</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Tee valik nimetuse metaandmete muutmiseks.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Muuda metaandmeid</message>
@@ -963,7 +970,7 @@
         <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Tegevus katkestati. Vajaduse korral pöörduge administraatori poole või uurige logisid.</message>
         <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Tegevus pandi järjekorda.</message>
         <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Tegevuse järjekorda panek ei õnnestunud. Vajaduse korral pöörduge administraatori poole või uurige logisid.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Kasutaja lisamine õnnestus.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Kasutaja lisamine õnnestus.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Kasutaja muutmine õnnestus.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Kasutajale saadeti meil, mis sisaldab andmeid uue salasõna valimiseks.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Kasutaja(te) kustutamine õnnestus.</message>
@@ -1018,12 +1025,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Registrid</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metaandmed</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Formaat</message>
-	<message key="xmlui.administrative.Navigation.administrative_content">Sisu administreerimine</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Sisu administreerimine</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Nimetused</message>
-  <message key="xmlui.administrative.Navigation.administrative_withdrawn">Katkestatud lisamised</message>
-  <message key="xmlui.administrative.Navigation.administrative_private">Privaatsed nimetused</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Juhtpaneel</message>
-  <message key="xmlui.administrative.Navigation.statistics">Statistika</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Katkestatud lisamised</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Privaatsed nimetused</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Juhtpaneel</message>
+    <message key="xmlui.administrative.Navigation.statistics">Statistika</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Impordi metaandmed</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">Hooldustegevused</message>
 
@@ -1058,7 +1066,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-inimesi otsitakse nime või e-posti aadressi järgi</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">E-inimested, kes sobisid sinu otsinguga. Vali E-inimene, kelle soovid kustutada ja vajuta "Kustuta". E-inimese e-posti aadressi või nime muutmiseks vajuta vastavalt e-posti aadressile või nimele.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Otsitulemused</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nimi</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">E-posti aadress</message>
@@ -1133,7 +1141,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Otsi rühmasid</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Rühmasid otsitakse nime või e-posti aadressi järgi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Otsitulemused</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nimi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Liikmed</message>
@@ -1165,18 +1173,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">E-post</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">E-post</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Kollektsioon</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">vaata</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Liikmed</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">E-post</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">rühm: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Sellel rühma ei ole ühtegi liiget.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[ootel]</message>
@@ -1210,7 +1218,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Kustuta väljad</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Kustuta väljad</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Kinnita kustutamine</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Kas sa oled <b>täiesti</b> kindel, et tahad need väljad kustutada? Kui nimetused sisaldavad välja metaandmeid, ei saa välja kustutada. Kontrolli, et ükski nimetus ei kasutaks neid välju.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Kas sa oled <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">HOIATUS: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Kui nimetuses sisalduvad väljade metaandmed tekib tõrge. </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1221,7 +1229,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Kustuta skeem</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Kustuta skeem</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Kinnita kustutamine</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Kas sa oled <b>täiesti</b> kindel, et tahad selle skeemi kustutada? Kui nimetused sisaldavad selle skeemi väljade metaandmeid, ei saa skeemi kustutada. Kontrolli, et ühelgi nimetusel ei oleks selles skeemis metaandmeid.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Kas sa oled <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">HOIATUS:: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Kui nimetused sisaldavad selle skeemi metaandmeid tekib tõrge.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1256,7 +1264,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metaandmete skeem: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">See metaandmete skeem kuulub: "{0}". Võid lisada uue metaandmete välja skeemi või uuendada mõnda olemasolevat. Välju võib märgistada ka kustutamiseks või teise skeemi liigutamiseks. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Skeemi metaandmete väli</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Väli</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Skoobi teade </message>
@@ -1283,12 +1291,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Bitivoo formaadi register</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">See bitivoo formaadi nimekiri sisaldab infot formaatide ja nende toetemise kohta. Selle tööriistaga saad muuta või lisada bitivoo formaate. Sisemiseks märgistustatud formaadid on kasutajate eest varjatud. Neid kasutatakse administratiivsetel eesmärkidel.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Lisa uus bitivoo formaat</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nimi</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Tüüp</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Toetamise tase</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>sisemine</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Tundmatu</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Tuntud</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Tugi</message>
@@ -1298,7 +1306,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metaandmete register</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metaandmete register</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Metaandmete register säilitab nimekirja repositooriumis kättesaadavatest metaandmete väljadest. Väljad võivad olla jagatud mitme skeemi vahel. DSpace nõuab kvalifitseeritud Dublin Core skeemi. Dublin Core skeemi võib laiendada lisaväljadega või uute skeemide lisamisega registrisse.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Nimeruum</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nimi</message>
@@ -1353,10 +1361,10 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Uute õiguste lisamiseks vajuta siia. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Lisa</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nimi</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nimi</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Tegevus</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Rühm</message>
-	 <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Algusaeg</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Algusaeg</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Lõppaeg</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Kustuta valitud</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Muuda</message>
@@ -1386,7 +1394,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Muuda õigusi {0} kohta {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Ühtegi rühma ei valitud</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Ühtegi tegevust ei valitud</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nimi</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Selle allika tegevused </message>
@@ -1399,7 +1407,7 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Otsi</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Vali tegevus</message>
 
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nimi</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nimi</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Kirjeldus</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Algusaeg</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Lõppaeg</message>
@@ -1407,8 +1415,8 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Identne reegel on juba seatud.</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Algusaeg on hilisem kui lõppaeg</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Lubatud formaat: yyyy, yyyy-mm, yyyy-mm-dd</message>
-    
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Õiguste haldur</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Rohkem autoriseerimisi</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Rohkemate õiguste haldur</message>
@@ -1423,9 +1431,9 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Kollektsioon</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Lisa õigusi</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Tühjenda õigused</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Lubatud formaat: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Lubatud formaat: yyyy, yyyy-mm, yyyy-mm-dd</message>
 
- <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nimi</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nimi</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Kirjeldus</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Algusaeg</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Lõppaeg</message>
@@ -1433,7 +1441,7 @@
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Algusaeg on lõppajast hilisem</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Vali vähemalt üks grupp</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Vali vähemalt üks kollektsioon</message>
-    
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Kinnita õiguste kustutamine</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Kinnita kustutamine</message>
@@ -1442,8 +1450,9 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Tegevus</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Rühm</message>
-	
-	<!-- Batch Import Tool -->
+
+
+    <!-- Batch Import Tool -->
     <!-- org.dspace.app.xmlui.administrative.batchimport -->
     <message key="xmlui.administrative.batchimport.general.select_collection">Vali kollektsioon</message>
     <message key="xmlui.administrative.batchimport.general.collection">Kollektsioon</message>
@@ -1501,7 +1510,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fail</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Sisesta sinu arvutis oleva faili nimi. Uues aknas faili otsimiseks ja valimiseks arvutist vajuta "Sirvi...".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Kirjeldus</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Soovi korral lisa faili lühikirjeldus, näiteks "<i>Põhiartikkel</i>", või "<i>Esmane andmeanalüüs</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Soovi korral lisa faili lühikirjeldus, näiteks "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Laadi üles</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Uute bitivoogude üleslaadimiseks on vaja vähemalt LISA &amp; KIRJUTA privileege vähemalt ühele kimbule.</message>
 
@@ -1526,7 +1535,7 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Keel</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Eemalda</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Arhiveeri uuesti</message>
-	 <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Tee privaatseks</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Tee privaatseks</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Tee avalikuks</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
@@ -1549,28 +1558,28 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">jah</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">ei</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Kirjeldus</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Soovi korral lisa faili lühikirjeldus, näiteks: "<i>Põhiartikkel</i>",või "<i>Esmane andmeanalüüs</i>"."</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Vali nimekirjast faili formaat, näiteks "<i>Adobe PDF</i>"või "<i>Microsoft Word</i>", <b>VÕI</b> kui formaati ei ole nimekirjas, kirjelda seda vastaval väljal.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Soovi korral lisa faili lühikirjeldus, näiteks: "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Vali nimekirjast faili formaat, näiteks "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Vali formaat</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formaati pole nimekirjas</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Kui formaati pole nimekirjas, <strong> vali "formaati pole nimekirjas" </strong> ja kirjelda seda vastaval väljal.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Kui formaati pole nimekirjas, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Muu formaat</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Kasutatud rakendus ja versioon (näiteks, "<i>ACMESoft SuperApp versioon 1.5</i>").</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.name_label">Failinimi</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Kasutatud rakendus ja versioon (näiteks, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Failinimi</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Muuda failinime NB see muudab faili urli, kuid kuni sequence-ID on muutmatu, töötab vana link.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Nimetuse bitivood</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Nimetuse bitivood</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitivood</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nimi</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Kirjeldus</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formaat</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Vaata</message>
-		<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Järjestus</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Järjestus</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Kimp: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (esmane) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">vaata</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Laadi uus bitivoog üles</message>
@@ -1620,13 +1629,13 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(ainult süsteemi administraatorid)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(ainult kollektsiooni administraatorid)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(tegevus ei ole sulle lubatud)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_private">Tee privaatseks</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Tee privaatseks</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Tee avalikuks</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Tee privaatseks...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Tee avalikuks...</message>	
-	
-	
-	
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Tee avalikuks...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Vaata nimetust</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Vaata nimetust</message>
@@ -1652,8 +1661,8 @@
         <message key="xmlui.administrative.metadataimport.general.new_item">Uus nimetus</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_successful">Üleslaadimine õnnestus</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_failed">Üleslaadimine ebaõnnestus</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Tundmatu metaandmete skeem pealkirjas</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Tundmatu metaandmete element pealkirjas</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Tundmatu metaandmete skeem pealkirjas</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Tundmatu metaandmete element pealkirjas</message>
         <message key="xmlui.administrative.metadataimport.flow.import_successful">Importimine õnnestus</message>
         <message key="xmlui.administrative.metadataimport.flow.import_failed">Importimine ebaõnnestus</message>
         <message key="xmlui.administrative.metadataimport.flow.over_limit">Muudatuste arv ületab lubatud piiri. Piira muudatusi või muuda bulkedit.gui-item-limit failis dspace.cfg</message>
@@ -1697,7 +1706,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Kollektsioon: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Nimetuse ühendamise tööriistaga saavad kollektsiooni administraatorid kaasata nimetusi teistest kollektsioonidest sellesse kollektsiooni. Sa saad otsida nimetusi teistest kollektsioonidest, nimetusi kaasata või sirvida kaasatud nimetusi.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statistika</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} nimetust {1}</strong>-st selles kollektsioonis on kaasatud siia teistest kollektsioonidest.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Otsi</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Otsi nimetusi</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Sirvi kaasatud nimetusi</message>
@@ -1708,7 +1717,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Otsi nimetusi</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Otsi nimetusi, mis sobituvad: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Kaasa märgitud nimetused</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Kollektsioon</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Pealkiri</message>
@@ -1718,7 +1727,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Sirvi kaasatud nimetusi</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Kaasatud nimetuste sirvimine</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Tühista valitud nimetuste kaasamine</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Kollektsioon</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Pealkiri</message>
@@ -1757,9 +1766,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Muuda metaandmeid etappp</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Sisestajad</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Vaikimisi lugemise juurdepääs</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(ainult süsteemi administraatorid)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repositooriumi tasemel grupp, ainult administraatorid)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(sul puuduvad õigused selle konfigureerimiseks)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Halda kollektsiooni: {0}</message>
@@ -1802,7 +1811,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Eemalda logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Kustuta kollektsioon</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Salvesta uuendused</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(ainult süsteemi administraatorid)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Loo kollektsioon</message>
@@ -1896,7 +1905,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Seotud rühm</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administraatorid</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(ainult süsteemi administraatorid)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Halda valdkonda: {0}</message>
@@ -1965,7 +1974,7 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Reserveeritud mälu</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Kasutatud mälu</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Vaba mälu</message>
-	<message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon versioon</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon vahemälu kataloog</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon töökataloog</message>
@@ -1974,7 +1983,7 @@
         <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Alaline vahemälu suurus ({0})</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Muutuv vahemälu suurus ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">DSpace sätted</message>
-	 <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace versioon</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace versioon</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">DSpace installeerimise kataloog</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">DSpace baas-URL</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">DSpace Hostinimi</message>
@@ -1990,7 +1999,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Tagasiside saaja</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Üldine lehe administratsiooni e-posti aadress</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Süsteemiülesed häired</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Hoiatus balanseeritud laadimisega süsteemidele</strong>: Süsteemiülesed häired töötavad vaid sõlmes, kus nad on aktiveeritud . Kontrolli, et iga sõlm saaks aktiveerimise häire käskluse.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Häire sõnum</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Süsteem läbib regulaarseid hooldustöid. Palun salvesta oma töö ja logi välja.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Aeg</message>
@@ -2004,7 +2013,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Autenditud sessioonide lubamiseks jätka</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Piira autentimist, aga säilita praegused sessioonid</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Piira autentimist ning katkesta ja lõpeta praegused sessioonid</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Pane tähele:</strong> Lehekülje administraatorid ei halda sessiooni.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktiveeri</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Deaktiveeri</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Praegused tegevused ({0} lehekülge maksimaalselt)</message>
@@ -2023,7 +2032,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">Vahelehtedel saad valida informatsiooni, mida näidata</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong> {0} minuti pärast</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Autoriseerimata</message>
@@ -2033,8 +2042,8 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">süsteemi administraatoriga</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Logi sisse teise kasutajana</message>
-	
-	       <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
         <message key="xmlui.administrative.CurateForm.title">Süsteemihoolduse tegevused</message>
         <message key="xmlui.administrative.CurateForm.trail">Hooldustegevused</message>
         <message key="xmlui.administrative.CurateForm.object_label_name">Objekti handle</message>
@@ -2064,6 +2073,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Failide külastamised</message>
     <message key="xmlui.statistics.Navigation.title">Statistika</message>
     <message key="xmlui.statistics.Navigation.usage.view">Vaata kasutusstatistikat</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Vaata otsistatistikat</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Vaata töövoo statistikat</message>
     <message key="xmlui.statistics.trail">Statistika</message>
@@ -2073,16 +2083,16 @@
     <message key="xmlui.statistics.workflow.error">Töövoo statistika genereerimisel tekkis viga. Palun proovige hiljem uuesti</message>
     <message key="xmlui.statistics.workflow.head">Töövoo statistika</message>
     <message key="xmlui.statistics.workflow.head-dso">Töövoo statistika {0} kohta</message>
-    
-    
+
+
     <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top otsiterminid</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Kokku</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Eelmine kuu</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Eelmised 6 kuud</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Eelmine aasta</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Üleüldse</message>
-    
-    
+
+
     <message key="xmlui.statistics.display.table.column-label.search-terms">Otsiterminid</message>
     <message key="xmlui.statistics.display.table.column-label.searches">Otsingud</message>
     <message key="xmlui.statistics.display.table.column-label.percent-total">% koguarvust</message>
@@ -2111,27 +2121,23 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Kasutaja ülevaated, aktsioon</message>
 
 
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                      Google Analytics Statistics Aspect
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
-   <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistika</message>
-   <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">Vaata Google Analytics</message>
-   <message key="xmlui.statisticsGoogleAnalytics.trail">Statistika</message>
-   <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistika</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistika</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">Vaata Google Analytics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistika</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistika</message>
 
-   <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Algus</message>
-   <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">Lõpp</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Algus</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">Lõpp</message>
     <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Uuenda</message>
 
     <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Lehekülje vaatamisi</message>
     <message key="xmlui.statisticsGoogleAnalytics.downloads.title">Faili allalaadimisi</message>
-
-
-
-
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2147,12 +2153,13 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Lehekülg kasutab Manakin'i, Texas A&amp;M Ülikooli Raamatukogude poolt loodud DSpace'i esiliidest  Liidest saab muuta, kasutades Manakin Aspects ja XSL-il toetuvaid teemasid. 
-			Rohkem infot aadressil
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> ja
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
@@ -2208,7 +2215,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formaat</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Vaata</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Kirjeldus</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Vaata/<wbr/>Ava</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Vaata/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Selle nimetusega ei ole seotud ühtegi faili.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">baidid</message>
@@ -2217,7 +2224,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Selle nimetusega on seotud järgmised litsentsi failid:</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Kui pole teisiti märgitud, kirjeldatakse litsentsi järgnevalt </message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Kui pole teisiti märgitud, kirjeldatakse litsentsi järgnevalt </message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		Kollektsiooni KollektsiooniVaade ei ole saadaval. 
@@ -2243,7 +2250,9 @@
 
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core elemendid</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terminid</message>
-      <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blokeeritud</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blokeeritud</message>
+
 
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Eelvaade</message>
@@ -2355,6 +2364,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Otsingu "@4@" @1@. - @2@. tulemus @3@-st </message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Valitud andmete laadimine ebaõnnestus: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Kirjastaja nimi</message>
@@ -2368,7 +2378,7 @@
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Eesnimi, nt. "Jüri"</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC normkirje</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Kohalik väärtus "@1@" (Puudub normkirje)</message>
-  
+
   <!-- mobile theme -->
   <message key="xmlui.mobile.home_mobile">DSpace mobiilile</message>
   <message key="xmlui.mobile.search_all">Otsi kõikjal</message>
@@ -2441,8 +2451,8 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">See pole objekti viimane versioon. Viimane versioon on:  </message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Märkus</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Selle objekti sobivam versioon on töövoos.</message>
-    
-   <message key="xmlui.aspect.sherpa.submission.consult">Kontrollige autoriõigusi ja isearhiveerimise reegleid:<a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">Kontrollige autoriõigusi ja isearhiveerimise reegleid:<a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
     <message key="xmlui.aspect.sherpa.submission.title">Kirjastaja info</message>
     <message key="xmlui.aspect.sherpa.submission.journal">Ajakiri: </message>
     <message key="xmlui.aspect.sherpa.submission.publisher">Kirjastaja info: </message>
@@ -2452,9 +2462,14 @@
     <message key="xmlui.aspect.sherpa.submission.blue">sinine</message>
     <message key="xmlui.aspect.sherpa.submission.white">valge</message>
     <message key="xmlui.aspect.sherpa.submission.yellow">kollane</message>
-
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
-  <message key="xmlui.mirage2.discovery.reset">Lähtesta</message>
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Lähtesta</message>
     <message key="xmlui.mirage2.discovery.newFilter">Lisa filter</message>
     <message key="xmlui.mirage2.discovery.showAdvancedFilters">Näita filtreid</message>
     <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Peida filtrid</message>
@@ -2478,6 +2493,4 @@
     <message key="xmlui.mirage2.choice-authority-control.loading">Laadimine...</message>
 
     <message key="xmlui.mirage2.item-list.thumbnail">Pisipilt</message>
-  
-  </catalogue>
-  
+</catalogue>

--- a/src/main/webapp/i18n/messages_et.xml
+++ b/src/main/webapp/i18n/messages_et.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="et">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_eu.xml
+++ b/src/main/webapp/i18n/messages_eu.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="eu">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_eu.xml
+++ b/src/main/webapp/i18n/messages_eu.xml
@@ -1,63 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="eu" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
-		The format used by all keys is as follows xmlui.<Aspect>.<Java Class>.<name>
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
 		There are a few exceptions to this naming format,
 		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
 		2) Some general keys which are specific to a particular aspect
-		   may be found at xmlui.<Aspect>without specifying a
-		   particular java class.    		-->
-  <!--messages from V1.5 Translated by Francisco Javier Herrero Vicente (fherrero@uji.es) at Universitat Jaume I de Castellon (http://www.uji.es/)-->   
-    <!--minor modifications to V1.5 and V1.6 and V1.7 by Alvaro López (alopez@arvo.es) at Arvo Consultores (http://www.arvo.es/)   -->
-    <!--  V1.8 messages   by Emilio Lorenzo (elorenzo@arvo.es) at Arvo Consultores (http://www.arvo.es/dspace) -->
-    <!--  V3.0 messages  by Emilio Lorenzo (elorenzo@arvo.es) at Arvo Consultores (http://www.arvo.es/dspace) -->
-<!-- Filas perdidas-->
-<message key="xmlui.Discovery.SimpleSearch.filter.contains">Dauka</message>
-<message key="xmlui.Discovery.SimpleSearch.filter.equals">Berdin</message>
-<message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-<message key="xmlui.Discovery.SimpleSearch.filter.notcontains">Ez Dauka</message>
-<message key="xmlui.Discovery.SimpleSearch.filter.notequals">Ezberdin</message>
-<message key="xmlui.Discovery.SimpleSearch.filter.notauthority">Ez ID</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Egilea</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Izenburua</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Gaia</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Argitalpen-data</message>
-<message key="xmlui.Discovery.SimpleSearch.filter_head">Iragazkiak</message>                                                                                    
-<message key="xmlui.Discovery.SimpleSearch.filter_help">Muga ezazu bilaketa iragazkiak erabiliz</message>
-<message key="xmlui.Discovery.AbstractSearch.head1_none">{0} emaitza {1} tik. <span class="searchTime">({2} seg)</span></message>
-<message key="xmlui.Discovery.AbstractSearch.filters.display">Erabili iragazkiak</message>  
-<message key="xmlui.Discovery.SimpleSearch.did_you_mean">Esan nahi duzu:</message>  
-<message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Joan</message>
-<message key="xmlui.Discovery.SimpleSearch.search_scope">Bilatu</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Zure bilaketarekin bat datozen erregistroak</message>
-<message key="xmlui.Discovery.AbstractSearch.head2">Komunitateak edo Bildumak</message>
-
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
 
 	<!-- General keys -->
-<message key="xmlui.general.dspace_home">EIMA Gordailua</message>
-<message key="xmlui.general.search">Bilaketak</message>
-<message key="xmlui.general.go">Joan</message>
-<message key="xmlui.general.go_home">Hasierako orrialdear joan DSpace</message>
-<message key="xmlui.general.save">Gorde</message>
-<message key="xmlui.general.cancel">Utzi</message>
-<message key="xmlui.general.return">Itzuli</message>
-<message key="xmlui.general.update">Aldatu</message>
-<message key="xmlui.general.delete">Ezabatu</message>
-<message key="xmlui.general.next">Hurrengoa</message>
-<message key="xmlui.general.untitled">Izenbururik gabe</message>
-<message key="xmlui.general.perform">Burutu</message>
-<message key="xmlui.general.queue">Encolar</message>
+	<message key="xmlui.general.dspace_home">EIMA Gordailua</message>
+	<message key="xmlui.general.search">Bilaketak</message>
+	<message key="xmlui.general.go">Joan</message>
+	<message key="xmlui.general.go_home">Hasierako orrialdear joan DSpace</message>
+	<message key="xmlui.general.save">Gorde</message>
+	<message key="xmlui.general.cancel">Utzi</message>
+	<message key="xmlui.general.return">Itzuli</message>
+	<message key="xmlui.general.update">Aldatu</message>
+	<message key="xmlui.general.delete">Ezabatu</message>
+	<message key="xmlui.general.next">Hurrengoa</message>
+	<message key="xmlui.general.untitled">Izenbururik gabe</message>
+        <message key="xmlui.general.perform">Burutu</message>
+        <message key="xmlui.general.queue">Encolar</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
 		Page not found keys
@@ -65,31 +39,31 @@
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
-<message key="xmlui.PageNotFound.title">Ez da orria aurkitu</message>
-<message key="xmlui.PageNotFound.head">Ez da orria aurkitu</message>
-<message key="xmlui.PageNotFound.para1">Bilatzen ari zaren orria ez da zerbitzarian aurkitu</message>
+	<message key="xmlui.PageNotFound.title">Ez da orria aurkitu</message>
+	<message key="xmlui.PageNotFound.head">Ez da orria aurkitu</message>
+	<message key="xmlui.PageNotFound.para1">Bilatzen ari zaren orria ez da zerbitzarian aurkitu</message>
 
 
 	<!--
 	   The "utils" non-aspect
        -->
-<message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Solo los administradores pueden acceder como otro usuario Administratzaileek baino ez dute beste erabiltzaile gisa sartzeko aukera.</message>
-<message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Administratzaileak diren baimendutako erabiltzaileek baino ezin dute beste erabiltzaile gisa sartzeko aukera.</message>
-<message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">No puede realizar el acceso como otro administrador Ezin da sartu beste administratzaile baten kontua erabiliz.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Solo los administradores pueden acceder como otro usuario Administratzaileek baino ez dute beste erabiltzaile gisa sartzeko aukera.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Administratzaileak diren baimendutako erabiltzaileek baino ezin dute beste erabiltzaile gisa sartzeko aukera.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">No puede realizar el acceso como otro administrador Ezin da sartu beste administratzaile baten kontua erabiliz.</message>
 
 
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
 	-->
-<message key="xmlui.feed.general_description">El repositorio digital DSpace captura, almacena, indexa, preserva y distribuye materiales de investigación en formato digital Dspace errepositorio digitalak jaso, gorde, indexatu, preserbatu eta banatzen ditu materialak formatu digitalean.</message>
-<message key="xmlui.feed.header">RSS Feeds</message>
-<message key="xmlui.feed.logo_title">Irudia</message>
-<message key="xmlui.feed.untitled">Izenbururik gabe</message>
+	<message key="xmlui.feed.general_description">El repositorio digital DSpace captura, almacena, indexa, preserva y distribuye materiales de investigación en formato digital Dspace errepositorio digitalak jaso, gorde, indexatu, preserbatu eta banatzen ditu materialak formatu digitalean.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
+	<message key="xmlui.feed.logo_title">Irudia</message>
+	<message key="xmlui.feed.untitled">Izenbururik gabe</message>
 
 	<!--
 		Default notice header
 	 	-->
-<message key="xmlui.general.notice.default_head">Aviso</message>
+	<message key="xmlui.general.notice.default_head">Aviso</message>
 
 
 
@@ -106,238 +80,355 @@
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Komunitate honetan egindako bilaketaren emaitzak: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Bilduma honetan egindako bilaketaren emaitzak: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Bilaketaren emaitzak</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Zure eskaerak "{0}" itzuli d(it)u {1} emaitza(k)</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Eskaerarekin bat datozen komunitate edo bildumak</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Eskaerarekin bat datozen itemak</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Bilaketak ez du emaitzarik izan</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Gordailu osoa</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Komunitate honetan egindako bilaketaren emaitzak: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Bilduma honetan egindako bilaketaren emaitzak: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Bilaketaren emaitzak</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Zure eskaerak "{0}" itzuli d(it)u {1} emaitza(k)</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Eskaerarekin bat datozen komunitate edo bildumak</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Eskaerarekin bat datozen itemak</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Bilaketak ez du emaitzarik izan</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Gordailu osoa</message>
 
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">izenburua</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">argitalpen data</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">bidalketa data</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">egokitasuna</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Itemak antolatu honen arabera:</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order">ordenean</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">gorako</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">beherako</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Emaitzak/orrialdea</message>
-
-  
-<!-- Site Leve Recently Added Content -->                                                                                                                                                   
-<message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Erantsitako azken lanak</message> 
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">izenburua</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">argitalpen data</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">bidalketa data</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">egokitasuna</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Itemak antolatu honen arabera:</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">ordenean</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">gorako</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">beherako</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Emaitzak/orrialdea</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Bilaketa aurreratua</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Bilaketa aurreratua</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Bilaketa aurreratua</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Bilaketaren eremua</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Mugatu bilaketa komunitate edo bilduma batean.</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunción</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Bilaketa mota</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Bilatu honako honen arabera:</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Egilea</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Izenburua</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Laburpena</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Seriea</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Babeslea</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identifikatzailea</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Hizkuntza (ISO)</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Hitz gakoa</message>
-
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Bilaketa aurreratua</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Bilaketa aurreratua</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Bilaketa aurreratua</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Bilaketaren eremua</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Mugatu bilaketa komunitate edo bilduma batean.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunción</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Bilaketa mota</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Bilatu honako honen arabera:</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Egilea</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Izenburua</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Laburpena</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Seriea</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Babeslea</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identifikatzailea</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Hizkuntza (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Hitz gakoa</message>
 
    <!--  some common other possibilities for Advanced Search Fields -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Laguntzailea/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Sortzailea/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Deskribap</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Erlazioa</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Beste laguntzaile bat</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Aholkularia/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Saila</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Laguntzailea/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Sortzailea/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Deskribap</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Erlazioa</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Beste laguntzaile bat</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Aholkularia/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Saila</message>
 
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Testu osoa</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">Y</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">O</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NO</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Testu osoa</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">Y</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">O</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NO</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Edo hasierako hitzak sartu:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Hitz hauekin hasten diren itemak bistaratu</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Joan aurkibideko puntu batera:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Aukeratu hilabetea)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Aukeratu urtea)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Edo sartu urtea:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Urte zehatz bateko itemak bistaratu.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sentitzen dugu, bilaketa honek ez du emaitzarik izan.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Honela ordenatu:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Ordena:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Emaitzak orrialdeko:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Egileak/Item:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Edo hasierako hitzak sartu:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Hitz hauekin hasten diren itemak bistaratu</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Joan aurkibideko puntu batera:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Aukeratu hilabetea)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Aukeratu urtea)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Edo sartu urtea:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Urte zehatz bateko itemak bistaratu.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sentitzen dugu, bilaketa honek ez du emaitzarik izan.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Honela ordenatu:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Ordena:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Emaitzak orrialdeko:</message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Egileak/Item:</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Guztiak</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Guztiak</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">izenburua</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">argitaratze data</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">bidalketadata</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">izenburua</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">argitaratze data</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">bidalketadata</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">beherako</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">gorako</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">beherako</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">gorako</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Egileen izena</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Egileen izena</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Zerendatu {0} honen arabera: egilea{1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Zerrendatu {0} honako honen arabera: egilea</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Zerendatu {0} honen arabera: egilea{1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Zerrendatu {0} honako honen arabera: egilea</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Zerrendatu {0} honen arabera: gaia{1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Zerrendatu {0} honen arabera: gaia</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Zerrendatu {0} honen arabera: gaia{1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Zerrendatu {0} honen arabera: gaia</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Zerrendatu {0} honen arabera: izenburua{1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Zerrendatu {0} honen arabera: izenburua</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Zerrendatu {0} honen arabera: izenburua{1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Zerrendatu {0} honen arabera: izenburua</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Zerrendatu {0} honen arabera: argitalpen data{1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Zerrendatu {0} honen arabera: argitalpen data</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Zerrendatu {0} honen arabera: argitalpen data{1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Zerrendatu {0} honen arabera: argitalpen data</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Zerrendatu {0} honen arabera: bidalketa data{1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Zerrendatu {0} honen arabera: bidalketa data</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Zerrendatu {0} honen arabera: bidalketa data{1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Zerrendatu {0} honen arabera: bidalketa data</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Bilaketaren eremua</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Gordailu osoa</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Bilduma honen bilaketa:</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Zerrendatu honako honen arabera:</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Izenburuak</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Egileak</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datak</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Bilaketa aurreratua</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Eransitako azken lanak</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Bilaketaren eremua</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Gordailu osoa</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Bilduma honen bilaketa:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Zerrendatu honako honen arabera:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Izenburuak</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Egileak</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datak</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Bilaketa aurreratua</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Eransitako azken lanak</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Komunitateen zerrenda</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Komunitateen zerrenda</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Komunitateak</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Aukeratu komunitate bat zure bildumak bistaratzeko</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Komunitateen zerrenda</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Komunitateen zerrenda</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Komunitateak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Aukeratu komunitate bat zure bildumak bistaratzeko</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Bilaketaren eremua</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Gordailu osoa</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Bilatu komunitate honetan eta bere bildumetan:</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Zerrendatu honako honen arabera</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Izenburuak</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Egileak</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Datak</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Bilaketa aurreratua</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Komunitate honetako azpikomunitateak</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Komunitate honetako bildumak</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Erantsitako azken lanak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Bilaketaren eremua</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Gordailu osoa</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Bilatu komunitate honetan eta bere bildumetan:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Zerrendatu honako honen arabera</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Izenburuak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Egileak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Datak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Bilaketa aurreratua</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Komunitate honetako azpikomunitateak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Komunitate honetako bildumak</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Erantsitako azken lanak</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-<message key="xmlui.ArtifactBrowser.Contact.title">Harremanetarako</message>
-<message key="xmlui.ArtifactBrowser.Contact.trail">Harremanetarako</message>
-<message key="xmlui.ArtifactBrowser.Contact.head">Harremanetarako</message>
-<message key="xmlui.ArtifactBrowser.Contact.para1">EIMA Gordailuaren administratzailearekin kontaktatzeko:</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formularioa sarean</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.Contact.email">Posta elektronikoa</message>
+	<message key="xmlui.ArtifactBrowser.Contact.title">Harremanetarako</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Harremanetarako</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Harremanetarako</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">EIMA Gordailuaren administratzailearekin kontaktatzeko:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formularioa sarean</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Posta elektronikoa</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Eskerrik asko EIMA Gordailuari buruzko iradokizunak egiteagatik. Zure iradokizunak kontuan hartuko ditugu!</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Zure posta elektronikoa</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Helbide hau erabiliko dugu zure iradokizunaren jarraipena egiteko.</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Iruzkinak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Eskerrik asko EIMA Gordailuari buruzko iradokizunak egiteagatik. Zure iradokizunak kontuan hartuko ditugu!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Zure posta elektronikoa</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Helbide hau erabiliko dugu zure iradokizunaren jarraipena egiteko.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Iruzkinak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Iradokizunak</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Iradokizunak</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Iradokizuna bidali da</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Jaso dugu zure iruzkina</message>
-
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Bilatu Dspcen</message>
-<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Idatzi testua Dspacen bilatzeko</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Iradokizunak</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Iradokizuna bidali da</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Jaso dugu zure iruzkina</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Itemaren erregistro erraza erakusten du</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Item hau honako bilduma honetan/hauetan agertzen da</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Itemaren erregistro erraza erakusten du</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Itemaren Dublin Core erregistro osoa erakusten du</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Itemaren erregistro erraza erakusten du</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Item hau honako bilduma honetan/hauetan agertzen da</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Itemaren erregistro erraza erakusten du</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Itemaren Dublin Core erregistro osoa erakusten du</message>
 
-<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Item hau ez dago eskuragarri, erretiratua izan da</message>
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Item hau ez dago eskuragarri, erretiratua izan da</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Zerrendatu honako honen arabera</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Gordailu osoa</message>
-<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Komunitateak &amp; bildumak</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Izenburuak</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Egileak</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materiak</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Argitalpen dataren arabera</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Bidalketa dataren arabera</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Bilduma hau</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Komunitate hau</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Zerrendatu honako honen arabera</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Gordailu osoa</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Komunitateak &amp; bildumak</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Izenburuak</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Egileak</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materiak</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Argitalpen dataren arabera</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Bidalketa dataren arabera</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Bilduma hau</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Komunitate hau</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Bilatu</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Bilatu</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Bilatu</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Bilaketaren eremua</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Testu osoko bilaketa</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Bilatu</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Bilatu</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Bilatu</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Bilaketaren eremua</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Testu osoko bilaketa</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Sarrera mugatuko baliabidea</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Mugatua</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Sarrera mugatuko baliabidea</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Sarrera mugatuko komunitatea</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Sarrera mugatuko bilduma</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Sarrera mugatuko itema</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Sarrera mugatuko fitxategia</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Sarrera mugatuko baliabidea. Ez daukazu sartzeko baimenik.</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Sarrera mugatuko komunitatea. Ez daukazu sartzeko baimenik</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Sarrera mugatuko bilduma. Ez daukazu sartzeko baimenik</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Sarrera mugatuko itema. Ez daukazu sartzeko baimenik</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Sarrera mugatuko fitxategia. Ez daukazu sartzeko baimenik</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">bilduma</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">komunitatea</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">fitxategia</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">itema</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">baliabidea</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">ezezaguna</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continue en la pantalla de acceso Sarbide-pantailan jarraitu</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Sarrera mugatuko baliabidea</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Mugatua</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Sarrera mugatuko baliabidea</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Sarrera mugatuko komunitatea</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Sarrera mugatuko bilduma</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Sarrera mugatuko itema</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Sarrera mugatuko fitxategia</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Sarrera mugatuko baliabidea. Ez daukazu sartzeko baimenik.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Sarrera mugatuko komunitatea. Ez daukazu sartzeko baimenik<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Sarrera mugatuko bilduma. Ez daukazu sartzeko baimenik<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Sarrera mugatuko itema. Ez daukazu sartzeko baimenik<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Sarrera mugatuko fitxategia. Ez daukazu sartzeko baimenik<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">bilduma</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">komunitatea</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">fitxategia</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">itema</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">baliabidea</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">ezezaguna</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continue en la pantalla de acceso Sarbide-pantailan jarraitu</message>
 
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem ha sido retirado Item hau kendu egin da</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">El ítem seleccionado ha sido retirado y no está disponible Aukeratu duzun itema erretiratua izan da eta ez dago eskuragarri</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">El ítem seleccionado es de acceso restringido  y requiere de credenciales para su visualización Aukeratu duzun itema sarrera mugatukoa da eta baimenak behar dira ikusi ahal izateko.</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Erabiltzaile honek ez du baimenik itema ikusteko. Informazio gehiago jasotzeko, administratzailearekin kontaktatu, mesedez</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem ha sido retirado Item hau kendu egin da</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">El ítem seleccionado ha sido retirado y no está disponible Aukeratu duzun itema erretiratua izan da eta ez dago eskuragarri</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">El ítem seleccionado es de acceso restringido  y requiere de credenciales para su visualización Aukeratu duzun itema sarrera mugatukoa da eta baimenak behar dira ikusi ahal izateko.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Erabiltzaile honek ez du baimenik itema ikusteko. Informazio gehiago jasotzeko, administratzailearekin kontaktatu, mesedez</message>
         
 	<!-- Authentication messages used at the top of the login page:  -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Sarrera mugatuko itema</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">El ítem al que intenta acceder es un ítem restringido y requiere credenciales para verse   Aukeratu duzun itemak sarrera mugatukoa da eta baimenak behar dira ikusi ahal izateko . Mesedez, itema ikusteko, sartu zure erabiltzaile-datuak</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Sarrera mugatuko itema</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">El ítem al que intenta acceder es un ítem restringido y requiere credenciales para verse   Aukeratu duzun itemak sarrera mugatukoa da eta baimenak behar dira ikusi ahal izateko . Mesedez, itema ikusteko, sartu zure erabiltzaile-datuak</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Hileko txostenak</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Estatistika-laburpena</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Hileko txostenak</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Estatistika-laburpena</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Une honetan ez dago txostenik</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Une honetan ez dago txostenik zerbitzu honetarako. Geroago egiaztatu eskuragarritasuna.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Une honetan ez dago txostenik</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Une honetan ez dago txostenik zerbitzu honetarako. Geroago egiaztatu eskuragarritasuna.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-<message key="xmlui.BitstreamReader.auth_header">Artxibo hau sarrera mugatukoa da.</message>
-<message key="xmlui.BitstreamReader.auth_message">Eskuratu nahi duzun fitxategia sarbide mugatukoa da eta baimenak behar dira. Mesedez, fitxategi hau eskuratzeko sartu zure erabiltzaile-datuak.</message>
+	<message key="xmlui.BitstreamReader.auth_header">Artxibo hau sarrera mugatukoa da.</message>
+	<message key="xmlui.BitstreamReader.auth_message">Eskuratu nahi duzun fitxategia sarbide mugatukoa da eta baimenak behar dira. Mesedez, fitxategi hau eskuratzeko sartu zure erabiltzaile-datuak.</message>
 
 	<!-- Export Archive download messages -->
-<message key="xmlui.ItemExportDownloadReader.auth_header">Fitxategi hau sarrera mugatukoa da.</message>
-<message key="xmlui.ItemExportDownloadReader.auth_message">Fitxategi hau sarrera mugatukoa da. Eskuratu nahi duzun fitxategia sarrera mugatukoa ds eta baimenak behar dira. Mesedez, artxibo hau eskuratzeko, sartu zure erabiltzaile-datuak.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Fitxategi hau sarrera mugatukoa da.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">Fitxategi hau sarrera mugatukoa da. Eskuratu nahi duzun fitxategia sarrera mugatukoa ds eta baimenak behar dira. Mesedez, artxibo hau eskuratzeko, sartu zure erabiltzaile-datuak.</message>
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		                EPerson Aspect
@@ -351,168 +442,168 @@
 
 
 	<!-- General keys used by the EPerson aspect -->
-<message key="xmlui.EPerson.trail_new_registration">Erabiltzaile-erregistro berria</message>
-<message key="xmlui.EPerson.trail_forgot_password">Pasahitza ahaztu al duzu?</message>
+	<message key="xmlui.EPerson.trail_new_registration">Erabiltzaile-erregistro berria</message>
+	<message key="xmlui.EPerson.trail_forgot_password">Pasahitza ahaztu al duzu?</message>
 
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-<message key="xmlui.EPerson.CannotRegister.title">Erregistro hau ez dago eskuragarri</message>
-<message key="xmlui.EPerson.CannotRegister.head">Erregistro hau ez dago eskuragarri</message>
-<message key="xmlui.EPerson.CannotRegister.para1">Dspaceko biltegi honen ezarpenek ez dute baimentzen erregistro hau testuinguru honetan. Mesedez, harremanetan jarri<a href="../contact">administratzailearekin</a>.</message>
+	<message key="xmlui.EPerson.CannotRegister.title">Erregistro hau ez dago eskuragarri</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Erregistro hau ez dago eskuragarri</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Dspaceko biltegi honen ezarpenek ez dute baimentzen erregistro hau testuinguru honetan. Mesedez, harremanetan jarri<a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-<message key="xmlui.EPerson.EditProfile.title_update">Aldatu profila aldatu</message>
-<message key="xmlui.EPerson.EditProfile.title_create">Sortu profila</message>
-<message key="xmlui.EPerson.EditProfile.trail_update">Aldatu profila</message>
-<message key="xmlui.EPerson.EditProfile.head_update">Aldatu profila</message>
-<message key="xmlui.EPerson.EditProfile.head_create">Sortu profila</message>
-<message key="xmlui.EPerson.EditProfile.email_address">Posta elektronikoko helbidea</message>
-<message key="xmlui.EPerson.EditProfile.first_name">Izena</message>
-<message key="xmlui.EPerson.EditProfile.last_name">Abizena</message>
-<message key="xmlui.EPerson.EditProfile.telephone">Telefonoa</message>
-<message key="xmlui.EPerson.EditProfile.Language">Hizkuntza</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions">Harpidetzak</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions_help">Egin dezakezu harpidetza nahi duzun bilduma guztietan. Horrela, harpidetutako bildumetan eransten diren itemei buruzko informazioa jasoko duzu postaz. Beste aukera bat RSS zerbitzua erabiltzea da.</message>
-<message key="xmlui.EPerson.EditProfile.email_subscriptions">Posta elektronikoaren bidezko harpidetza</message>
-<message key="xmlui.EPerson.EditProfile.select_collection">(Bilduma aukeratu)</message>
-<message key="xmlui.EPerson.EditProfile.update_password_instructions">Nahi izanez gero, pasahitz berria aukera dezakezu, beheko laukitxoan tekleatuta eta bigarren laukitxoan baieztatuta. Pasahitzak, gutxienez sei karaktere eduki beharko luke.</message>
-<message key="xmlui.EPerson.EditProfile.create_password_instructions">Sartu pasahitza lehenengo laukian, mesedez, eta berretsi bigarren laukian. Gutxienez, sei karaktere izan behar ditu.</message>
-<message key="xmlui.EPerson.EditProfile.password">Pasahitza</message>
-<message key="xmlui.EPerson.EditProfile.confirm_password">Berresteko, errepikatu.</message>
-<message key="xmlui.EPerson.EditProfile.submit_update">Amaitu erregistro-prozesua</message>
-<message key="xmlui.EPerson.EditProfile.submit_create">Aldatu profila</message>
-<message key="xmlui.EPerson.EditProfile.error_required">Eremu hau nahitaezkoa da</message>
-<message key="xmlui.EPerson.EditProfile.error_invalid_password">Aukeratu pasahitza. Gutxienez, 6 karaktere.</message>
-<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Mesedez, berresteko, errepikatu pasahitza</message>
-<message key="xmlui.EPerson.EditProfile.head_auth">Baimen-talde hauetako kidea zara:</message>
-<message key="xmlui.EPerson.EditProfile.head_identify">Identifikatu</message>
-<message key="xmlui.EPerson.EditProfile.head_security">Segurtasuna</message>
+	<message key="xmlui.EPerson.EditProfile.title_update">Aldatu profila aldatu</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Sortu profila</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Aldatu profila</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Aldatu profila</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Sortu profila</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Posta elektronikoko helbidea</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Izena</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Abizena</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Telefonoa</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Hizkuntza</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Harpidetzak</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Egin dezakezu harpidetza nahi duzun bilduma guztietan. Horrela, harpidetutako bildumetan eransten diren itemei buruzko informazioa jasoko duzu postaz. Beste aukera bat RSS zerbitzua erabiltzea da.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Posta elektronikoaren bidezko harpidetza</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">(Bilduma aukeratu)</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Nahi izanez gero, pasahitz berria aukera dezakezu, beheko laukitxoan tekleatuta eta bigarren laukitxoan baieztatuta. Pasahitzak, gutxienez sei karaktere eduki beharko luke.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Sartu pasahitza lehenengo laukian, mesedez, eta berretsi bigarren laukian. Gutxienez, sei karaktere izan behar ditu.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Pasahitza</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Berresteko, errepikatu.</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Amaitu erregistro-prozesua</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Aldatu profila</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Eremu hau nahitaezkoa da</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Aukeratu pasahitza. Gutxienez, 6 karaktere.</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Mesedez, berresteko, errepikatu pasahitza</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Baimen-talde hauetako kidea zara:</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identifikatu</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Segurtasuna</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Baieztatu posta elektronikoa</message>
-<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Sortu profila</message>
-<message key="xmlui.EPerson.EPersonUtils.register_finished">Amaituta</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Baieztatu posta elektronikoa</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Berrezarri pasahitza</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Amaituta</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Baieztatu posta elektronikoa</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Sortu profila</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Amaituta</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Baieztatu posta elektronikoa</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Berrezarri pasahitza</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Amaituta</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-<message key="xmlui.EPerson.ForgotPasswordFinished.title">Berrezarri pasahitza</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.head">Berrezarri pasahitza</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Zure pasahitza berrezarria izan da</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Berrezarri pasahitza</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Berrezarri pasahitza</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Zure pasahitza berrezarria izan da</message>
 
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-<message key="xmlui.EPerson.InvalidToken.title">Karaktere-kate hau ez da baliozkoa</message>
-<message key="xmlui.EPerson.InvalidToken.trail">Karaktere-kate hau ez da baliozkoa</message>
-<message key="xmlui.EPerson.InvalidToken.head">Karaktere-kate hau ez da baliozkoa</message>
-<message key="xmlui.EPerson.InvalidToken.para1">URL hori ez da baliozkoa. Agian zure postak URLa hainbat lerrotan zatikatu du,  hala nola:</message>
-<message key="xmlui.EPerson.InvalidToken.para2">Kasua hau bada, loturan klik egin beharrean, URL osoa kopiatu eta itsatsi beharko duzu zuzenean zure nabigatzailearen helbide-barran. Helbide-barrak halako zerbait izan beharko du:</message>
+	<message key="xmlui.EPerson.InvalidToken.title">Karaktere-kate hau ez da baliozkoa</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Karaktere-kate hau ez da baliozkoa</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Karaktere-kate hau ez da baliozkoa</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">URL hori ez da baliozkoa. Agian zure postak URLa hainbat lerrotan zatikatu du,  hala nola:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Kasua hau bada, loturan klik egin beharrean, URL osoa kopiatu eta itsatsi beharko duzu zuzenean zure nabigatzailearen helbide-barran. Helbide-barrak halako zerbait izan beharko du:</message>
 
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-<message key="xmlui.EPerson.Navigation.my_account">Nire kontua</message>
-<message key="xmlui.EPerson.Navigation.profile">Profila</message>
-<message key="xmlui.EPerson.Navigation.logout">Irten</message>
-<message key="xmlui.EPerson.Navigation.login">Sartu</message>
-<message key="xmlui.EPerson.Navigation.register">Erregistratu</message>
+	<message key="xmlui.EPerson.Navigation.my_account">Nire kontua</message>
+	<message key="xmlui.EPerson.Navigation.profile">Profila</message>
+	<message key="xmlui.EPerson.Navigation.logout">Irten</message>
+	<message key="xmlui.EPerson.Navigation.login">Sartu</message>
+	<message key="xmlui.EPerson.Navigation.register">Erregistratu</message>
 
 	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-<message key="xmlui.EPerson.PasswordLogin.title">Sartu</message>
-<message key="xmlui.EPerson.PasswordLogin.trail">Sartu</message>
-<message key="xmlui.EPerson.PasswordLogin.head1">Sartu Gordailuan</message>
-<message key="xmlui.EPerson.PasswordLogin.email_address">Posta elektronikoa</message>
-<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Sartutako posta elektronikoko helbidea eta/edo pasahitza ez dira zuzenak.</message>
-<message key="xmlui.EPerson.PasswordLogin.password">Pasahitza</message>
-<message key="xmlui.EPerson.PasswordLogin.forgot_link">Pasahitza ahaztu al duzu?</message>
-<message key="xmlui.EPerson.PasswordLogin.submit">Sartu</message>
-<message key="xmlui.EPerson.PasswordLogin.head2">Erabiltzaile berria al zara?</message>
-<message key="xmlui.EPerson.PasswordLogin.para1">Sortu kontu bat</message>
-<message key="xmlui.EPerson.PasswordLogin.register_link">Egin klik erregistratzeko.</message>
+	<message key="xmlui.EPerson.PasswordLogin.title">Sartu</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Sartu</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Sartu Gordailuan</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Posta elektronikoa</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Sartutako posta elektronikoko helbidea eta/edo pasahitza ez dira zuzenak.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Pasahitza</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">Pasahitza ahaztu al duzu?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Sartu</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Erabiltzaile berria al zara?</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Sortu kontu bat</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Egin klik erregistratzeko.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-<message key="xmlui.EPerson.LDAPLogin.title">Sartu</message>
-<message key="xmlui.EPerson.LDAPLogin.trail">Sartu</message>
-<message key="xmlui.EPerson.LDAPLogin.head1">Sartu Gordailuan</message>
-<message key="xmlui.EPerson.LDAPLogin.username">Erabiltzailearen izena</message>
-<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Erabiltzailearen izena edo pasahitza ez dira zuzenak</message>
-<message key="xmlui.EPerson.LDAPLogin.password">Pasahitza</message>
-<message key="xmlui.EPerson.LDAPLogin.submit">Sartu</message>
+	<message key="xmlui.EPerson.LDAPLogin.title">Sartu</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Sartu</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Sartu Gordailuan</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Erabiltzailearen izena</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Erabiltzailearen izena edo pasahitza ez dira zuzenak</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Pasahitza</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Sartu</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-<message key="xmlui.EPerson.LoginChooser.title">Sarbide-metodo bat aukeratu</message>
-<message key="xmlui.EPerson.LoginChooser.trail">Erabiltzailearen izena aukeratu</message>
-<message key="xmlui.EPerson.LoginChooser.head1">Sarbide-metodo bat aukeratu</message>
-<message key="xmlui.EPerson.LoginChooser.para1">Sarbide-metodoa:</message>
-<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth-en bidezko baimentzea Shibboleth</message>
-<message key="org.dspace.eperson.LDAPAuthentication.title">LDAP-aren bidezko baimentzea</message>
-<message key="org.dspace.eperson.PasswordAuthentication.title">Pasahitzaren bidezko baimentzea</message>
-<message key="org.dspace.eperson.X509Authentication.title">Web-ziurtagiriaren bidezko baimentzea</message>
+	<message key="xmlui.EPerson.LoginChooser.title">Sarbide-metodo bat aukeratu</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Erabiltzailearen izena aukeratu</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Sarbide-metodo bat aukeratu</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Sarbide-metodoa:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth-en bidezko baimentzea Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">LDAP-aren bidezko baimentzea</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Pasahitzaren bidezko baimentzea</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Web-ziurtagiriaren bidezko baimentzea</message>
 
 	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Emandako egiaztagiriak baliogabeak dira.</message>
-<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Jasotako argumentuak baliogabeak direla eta, baimentzea ez da burutu.</message>
-<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Ez da aurkitu zehaztutako baimenak dituen erabiltzailerik.</message>
-<message key="xmlui.EPerson.FailedAuthentication.title">Baimentzeak huts egin du</message>
-<message key="xmlui.EPerson.FailedAuthentication.trail">Baimentzeak huts egin du</message>
-<message key="xmlui.EPerson.FailedAuthentication.h1">Baimentzeak huts egin du</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Emandako egiaztagiriak baliogabeak dira.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Jasotako argumentuak baliogabeak direla eta, baimentzea ez da burutu.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Ez da aurkitu zehaztutako baimenak dituen erabiltzailerik.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Baimentzeak huts egin du</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Baimentzeak huts egin du</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Baimentzeak huts egin du</message>
 
 	<!-- Login xml files -->
-<message key="xmlui.eperson.noAuthMethod.head">Ez da aurkitu baimentze-metodorik</message>
-<message key="xmlui.eperson.noAuthMethod.p1">Ez da aurkitu baimentze-metodorik.</message>
-<message key="xmlui.eperson.shibbLoginFailure.head">Shibboleth-en bidezko baimentzeak huts egin du.</message>
-<message key="xmlui.eperson.shibbLoginFailure.p1">Shibboleth-en bidezko baimentzea ez dago eskuragarri une honetan. Mesedez jarri harremanetan administratzailearekin.</message>
+	<message key="xmlui.eperson.noAuthMethod.head">Ez da aurkitu baimentze-metodorik</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">Ez da aurkitu baimentze-metodorik.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">Shibboleth-en bidezko baimentzeak huts egin du.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">Shibboleth-en bidezko baimentzea ez dago eskuragarri une honetan. Mesedez jarri harremanetan administratzailearekin.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-<message key="xmlui.EPerson.ProfileUpdated.title">Profila aldatu egin da</message>
-<message key="xmlui.EPerson.ProfileUpdated.trail">Aldatu profila</message>
-<message key="xmlui.EPerson.ProfileUpdated.head">Profila aldatu egin da</message>
-<message key="xmlui.EPerson.ProfileUpdated.para1">Zure profilaren informazioa aldatua izan da.</message>
+	<message key="xmlui.EPerson.ProfileUpdated.title">Profila aldatu egin da</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Aldatu profila</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Profila aldatu egin da</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">Zure profilaren informazioa aldatua izan da.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-<message key="xmlui.EPerson.RegistrationFinished.title">Erregistroa burutu da</message>
-<message key="xmlui.EPerson.RegistrationFinished.head">Erregistroa burutu da</message>
-<message key="xmlui.EPerson.RegistrationFinished.para1">Orain Dspacen erregistratuta zaude. Bildumetan harpidetza egin dezakezu, itemen aldaketen edo eskuratzeen inguruko informazioa posta elektronikoaren bidez jasotzeko.</message>
+	<message key="xmlui.EPerson.RegistrationFinished.title">Erregistroa burutu da</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Erregistroa burutu da</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Orain Dspacen erregistratuta zaude. Bildumetan harpidetza egin dezakezu, itemen aldaketen edo eskuratzeen inguruko informazioa posta elektronikoaren bidez jasotzeko.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-<message key="xmlui.EPerson.ResetPassword.title">Pasahitza berrezarri</message>
-<message key="xmlui.EPerson.ResetPassword.head">Pasahitza berrezarri</message>
-<message key="xmlui.EPerson.ResetPassword.para1">Sartu pasahitz berri bat lehenengo laukian, mesedez, eta berretsi bigarren laukian. Gutxienez, sei karaktere izan behar ditu.</message>
-<message key="xmlui.EPerson.ResetPassword.email_address">Posta elektronikoko helbidea</message>
-<message key="xmlui.EPerson.ResetPassword.new_password">Pasahitz berria</message>
-<message key="xmlui.EPerson.ResetPassword.confirm_password">Berresteko, errepikatu</message>
-<message key="xmlui.EPerson.ResetPassword.submit">Pasahitza berrezarri</message>
-<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Aukeratu ,gutxienez, 6 karaktere duen pasahitza</message>
-<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Mesedez, berresteko, errepikatu pasahitza</message>
+	<message key="xmlui.EPerson.ResetPassword.title">Pasahitza berrezarri</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Pasahitza berrezarri</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Sartu pasahitz berri bat lehenengo laukian, mesedez, eta berretsi bigarren laukian. Gutxienez, sei karaktere izan behar ditu.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Posta elektronikoko helbidea</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Pasahitz berria</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Berresteko, errepikatu</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Pasahitza berrezarri</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Aukeratu ,gutxienez, 6 karaktere duen pasahitza</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Mesedez, berresteko, errepikatu pasahitza</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-<message key="xmlui.EPerson.StartForgotPassword.title">Pasahitza ahaztu al duzu?</message>
-<message key="xmlui.EPerson.StartForgotPassword.head">Pasahitza ahaztu al duzu?</message>
-<message key="xmlui.EPerson.StartForgotPassword.para1">Sartu Gordailuan erregistratzeko erabili zenuen posta elektronikoko helbidea. Bertara bidaliko  zaizkizu pasahitza berreskuratzeko behar diren argibideak.</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address">Posta elektronikoko helbidea</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Sartu erregistroa egin zenuenean erabili zenuen helbide bera.</message>
-<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Posta elektronikoko helbidea ez da aurkitu.</message>
-<message key="xmlui.EPerson.StartForgotPassword.submit">Bidali informazioa</message>
+	<message key="xmlui.EPerson.StartForgotPassword.title">Pasahitza ahaztu al duzu?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Pasahitza ahaztu al duzu?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Sartu Gordailuan erregistratzeko erabili zenuen posta elektronikoko helbidea. Bertara bidaliko  zaizkizu pasahitza berreskuratzeko behar diren argibideak.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Posta elektronikoko helbidea</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Sartu erregistroa egin zenuenean erabili zenuen helbide bera.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Posta elektronikoko helbidea ez da aurkitu.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Bidali informazioa</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-<message key="xmlui.EPerson.StartRegistration.title">Erabiltzaile berriaren erregistroa</message>
-<message key="xmlui.EPerson.StartRegistration.head1">Erabiltzen ari den posta elektronikoaren helbidea</message>
-<message key="xmlui.EPerson.StartRegistration.para1">Posta-helbide hau beste pertsona batek erabiltzen du. Kontu honen pasahitza berrezarri nahi baduzu, sakatu “Berrezarri pasahitza” botoia.</message>
-<message key="xmlui.EPerson.StartRegistration.reset_password_for">Berrezarri pasahitza:</message>
-<message key="xmlui.EPerson.StartRegistration.submit_reset">Berrezarri pasahitza</message>
-<message key="xmlui.EPerson.StartRegistration.head2">Erabiltzailearen erregistroa</message>
-<message key="xmlui.EPerson.StartRegistration.para2">Sortu kontu bat.</message>
-<message key="xmlui.EPerson.StartRegistration.email_address">Posta elektronikoko helbidea</message>
-<message key="xmlui.EPerson.StartRegistration.email_address_help">Helbide hau egiaztatuko da eta erabiliko da zure sarbiderako izen gisa.</message>
-<message key="xmlui.EPerson.StartRegistration.error_bad_email">Ezinezkoa da posta elektronikorik helbide honetara bidaltzea.</message>
-<message key="xmlui.EPerson.StartRegistration.submit_register">Erregistratu</message>
+	<message key="xmlui.EPerson.StartRegistration.title">Erabiltzaile berriaren erregistroa</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Erabiltzen ari den posta elektronikoaren helbidea</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Posta-helbide hau beste pertsona batek erabiltzen du. Kontu honen pasahitza berrezarri nahi baduzu, sakatu “Berrezarri pasahitza” botoia.</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Berrezarri pasahitza:</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Berrezarri pasahitza</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Erabiltzailearen erregistroa</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Sortu kontu bat.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Posta elektronikoko helbidea</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Helbide hau egiaztatuko da eta erabiliko da zure sarbiderako izen gisa.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Ezinezkoa da posta elektronikorik helbide honetara bidaltzea.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Erregistratu</message>
 
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-<message key="xmlui.EPerson.VerifyEmail.title">Pasahitza berreskuratzeko posta bidali da</message>
-<message key="xmlui.EPerson.VerifyEmail.head">Pasahitza berreskuratzeko posta bidali da</message>
-<message key="xmlui.EPerson.VerifyEmail.para">Mezu elektroniko bat bidali dizugu {0} helbidera. Mezu horretan dagoen URLan klik egiten baduzu, pasahitz berri bat sartu ahalko duzu.</message>
+	<message key="xmlui.EPerson.VerifyEmail.title">Pasahitza berreskuratzeko posta bidali da</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Pasahitza berreskuratzeko posta bidali da</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">Mezu elektroniko bat bidali dizugu {0} helbidera. Mezu horretan dagoen URLan klik egiten baduzu, pasahitz berri bat sartu ahalko duzu.</message>
 
-                                 
-                                 
-                                 
-                                 
+
+
+
+
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -527,329 +618,343 @@
 
 
 	<!-- general submission aspect messages -->
-<message key="xmlui.Submission.general.mydspace_home">DSpace Nagusia</message>
-<message key="xmlui.Submission.general.go_mydspace">Nire DSpace</message>
-<message key="xmlui.Submission.general.submission.title">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.submission.trail">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.submission.head">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.submission.previous">&lt; Aurrekoa</message>
-<message key="xmlui.Submission.general.submission.save">Gorde/ Irten</message>
-<message key="xmlui.Submission.general.submission.next">Hurrengoa &gt;</message>
-<message key="xmlui.Submission.general.submission.complete">Bukatu bidalketa</message>
-<message key="xmlui.Submission.general.workflow.title">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.workflow.trail">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.workflow.head">Itemen bidalketa</message>
-<message key="xmlui.Submission.general.showfull">Itemaren erregistro osoa erakutsi</message>
-<message key="xmlui.Submission.general.showsimple">Itemaren erregistro erraza erakutsi</message>
-<message key="xmlui.Submission.general.default.title">Bidalketa</message>
-<message key="xmlui.Submission.general.default.trail">Bidalketa</message>
+	<message key="xmlui.Submission.general.mydspace_home">DSpace Nagusia</message>
+	<message key="xmlui.Submission.general.go_mydspace">Nire DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.submission.trail">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.submission.head">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Aurrekoa</message>
+	<message key="xmlui.Submission.general.submission.save">Gorde/ Irten</message>
+	<message key="xmlui.Submission.general.submission.next">Hurrengoa &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Bukatu bidalketa</message>
+	<message key="xmlui.Submission.general.workflow.title">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.workflow.trail">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.workflow.head">Itemen bidalketa</message>
+	<message key="xmlui.Submission.general.showfull">Itemaren erregistro osoa erakutsi</message>
+	<message key="xmlui.Submission.general.showsimple">Itemaren erregistro erraza erakutsi</message>
+	<message key="xmlui.Submission.general.default.title">Bidalketa</message>
+	<message key="xmlui.Submission.general.default.trail">Bidalketa</message>
 
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-<message key="xmlui.Submission.CollectionViewer.link1">Bidali item bat bilduma honetara</message>
+	<message key="xmlui.Submission.CollectionViewer.link1">Bidali item bat bilduma honetara</message>
 
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
-<message key="xmlui.Submission.Navigation.submissions">Bidalketak</message>
+	<message key="xmlui.Submission.Navigation.submissions">Bidalketak</message>
 
-	
-  <!-- org.dspace.app.xmlui.Submission.submissions -->
-<message key="xmlui.Submission.Submissions.title">Bidalketak &amp; Flujos de trabajo</message>
-<message key="xmlui.Submission.Submissions.trail">Bidalketak</message>
-<message key="xmlui.Submission.Submissions.head">Bidalketak &amp; lan-fluxuaren atazak</message>
-<message key="xmlui.Submission.Submissions.untitled"><i>Izenbururik gabe</i></message>
-<message key="xmlui.Submission.Submissions.email">posta elektronikoa:</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Bidalketak &amp; Flujos de trabajo</message>
+	<message key="xmlui.Submission.Submissions.trail">Bidalketak</message>
+	<message key="xmlui.Submission.Submissions.head">Bidalketak &amp; lan-fluxuaren atazak</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">posta elektronikoa:</message>
 	<!-- Same transformer, workflow section -->
-<message key="xmlui.Submission.Submissions.workflow_head1">Lan-fluxuaren atazak</message>
-<message key="xmlui.Submission.Submissions.workflow_info1">Ataza hauek errepositoriora bidali aurretik onespenaren zain dauden itemak dira. Bi ataza-errenkada dago, bat onartu diren atazei dagokie eta bestea oraindik inork bere gain hartu ez dituenei.</message>
-<message key="xmlui.Submission.Submissions.workflow_head2">Zure atazak</message>
-<message key="xmlui.Submission.Submissions.workflow_column1"></message>
-<message key="xmlui.Submission.Submissions.workflow_column2">Ataza</message>
-<message key="xmlui.Submission.Submissions.workflow_column3">Itema</message>
-<message key="xmlui.Submission.Submissions.workflow_column4">Bilduma</message>
-<message key="xmlui.Submission.Submissions.workflow_column5">Igorlea</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_return">Itzuli aukeratutako atazak poolera</message>
-<message key="xmlui.Submission.Submissions.workflow_info2">Ez zaizu atazarik esleitu</message>
-<message key="xmlui.Submission.Submissions.workflow_head3">Atazak poolean</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_take">Aukeratutako atazak onartu</message>
-<message key="xmlui.Submission.Submissions.workflow_info3">Ez dago atazarik poolean</message>  
+	<message key="xmlui.Submission.Submissions.workflow_head1">Lan-fluxuaren atazak</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Ataza hauek errepositoriora bidali aurretik onespenaren zain dauden itemak dira. Bi ataza-errenkada dago, bat onartu diren atazei dagokie eta bestea oraindik inork bere gain hartu ez dituenei.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Zure atazak</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Ataza</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Itema</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Bilduma</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Igorlea</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Itzuli aukeratutako atazak poolera</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">Ez zaizu atazarik esleitu</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Atazak poolean</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Aukeratutako atazak onartu</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">Ez dago atazarik poolean</message>
 	<!-- Same transformer, submissions section -->
-<message key="xmlui.Submission.Submissions.submit_head1">Bidalketak</message>
-<message key="xmlui.Submission.Submissions.submit_info1a">Beharrezkoa da</message>
-<message key="xmlui.Submission.Submissions.submit_info1b">bidalketa bat egiten hastea</message>
-<message key="xmlui.Submission.Submissions.submit_info1c">Bidalketa prozesua burutzeko, metadatoen sarrera-inprimakia bete behar da eta item digitala osatzen du(t)en fitxategia(k)gordailutu. Komunitate edo bilduma bakoitzak bere bidalketa-politika propioa izan dezake.</message>
-<message key="xmlui.Submission.Submissions.submit_head2">Bukatu gabeko bidalketak</message>
-<message key="xmlui.Submission.Submissions.submit_info2a">Hauek dira bukatu ez diren itemen bidalketa partzialak. Posible da</message>
-<message key="xmlui.Submission.Submissions.submit_info2b">bidalketa berri bati ekitea</message>
-<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-<message key="xmlui.Submission.Submissions.submit_column1"></message>
-<message key="xmlui.Submission.Submissions.submit_column2">Izenburua</message>
-<message key="xmlui.Submission.Submissions.submit_column3">Bilduma</message>
-<message key="xmlui.Submission.Submissions.submit_column4">Igorlea</message>
-<message key="xmlui.Submission.Submissions.submit_head3">Egiletza</message>
-<message key="xmlui.Submission.Submissions.submit_info3">Ez dago bukatu gabeko bidalketarik.</message>
-<message key="xmlui.Submission.Submissions.submit_head4">Kudeatzen:</message>
-<message key="xmlui.Submission.Submissions.submit_submit_remove">Ezabatu aukeratutako bidalketak</message>
-
+	<message key="xmlui.Submission.Submissions.submit_head1">Bidalketak</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Beharrezkoa da</message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">bidalketa bat egiten hastea</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">Bidalketa prozesua burutzeko, metadatoen sarrera-inprimakia bete behar da eta item digitala osatzen du(t)en fitxategia(k)gordailutu. Komunitate edo bilduma bakoitzak bere bidalketa-politika propioa izan dezake.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Bukatu gabeko bidalketak</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Hauek dira bukatu ez diren itemen bidalketa partzialak. Posible da</message>
+	<message key="xmlui.Submission.Submissions.submit_info2b">bidalketa berri bati ekitea</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Izenburua</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Bilduma</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Igorlea</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Egiletza</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">Ez dago bukatu gabeko bidalketarik.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Kudeatzen:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Ezabatu aukeratutako bidalketak</message>
 	<!-- Same transformer, inprogress section -->
-<message key="xmlui.Submission.Submissions.progress_head1">Berrikuspen-fasean dauden bidalketak</message>
-<message key="xmlui.Submission.Submissions.progress_info1">Hauek dira bildumako arduradunak berrikusten ari diren burututako bidalketak.</message>
-<message key="xmlui.Submission.Submissions.progress_column1">Izenburua</message>
-<message key="xmlui.Submission.Submissions.progress_column2">Bilduma</message>
-<message key="xmlui.Submission.Submissions.progress_column3">Egoera</message>
-
+	<message key="xmlui.Submission.Submissions.progress_head1">Berrikuspen-fasean dauden bidalketak</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Hauek dira bildumako arduradunak berrikusten ari diren burututako bidalketak.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Izenburua</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Bilduma</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Egoera</message>
 	<!-- Same transformer, workflow status -->
-<message key="xmlui.Submission.Submissions.status_0">Bidaliak</message>
-<message key="xmlui.Submission.Submissions.status_1">Berrikuspenaren zain</message>
-<message key="xmlui.Submission.Submissions.status_2">Berrikuspen fasean</message>
-<message key="xmlui.Submission.Submissions.status_3">Editorearen berrikuspenaren zain</message>
-<message key="xmlui.Submission.Submissions.status_4">Edizioan</message>
-<message key="xmlui.Submission.Submissions.status_5">Editorearen behin betiko berrikuspenaren zain</message>
-<message key="xmlui.Submission.Submissions.status_6">Edizioan</message>
-<message key="xmlui.Submission.Submissions.status_7">Artxibatutako bidalketa</message>
-<message key="xmlui.Submission.Submissions.status_unknown">Egoera ezezaguna</message>
-
+	<message key="xmlui.Submission.Submissions.status_0">Bidaliak</message>
+	<message key="xmlui.Submission.Submissions.status_1">Berrikuspenaren zain</message>
+	<message key="xmlui.Submission.Submissions.status_2">Berrikuspen fasean</message>
+	<message key="xmlui.Submission.Submissions.status_3">Editorearen berrikuspenaren zain</message>
+	<message key="xmlui.Submission.Submissions.status_4">Edizioan</message>
+	<message key="xmlui.Submission.Submissions.status_5">Editorearen behin betiko berrikuspenaren zain</message>
+	<message key="xmlui.Submission.Submissions.status_6">Edizioan</message>
+	<message key="xmlui.Submission.Submissions.status_7">Artxibatutako bidalketa</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Egoera ezezaguna</message>
         <!-- Same transformer, completed submissions section -->
-<message key="xmlui.Submission.Submissions.completed.head">Artxibatutako Bidalketak</message>
-<message key="xmlui.Submission.Submissions.completed.info">Hauek dira Dspace-n onartuak izan diren zure bidalketak</message>
-<message key="xmlui.Submission.Submissions.completed.column1">Onarpen-data</message>
-<message key="xmlui.Submission.Submissions.completed.column2">Izenburua</message>
-<message key="xmlui.Submission.Submissions.completed.column3">Bilduma</message>
-<message key="xmlui.Submission.Submissions.completed.limit">Artxibatutako zure bidalketatik 50 baino ez dira erakusten</message>
-<message key="xmlui.Submission.Submissions.completed.displayall">Nire artxibatutako bidalketa guztiak erakutsi.</message>
+        <message key="xmlui.Submission.Submissions.completed.head">Artxibatutako Bidalketak</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Hauek dira Dspace-n onartuak izan diren zure bidalketak</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Onarpen-data</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Izenburua</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Bilduma</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Artxibatutako zure bidalketatik 50 baino ez dira erakusten</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Nire artxibatutako bidalketa guztiak erakutsi.</message>
 
 	<!-- submission progress bar messages -->
-<message key="xmlui.Submission.submit.progressbar.initial-questions">Hasierako galderak</message>
-<message key="xmlui.Submission.submit.progressbar.describe">Deskribatu</message>
-<message key="xmlui.Submission.submit.progressbar.access">Sartu</message>
-<message key="xmlui.Submission.submit.progressbar.upload">Igo</message>
-<message key="xmlui.Submission.submit.progressbar.verify">Berrikusi</message>
-<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-<message key="xmlui.Submission.submit.progressbar.CClicense">Baimena CC</message>
-<message key="xmlui.Submission.submit.progressbar.license">Baimena</message>
-<message key="xmlui.Submission.submit.progressbar.complete">Osotu</message>
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Hasierako galderak</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Deskribatu</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Sartu</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Igo</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Berrikusi</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">Baimena CC</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Baimena</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Osotu</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Berrekin</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Berrekin</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-<message key="xmlui.Submission.submit.SelectCollection.head">Bilduma bat aukeratu...</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection">Bilduma</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_help">Aukeratu zein bildumatara bidali nahi duzun itema.</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_default">Bilduma bat aukeratu...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.head">Bilduma bat aukeratu...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Bilduma</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Aukeratu zein bildumatara bidali nahi duzun itema.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Bilduma bat aukeratu...</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Bidalketa gorde edo utzi bidaltzeari?</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Bidalketa ezabatu nahi al duzu edo beranduago berarekin lanean jarraitzeko gorde nahi al duzu? Nahi gabe Utzi sakatu baduzu ere, bidalketa prozesua eten zenuen puntura itzul zaitezke</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Bidalketarekin jarraitu</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Gorde geroago jarraitzeko</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Ezabatu bidalketa</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Bidalketa gorde edo utzi bidaltzeari?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Bidalketa ezabatu nahi al duzu edo beranduago berarekin lanean jarraitzeko gorde nahi al duzu? Nahi gabe Utzi sakatu baduzu ere, bidalketa prozesua eten zenuen puntura itzul zaitezke</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Bidalketarekin jarraitu</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Gorde geroago jarraitzeko</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Ezabatu bidalketa</message>
+
 
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Hasierako galderak</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Ohar garrntzitsua:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.and">eta</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Izenburu anitz</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Itemak izenburu bat baino gehiago dauka,<i>adibidez, itzulitako izenburu bat</i></message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Aldameneko kontrol-laukia markatuta ez badago, izenburua(k) itemetik ezabatua(k) izango d(ir)a:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Argitaratua</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Itema jadanik argitaratua edo publikoki banatua izan da.</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Aldameneko kontrol-laukia markatuta ez badago, izenburua(k) itemetik ezabatua(k) izango d(ir)a:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Argitalpen-data</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editorea</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Hasierako galderak</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Ohar garrntzitsua:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and">eta</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Izenburu anitz</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Itemak izenburu bat baino gehiago dauka,<i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Aldameneko kontrol-laukia markatuta ez badago, izenburua(k) itemetik ezabatua(k) izango d(ir)a:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Argitaratua</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Itema jadanik argitaratua edo publikoki banatua izan da.</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Aldameneko kontrol-laukia markatuta ez badago, izenburua(k) itemetik ezabatua(k) izango d(ir)a:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Argitalpen-data</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editorea</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-<message key="xmlui.Submission.submit.DescribeStep.head">Deskribatu Itema</message>
-<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Errorea: Eremu-mota ezezaguna</message>
-<message key="xmlui.Submission.submit.DescribeStep.required_field">Eremu hau nahitaezkoa da</message>
-<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Abizena,<i>p.ej. Pérez</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Izena(s),<i>adib. Manuel</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.year">Urtea</message>
-<message key="xmlui.Submission.submit.DescribeStep.month">Hilabetea</message>
-<message key="xmlui.Submission.submit.DescribeStep.day">Eguna</message>
-<message key="xmlui.Submission.submit.DescribeStep.series_name">Seriearen izena</message>
-<message key="xmlui.Submission.submit.DescribeStep.report_no">Txostenaren znbk.</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Gai-kategoriak</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Gaikako arloak</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Materiak hautatu</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Hautatu</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Itxaron kontrolatutako hiztegia kargatu bitartean.</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Kontrolatutako hiztegiaren karga prozesuan errorea jazo da, mesedez, saiatu berriro geroago.</message>
- 
-	<!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
-<message key="xmlui.Submission.submit.AccessStep.head">Sarbideen doitzea</message>
-<message key="xmlui.Submission.submit.AccessStep.access_settings">Ikusgarria erabiltzaile-talde batentzat (ez da beharrezkoa erabiltzaile anonimoentzat)</message>
-<message key="xmlui.Submission.submit.AccessStep.open_access">Fitxategian onartutakoan, itema ikusi ahal izango da.</message>
-<message key="xmlui.Submission.submit.AccessStep.embargo">Enbargatuta data zehatz batera arte</message>
-<message key="xmlui.Submission.submit.AccessStep.embargo_visible">Ikusgai/Enbargatua</message>
-<message key="xmlui.Submission.submit.AccessStep.name">Izena</message>
-<message key="xmlui.Submission.submit.AccessStep.description">Deskribap</message>
-<message key="xmlui.Submission.submit.AccessStep.reason">Arrazoia</message>
-<message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Baieztatu lehentasunak &amp; erantsi</message>
-<message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Taldeak</message>
-<message key="xmlui.Submission.submit.AccessStep.error_format_date">Errorea dataren formatuan</message>
-<message key="xmlui.Submission.submit.AccessStep.error_missing_date">Enbargo aukeratzen baduzu, data zehaztu behar duzu</message>
-<message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Talde eta ekintza hauentzat pribilegio berdinak badaude jadanik.</message>
-<message key="xmlui.Submission.submit.AccessStep.table_policies">Pribilegioen zerrenda</message>
-<message key="xmlui.Submission.submit.AccessStep.private_settings">Item pribatua</message>
-<message key="xmlui.Submission.submit.AccessStep.private_settings_help">Aukeratzen baduzu, itema ez da bilaketen emaitzetan sartuko</message>
-<message key="xmlui.Submission.submit.AccessStep.column0">Izena</message>
-<message key="xmlui.Submission.submit.AccessStep.column1">Ekintza</message>
-<message key="xmlui.Submission.submit.AccessStep.column2">Taldea</message>
-<message key="xmlui.Submission.submit.AccessStep.column3">Hasiera-data</message>
-<message key="xmlui.Submission.submit.AccessStep.column4">Bukaera-data</message>
-<message key="xmlui.Submission.submit.AccessStep.table_edit_button">Editatu</message>
-<message key="xmlui.Submission.submit.AccessStep.table_delete_button">Ezabatu</message>
-<message key="xmlui.administrative.authorization.AccessStep.label_date_help">Onartutako formatuak: uuuu, uuuu-hh, uuuu-hh-ee</message>
+	<message key="xmlui.Submission.submit.DescribeStep.head">Deskribatu Itema</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Errorea: Eremu-mota ezezaguna</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Eremu hau nahitaezkoa da</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Abizena,<i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Izena(s),<i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Urtea</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Hilabetea</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Eguna</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Seriearen izena</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Txostenaren znbk.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Gai-kategoriak</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Gaikako arloak</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Materiak hautatu</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Hautatu</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Itxaron kontrolatutako hiztegia kargatu bitartean.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Kontrolatutako hiztegiaren karga prozesuan errorea jazo da, mesedez, saiatu berriro geroago.</message>
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Sarbideen doitzea</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Ikusgarria erabiltzaile-talde batentzat (ez da beharrezkoa erabiltzaile anonimoentzat)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Fitxategian onartutakoan, itema ikusi ahal izango da.</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Enbargatuta data zehatz batera arte</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Ikusgai/Enbargatua</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Izena</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Deskribap</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Arrazoia</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Baieztatu lehentasunak &amp; erantsi</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Taldeak</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Errorea dataren formatuan</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Enbargo aukeratzen baduzu, data zehaztu behar duzu</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Talde eta ekintza hauentzat pribilegio berdinak badaude jadanik.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Pribilegioen zerrenda</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Item pribatua</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Aukeratzen baduzu, itema ez da bilaketen emaitzetan sartuko</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Izena</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Ekintza</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Taldea</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Hasiera-data</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">Bukaera-data</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Editatu</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Ezabatu</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Onartutako formatuak: uuuu, uuuu-hh, uuuu-hh-ee</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
-<message key="xmlui.Submission.submit.EditPolicyStep.head">Politika editatu</message>
-    
-<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-<message key="xmlui.Submission.submit.UploadStep.head">Fitxategia(k) gora kargatu</message>
-<message key="xmlui.Submission.submit.UploadStep.file">Fitxategia</message>
-<message key="xmlui.Submission.submit.UploadStep.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
-<message key="xmlui.Submission.submit.UploadStep.file_error">temak, gutxienez, fitxategi bat eduki behar du.</message>
-<message key="xmlui.Submission.submit.UploadStep.upload_error">Fitxategia igotzerakoan arazo bat egon da. Baliteke fitxategiaren izena zuzena ez izatea, edo, sare-arazo bat dela medio, fitxategia ondo iritsi ez izana, edo erantsi duzun fitxategiaren formatua soilik sistemaren barne-erabiletarako baimendua egotea. Saiatu berriro, mesedez.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_error">Fitxategia ez da ondo kargatu birus bat duelako. Mesedez, harremanetan jarri administratzailearekin.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Arazo bat egon da fitxategian birusik ote dagoen egiaztatzerakoan. Mesedez, jarri harremanetan sistemaren administratzailearekin</message>
-<message key="xmlui.Submission.submit.UploadStep.description">Fitxategiaren deskribapena</message>
-<message key="xmlui.Submission.submit.UploadStep.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Artikulu nagusia</i>", edo "<i>Dokumentuaren datuen irakurketa</i>"  .</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_upload">Igo fitxategia eta erantsi beste bat</message>
-<message key="xmlui.Submission.submit.UploadStep.head2">Igotako fitxategiak</message>
-<message key="xmlui.Submission.submit.UploadStep.column0">Primarioa</message>
-<message key="xmlui.Submission.submit.UploadStep.column1"></message>
-<message key="xmlui.Submission.submit.UploadStep.column2">Fitxategia</message>
-<message key="xmlui.Submission.submit.UploadStep.column3">Tamaina</message>
-<message key="xmlui.Submission.submit.UploadStep.column4">Deskribap</message>
-<message key="xmlui.Submission.submit.UploadStep.column5">Formatua</message>
-<message key="xmlui.Submission.submit.UploadStep.column6"></message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_name">Ezezaguna</message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_format">formatu ezezaguna</message>
-<message key="xmlui.Submission.submit.UploadStep.supported">(Bateragarria)</message>
-<message key="xmlui.Submission.submit.UploadStep.known">(Ezaguna)</message>
-<message key="xmlui.Submission.submit.UploadStep.unsupported">(Ez jasana)</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editatu</message>
-<message key="xmlui.Submission.submit.UploadStep.checksum">Fitxategiarern egiaztapena:</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_remove">Ezabatu aukeratutako fitxategiak</message>
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Politika editatu</message>
 
- <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Igo fitxategia(k)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fichero</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Itemak, gutxienez, fitxategi bat eduki behar du.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Fitxategia igotzerakoan arazo bat egon da. Baliteke fitxategiaren izena zuzena ez izatea, edo, sare-arazo bat dela medio, fitxategia ondo iritsi ez izana, edo, erantsi duzun fitxategiaren formatua soilik sistemaren barne-erabiletarako baimendua egotea. Saiatu berriro, mesedez.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Fitxategia ez da kargatu birus bat eduki dezakeelako. Mesedez, harremanetan jarri sistemaren administratzailearekin.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Arazo bat egon da fitxategian birusik ote dagoen egiaztatzerakoan. Mesedez, jarri harremanetan sistemaren administratzailearekin.</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Fitxategiaren deskribapena</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, describa brevemente el fichero, for example "<i>Artículo principal</i>", r "<i>Datos Experimentales</i>" Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Artikulu nagusia</i>", edota "<i>Datu esperimentalak</i>"  .</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Fitxategia kargatu &amp; añadir otro</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Igotako fitxategiak</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primarioa</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1"></message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Fitxategia</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Tamaina</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Deskribap</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formatua</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Ezezaguna</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">formatu ezezagunao</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Bateragarria)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Ezaguna)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Ez jasana)</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Editatu</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Fitxategiaren egiaztapena:</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Ezabatu aukeratutako fitxategiak</message>
-<message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Pribilegioak</message>
-       
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+	<message key="xmlui.Submission.submit.UploadStep.head">Fitxategia(k) gora kargatu</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Fitxategia</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">temak, gutxienez, fitxategi bat eduki behar du.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Fitxategia igotzerakoan arazo bat egon da. Baliteke fitxategiaren izena zuzena ez izatea, edo, sare-arazo bat dela medio, fitxategia ondo iritsi ez izana, edo erantsi duzun fitxategiaren formatua soilik sistemaren barne-erabiletarako baimendua egotea. Saiatu berriro, mesedez.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">Fitxategia ez da ondo kargatu birus bat duelako. Mesedez, harremanetan jarri administratzailearekin.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Arazo bat egon da fitxategian birusik ote dagoen egiaztatzerakoan. Mesedez, jarri harremanetan sistemaren administratzailearekin</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Fitxategiaren deskribapena</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Igo fitxategia eta erantsi beste bat</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Igotako fitxategiak</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Primarioa</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Fitxategia</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Tamaina</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Deskribap</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Formatua</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Ezezaguna</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">formatu ezezaguna</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Bateragarria)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Ezaguna)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Ez jasana)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editatu</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Fitxategiarern egiaztapena:</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Ezabatu aukeratutako fitxategiak</message>
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Igo fitxategia(k)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fichero</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Itemak, gutxienez, fitxategi bat eduki behar du.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Fitxategia igotzerakoan arazo bat egon da. Baliteke fitxategiaren izena zuzena ez izatea, edo, sare-arazo bat dela medio, fitxategia ondo iritsi ez izana, edo, erantsi duzun fitxategiaren formatua soilik sistemaren barne-erabiletarako baimendua egotea. Saiatu berriro, mesedez.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Fitxategia ez da kargatu birus bat eduki dezakeelako. Mesedez, harremanetan jarri sistemaren administratzailearekin.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Arazo bat egon da fitxategian birusik ote dagoen egiaztatzerakoan. Mesedez, jarri harremanetan sistemaren administratzailearekin.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Fitxategiaren deskribapena</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, describa brevemente el fichero, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Fitxategia kargatu &amp; añadir otro</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Igotako fitxategiak</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primarioa</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Fitxategia</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Tamaina</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Deskribap</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formatua</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Ezezaguna</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">formatu ezezagunao</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Bateragarria)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Ezaguna)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Ez jasana)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Editatu</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Fitxategiaren egiaztapena:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Ezabatu aukeratutako fitxategiak</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Pribilegioak</message>
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-<message key="xmlui.Submission.submit.EditFileStep.head">Fitxategia editatu</message>
-<message key="xmlui.Submission.submit.EditFileStep.file">Fichero</message>
-<message key="xmlui.Submission.submit.EditFileStep.description">Fitxategiaren deskribapena</message>
-<message key="xmlui.Submission.submit.EditFileStep.description_help">"Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Artikulu nagusia</i>", edota "<i>Dokumentuaren datuen irakurketa</i>"  .</message>
-<message key="xmlui.Submission.submit.EditFileStep.info1">Aukeratu zerrendan fitxategiaren formatua, adibidez, "<i>Adobe PDF</i>" edo "<i>Microsoft Word</i>",<b>O</b>formatua ez badago zerrendan, mesedez, deskribatu fitxategiaren formatua zerrendaren azpian dagoen laukian.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_detected">Detektatutako formatua</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_selected">Aukeratutako formatua</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_default">Formatua ez dago zerrendan</message>
-<message key="xmlui.Submission.submit.EditFileStep.info2">Formatua ez badago zerrendan, aukeratu “Formatua ez dago zerrendan” eta deskriba ezazu azpiko laukitxoan.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user">Bestelako formatua</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Fitxategia sortzeko erabili zenuen aplikazioaren izena eta bertsioa (adibidez, "<i>ACMESoft SuperApp versión 1.5</i>").</message>
+	<message key="xmlui.Submission.submit.EditFileStep.head">Fitxategia editatu</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Fichero</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Fitxategiaren deskribapena</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">"Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Aukeratu zerrendan fitxategiaren formatua, adibidez, "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Detektatutako formatua</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Aukeratutako formatua</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formatua ez dago zerrendan</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Formatua ez badago zerrendan, aukeratu “Formatua ez dago zerrendan” eta deskriba ezazu azpiko laukitxoan.<strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Bestelako formatua</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Fitxategia sortzeko erabili zenuen aplikazioaren izena eta bertsioa (adibidez, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
-	   <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
-<message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Editatu fitxategien baimenak</message>
-    
-    <!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-<message key="xmlui.Submission.submit.ReviewStep.head">E</message>
-<message key="xmlui.Submission.submit.ReviewStep.yes">Bai</message>
-<message key="xmlui.Submission.submit.ReviewStep.no">Ez</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Zuzendu hauetako bat</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Fitxategia erantsi edo ezabatu</message>
-<message key="xmlui.Submission.submit.ReviewStep.head1">Hasierako galderak</message>
-<message key="xmlui.Submission.submit.ReviewStep.head2">Deskribatu orrialdea {0}</message>
-<message key="xmlui.Submission.submit.ReviewStep.head3">Igotako fitxategiak</message>
-<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Izenburu anitz</message>
-<message key="xmlui.Submission.submit.ReviewStep.published_before">Honako data hau baino lehenago argitaratua:</message>
-<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-<message key="xmlui.Submission.submit.ReviewStep.unknown">ezezaguna</message>
-<message key="xmlui.Submission.submit.ReviewStep.known">ezaguna</message>
-<message key="xmlui.Submission.submit.ReviewStep.supported">bateragarria</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Editatu fitxategien baimenak</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">E</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Bai</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">Ez</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Zuzendu hauetako bat</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Fitxategia erantsi edo ezabatu</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Hasierako galderak</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Deskribatu orrialdea {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Igotako fitxategiak</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Izenburu anitz</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Honako data hau baino lehenago argitaratua:</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">ezezaguna</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">ezaguna</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">bateragarria</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Errorea jazo da ... {0}</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.head">Baimendu zure lana</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.info1">Zure itemari <a href="http://creativecommons.org/">Creative Commons</a>baimen bat egokitu ahal diozu. Creative Commons beimenek baldintzatzen dute irakurleek zer egin dezaketen zure lanarekin.</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Aukeratu lizentzia</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Sartu Creative Commons-en lizentzia aukeratzeko</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.license">Baimen- mota</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Aukeratu edo aldatu baimena...</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Creative Commons-baimenik gabe</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Sakatu Hurrengoa aldaketak gordetzeko.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Errorea jazo da ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Baimendu zure lana</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Zure itemari <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Aukeratu lizentzia</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Sartu Creative Commons-en lizentzia aukeratzeko</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Baimen- mota</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Aukeratu edo aldatu baimena...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Creative Commons-baimenik gabe</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Sakatu Hurrengoa aldaketak gordetzeko.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-<message key="xmlui.Submission.submit.LicenseStep.head">Banaketa-baimena</message>
-<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Azken urratsa falta da:</strong>Dspace-k zure bidalketa munduan zehar erreproduzitu, itzuli eta banatzeko baimena izan dezan, zure onarpena behar dugu, terminu hauetan.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info2">Banaketa-baimena estandarra onartzeko ‘Onartzen dut baimena aukeratu eta ‘Bidalketa bukatu’ sakatu.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info3">Baimenari buruzko zalantzarik baduzu, mesedez jarri harremanetan sistemaren administratzailearekin.</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_label">Banaketa-baimena</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Eman baimena</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_error">Bidalketa amaitzeko baimena onartu behar duzu. Ezin baduzu orain baimena onartu, gorde dezakezu zure lana eta geroago itzuli edo bidalketa ezabatu dezakezu ‘Ezabatu bidalketa’ sakatuz.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.head">Banaketa-baimena</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Banaketa-baimena estandarra onartzeko ‘Onartzen dut baimena aukeratu eta ‘Bidalketa bukatu’ sakatu.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Baimenari buruzko zalantzarik baduzu, mesedez jarri harremanetan sistemaren administratzailearekin.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Banaketa-baimena</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Eman baimena</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Bidalketa amaitzeko baimena onartu behar duzu. Ezin baduzu orain baimena onartu, gorde dezakezu zure lana eta geroago itzuli edo bidalketa ezabatu dezakezu ‘Ezabatu bidalketa’ sakatuz.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-<message key="xmlui.Submission.submit.RemovedStep.head">Bidalketa ezabatua izan da</message>
-<message key="xmlui.Submission.submit.RemovedStep.info1">Zure bidalketa bertan behera geratu da eta bukatu gabeko itema sistematik ezabatua izan da</message>
-<message key="xmlui.Submission.submit.RemovedStep.go_submission">Joan bidalketen orrira joan</message>
+	<message key="xmlui.Submission.submit.RemovedStep.head">Bidalketa ezabatua izan da</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Zure bidalketa bertan behera geratu da eta bukatu gabeko itema sistematik ezabatua izan da</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Joan bidalketen orrira joan</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-<message key="xmlui.Submission.submit.CompletedStep.head">Bidalketa amaitua</message>
-<message key="xmlui.Submission.submit.CompletedStep.info1">Zure bidalketa bidaltzen ari zaren bildumari esleitutako eginkizun-korrontearen prozesu batetik pasatuko da orain. Zure bidalketa bilduman sartu bezain laster, edo zure bidalketarekin arazoren bat baldin badago, jakinarazpen bat jasoko duzu posta elektroniko bidez. Era berean, zure bidalketaren egoera egiaztatu ahal izango duzu "Nire DSpace" orrira joz</message>
-<message key="xmlui.Submission.submit.CompletedStep.go_submission">Joan “Nire Dspacera”</message>
-<message key="xmlui.Submission.submit.CompletedStep.submit_again">Bidali beste item bat</message>
+	<message key="xmlui.Submission.submit.CompletedStep.head">Bidalketa amaitua</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Zure bidalketa bidaltzen ari zaren bildumari esleitutako eginkizun-korrontearen prozesu batetik pasatuko da orain. Zure bidalketa bilduman sartu bezain laster, edo zure bidalketarekin arazoren bat baldin badago, jakinarazpen bat jasoko duzu posta elektroniko bidez. Era berean, zure bidalketaren egoera egiaztatu ahal izango duzu "Nire DSpace" orrira joz</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Joan “Nire Dspacera”</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Bidali beste item bat</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Ataza honetarako ekintza posibleak:</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Hartu ataza.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Onartu ataza</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Utzi ataza hau poolean beste pertsona batek bere gain har dezan.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Ataza bertan behera utzi</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Itema berrikusi baduzu eta bilduma honetan egoteko egokia dela iruditzen bazaizu, aukeratu “Onartu”.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Onartu</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Itema editatu ondoren, erabili aukera hau eguneratzeko.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Eguneratu fitxategian</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Itema berrikusi baduzu, eta <strong>ez</strong>ezin bada bilduman sartu, hautatu "Ezetsi". Mezu bat sartzeko eskatuko dizute, eta bertan, itema ezesteko izan diren arrazoiak azaldu beharko dituzu; horretaz gain, adieraziko dizute bidalketa egin duenak gauzaren bat aldatu beharko ote duen edo berriz kargatu beharko ote duzun.
-</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Ezetzi itema</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Hautatu aukera hau itemaren metadatuak zuzentzeko edo editatzeko.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editatu metadatuak</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Ataza poolera itzultzeko eta beste norbaitek egiteko aukera izan dezan, erabili aukera hau</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Itzuli ataza poolera.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Ataza honetarako ekintza posibleak:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Hartu ataza.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Onartu ataza</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Utzi ataza hau poolean beste pertsona batek bere gain har dezan.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Ataza bertan behera utzi</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Itema berrikusi baduzu eta bilduma honetan egoteko egokia dela iruditzen bazaizu, aukeratu “Onartu”.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Onartu</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Itema editatu ondoren, erabili aukera hau eguneratzeko.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Eguneratu fitxategian</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Itema berrikusi baduzu, eta <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Ezetzi itema</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Hautatu aukera hau itemaren metadatuak zuzentzeko edo editatzeko.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editatu metadatuak</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Ataza poolera itzultzeko eta beste norbaitek egiteko aukera izan dezan, erabili aukera hau</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Itzuli ataza poolera.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Sartu itema ezesteko arrazoia. Zure mezuan adierazi igorleak berak konpondu beharko ote lukeen arazoa ala ez eta birbidali.
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Sartu itema ezesteko arrazoia. Zure mezuan adierazi igorleak berak konpondu beharko ote lukeen arazoa ala ez eta birbidali.
 .</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motiboa</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">“Motiboa” eremua nahitaezkoa da</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Ezetsi itema</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motiboa</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">“Motiboa” eremua nahitaezkoa da</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Ezetsi itema</message>
+
 
 
 
@@ -859,1044 +964,1096 @@
 
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
-
 	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
-<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Ataza ondo burutu da.</message>
-<message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Ataza bukatu da edo ustekabean huts egin du.  Jarri harremanetan administratzailearekin edo erroreen artxiboak berrikusi</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Ataza poolera bidali da.</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Errore bat jazo dela eta, ataza ezin da poolera bidali.  Informazio gehiago jasotzeko, jarri harremanetan administratzailearekin edo erroreen artxiboak berrikusi.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Erabiltzailea behar bezala erregistratu da.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Erabiltzailea behar bezala editatu da.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Pasahitza berria lortzen ahalbidetuko dion mezu bat bidali zaio erabiltzaileari.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Erabiltzailea(k) behar bezala ezabatua izan d(ir)a.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Zerrendan dauden erabiltzaileak ez dira ezabatu ekintza hori burutzeko murrizketak daudelako. Informazio gehiago lortzeko, erabiltzailearen datuen orria ikusi.</message>
-<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Taldea behar bezala aldatu da.</message>
-<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Aukeratutako taldeak behar bezala ezabatu dira.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Eskema berria behar bezala sortu da.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Eskema(k) behar bezala ezabatu d(ir)a.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Metadatuaren eremua behar bezala erantsi da.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente Metadatuaren eremua behar bezala aldatu da .</message>
-<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">El campo(s) fue movido correctamente Ermua(k) behar bezala mugitua izan d(ir)a.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Eremua(k) behar bezala ezabatua(k) izan d(ir)a.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Formatua behar bezala gorde da.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Formatua(k) behar bezala ezabatu d(ir)a.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Itemaren metadatuak behar bezala aldatu dira.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_added">Metadatua erantsi da.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Itema kendu egin da.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Itema berriro erantsi da.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_moved">Itema mugitua izan da.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_move_failed">Ez da aurkitu aukeratutako bilduma.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Fitxategi berria behar bezala igo da.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Errorea fitxategia igotzerakoan.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Fitxategia aldatua izan da.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Aukeratutako fitxategiak ezabatu egin dira.</message>
-<message key="xmlui.administrative.FlowMapperUtils.map_items">Itemak behar bezala mapeatuak izan dira.</message>
-<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Itemen arteko erlazioa behar bezala ezabatu da.</message>
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Ataza ondo burutu da.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Ataza bukatu da edo ustekabean huts egin du.  Jarri harremanetan administratzailearekin edo erroreen artxiboak berrikusi</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Ataza poolera bidali da.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Errore bat jazo dela eta, ataza ezin da poolera bidali.  Informazio gehiago jasotzeko, jarri harremanetan administratzailearekin edo erroreen artxiboak berrikusi.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Erabiltzailea behar bezala erregistratu da.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Erabiltzailea behar bezala editatu da.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Pasahitza berria lortzen ahalbidetuko dion mezu bat bidali zaio erabiltzaileari.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Erabiltzailea(k) behar bezala ezabatua izan d(ir)a.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Zerrendan dauden erabiltzaileak ez dira ezabatu ekintza hori burutzeko murrizketak daudelako. Informazio gehiago lortzeko, erabiltzailearen datuen orria ikusi.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Taldea behar bezala aldatu da.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Aukeratutako taldeak behar bezala ezabatu dira.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Eskema berria behar bezala sortu da.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Eskema(k) behar bezala ezabatu d(ir)a.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Metadatuaren eremua behar bezala erantsi da.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente Metadatuaren eremua behar bezala aldatu da .</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">El campo(s) fue movido correctamente Ermua(k) behar bezala mugitua izan d(ir)a.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Eremua(k) behar bezala ezabatua(k) izan d(ir)a.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Formatua behar bezala gorde da.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Formatua(k) behar bezala ezabatu d(ir)a.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Itemaren metadatuak behar bezala aldatu dira.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Metadatua erantsi da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Itema kendu egin da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Itema berriro erantsi da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">Itema mugitua izan da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">Ez da aurkitu aukeratutako bilduma.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Fitxategi berria behar bezala igo da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Errorea fitxategia igotzerakoan.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Fitxategia aldatua izan da.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Aukeratutako fitxategiak ezabatu egin dira.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Itemak behar bezala mapeatuak izan dira.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Itemen arteko erlazioa behar bezala ezabatu da.</message>
 
 	<!-- general items for all of the eperson classes -->
-<message key="xmlui.administrative.eperson.general.epeople_trail">Kudeatu erabiltzaileak</message>
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Kudeatu erabiltzaileak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
-<message key="xmlui.administrative.Navigation.context_head">Testuingurua</message>
-<message key="xmlui.administrative.Navigation.context_edit_item">Editatu item hau</message>
-<message key="xmlui.administrative.Navigation.context_edit_collection">Editatu Bilduma</message>
-<message key="xmlui.administrative.Navigation.context_item_mapper">Itemen mapeatzailea</message>
-<message key="xmlui.administrative.Navigation.context_edit_community">Editatu Komunitatea</message>
-<message key="xmlui.administrative.Navigation.context_create_collection">Sortu bilduma</message>
-<message key="xmlui.administrative.Navigation.context_create_subcommunity">Sortu azpikomunitatea</message>
-<message key="xmlui.administrative.Navigation.context_create_community">Sortu komunitatea</message>
-<message key="xmlui.administrative.Navigation.context_export_item">Esportatu itema</message>
-<message key="xmlui.administrative.Navigation.context_export_collection">Esportatu bilduma</message>
-<message key="xmlui.administrative.Navigation.context_export_community">Esportatu komunitatea</message>
-<message key="xmlui.administrative.Navigation.context_export_metadata">Esportatu metadatuak</message>
+	<message key="xmlui.administrative.Navigation.context_head">Testuingurua</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Editatu item hau</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Editatu Bilduma</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Itemen mapeatzailea</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Editatu Komunitatea</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Sortu bilduma</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Sortu azpikomunitatea</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Sortu komunitatea</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Esportatu itema</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Esportatu bilduma</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Esportatu komunitatea</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Esportatu metadatuak</message>
 
 	<!-- Site administrator options -->
-<message key="xmlui.administrative.Navigation.administrative_head">Administratzailea</message>
-<message key="xmlui.administrative.Navigation.administrative_access_control">Atzipen-kontrola</message>
-<message key="xmlui.administrative.Navigation.administrative_people">Pertsonak</message>
-<message key="xmlui.administrative.Navigation.administrative_groups">Taldeak</message>
-<message key="xmlui.administrative.Navigation.administrative_authorizations">Baimenak</message>
-<message key="xmlui.administrative.Navigation.administrative_registries">Erregistroak</message>
-<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatuak</message>
-<message key="xmlui.administrative.Navigation.administrative_format">Formatua</message>
-<message key="xmlui.administrative.Navigation.administrative_items">Itemak</message>
-<message key="xmlui.administrative.Navigation.administrative_withdrawn">Ezabatutako itemak</message>
-<message key="xmlui.administrative.Navigation.administrative_private">Item pribatuak</message>
-<message key="xmlui.administrative.Navigation.administrative_control_panel">Kontrol-panela</message>
-<message key="xmlui.administrative.Navigation.statistics">Estatistikak</message>
-<message key="xmlui.administrative.Navigation.administrative_import_metadata">Metadatuak inportatu</message>
-<message key="xmlui.administrative.Navigation.administrative_curation">Tareas de Curación</message>
+	<message key="xmlui.administrative.Navigation.administrative_head">Administratzailea</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Atzipen-kontrola</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Pertsonak</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Taldeak</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Baimenak</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Erregistroak</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatuak</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Formatua</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Itemak</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Ezabatutako itemak</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Item pribatuak</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Kontrol-panela</message>
+    <message key="xmlui.administrative.Navigation.statistics">Estatistikak</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Metadatuak inportatu</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Tareas de Curación</message>
 
     <!-- my account items -->
-<message key="xmlui.administrative.Navigation.account_export">Nire esportazioak</message>
+	<message key="xmlui.administrative.Navigation.account_export">Nire esportazioak</message>
+
 
 	<!-- export item -->
-<message key="xmlui.administrative.ItemExport.head">Exportar Archivo</message>
-<message key="xmlui.administrative.ItemExport.item.id.error">Sartu duzun itemaren kodea baliogabea da.</message>
-<message key="xmlui.administrative.ItemExport.collection.id.error">Sartu duzun bildumaren identifikatzailea baliogabea da.</message>
-<message key="xmlui.administrative.ItemExport.community.id.error">Sartu duzun komunitatearen kodea baliogabea da.</message>
-<message key="xmlui.administrative.ItemExport.item.not.found">Ez da aurkitu eskatutako itema.</message>
-<message key="xmlui.administrative.ItemExport.collection.not.found">Ez da aurkitu eskatutako bilduma.</message>
-<message key="xmlui.administrative.ItemExport.community.not.found">Ez da aurkitu eskatutako komunitatea.</message>
-<message key="xmlui.administrative.ItemExport.item.success">Se ha exportado correctamente el ítem. Recibirá un correo electrónico cuando el archivo esté listo  para la descarga.  Puede usar asímismo el  enlace  'Mis Exportaciones' para ver los archivos disponibles Itema behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko</message>
-<message key="xmlui.administrative.ItemExport.collection.success">La colección se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición Bilduma behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko</message>
-<message key="xmlui.administrative.ItemExport.community.success">La comunidad se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición Komunitatea behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko.</message>
-<message key="xmlui.administrative.ItemExport.available.head">Behera kargatzeko prest dauden esportazio-fitxategiak:</message>
+	<message key="xmlui.administrative.ItemExport.head">Exportar Archivo</message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">Sartu duzun itemaren kodea baliogabea da.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">Sartu duzun bildumaren identifikatzailea baliogabea da.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">Sartu duzun komunitatearen kodea baliogabea da.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">Ez da aurkitu eskatutako itema.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">Ez da aurkitu eskatutako bilduma.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">Ez da aurkitu eskatutako komunitatea.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Se ha exportado correctamente el ítem. Recibirá un correo electrónico cuando el archivo esté listo  para la descarga.  Puede usar asímismo el  enlace  'Mis Exportaciones' para ver los archivos disponibles Itema behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">La colección se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición Bilduma behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko</message>
+	<message key="xmlui.administrative.ItemExport.community.success">La comunidad se ha exportado satisfactoriamente. Deberá recibir un mensaje de correo electrónico cuando el archivo esté listo para descargar. También puede utilizar el enlace "Mis exportaciones" para ver una lista de los archivos que están a su disposición Komunitatea behar bezala esportatua izan da. Fitxategia behera kargatzeko prest dagoenean, posta elektroniko bat jasoko duzu. Era berean, ‘Nire esportazioak’ lotura erabil dezakezu erabilgarri dauden fitxategiak ikusteko.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Behera kargatzeko prest dauden esportazio-fitxategiak:</message>
+
+
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Kudeatu erabiltzaileak</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Erabiltzaileen kudeaketa</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Ekintzak</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Sortu erabiltzaile berri bat</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Sakatu hemen erabiltzaile berri bat eransteko.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Zerrendatu erabiltzaileak</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Sakatu hemen erabiltzaile guztiak zerrendatzeko.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Bilatu erabiltzaileak</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Erabiltzaileak bilatzen dira posta elektronikoaren edo izenaren parekatze partzialaren bidez</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Azpian ikus dezakezu zure bilaketa-irizpidearekin bat datozen erabiltzaileen zerrenda. Jarraitzeko, aukeratu ezabatu nahi duzuna eta “Ezabatu” botoia sakatu, edo sakatu erabiltzaile baten posta elektronikoko helbidean edo erabiltzailearen izenean editatzeko.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Bilaketaren emaitza</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Izena</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Posta elektronikoa</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Erabiltzaileak ezabatu</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Bilaketak ez du emaitzarik izan</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Kudeatu erabiltzaileak</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Erabiltzaileen kudeaketa</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Ekintzak</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Sortu erabiltzaile berri bat</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Sakatu hemen erabiltzaile berri bat eransteko.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Zerrendatu erabiltzaileak</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Sakatu hemen erabiltzaile guztiak zerrendatzeko.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Bilatu erabiltzaileak</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Erabiltzaileak bilatzen dira posta elektronikoaren edo izenaren parekatze partzialaren bidez</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Azpian ikus dezakezu zure bilaketa-irizpidearekin bat datozen erabiltzaileen zerrenda. Jarraitzeko, aukeratu ezabatu nahi duzuna eta “Ezabatu” botoia sakatu, edo sakatu erabiltzaile baten posta elektronikoko helbidean edo erabiltzailearen izenean editatzeko.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Bilaketaren emaitza</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Izena</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Posta elektronikoa</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Erabiltzaileak ezabatu</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Bilaketak ez du emaitzarik izan</message>
+
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-<message key="xmlui.administrative.eperson.AddEPersonForm.title">Erantsi erabiltzailea</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Erantsi erabiltzailea</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Sortu erabiltzaile berria</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Beste pertsona bat ari da posta elektronikoko helbide hau erabiltzen. Posta elektronikoko helbidea bakarra izan behar da.</message>
-
-<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Erabiltzaile berriari buruzko informazioa:</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">Posta elektronikoko helbidea bakarra izan behar da</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Posta elektronikoko helbide bat eskatzen da</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Izena nahitaezko datua da</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Abizena nahitaezko datua da</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Ziurtagiria behar duzu</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Sar zaitezke</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Sortu erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Erantsi erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Erantsi erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Sortu erabiltzaile berria</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Beste pertsona bat ari da posta elektronikoko helbide hau erabiltzen. Posta elektronikoko helbidea bakarra izan behar da.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Erabiltzaile berriari buruzko informazioa:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">Posta elektronikoko helbidea bakarra izan behar da</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Posta elektronikoko helbide bat eskatzen da</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Izena nahitaezko datua da</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Abizena nahitaezko datua da</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Ziurtagiria behar duzu</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Sar zaitezke</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Sortu erabiltzailea</message>
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editatu erabiltzailea</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editatu erabiltzailea</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Erabiltzailea editatu</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Beste pertsona bat ari da posta elektronikoko helbide hau erabiltzen. Posta elektronikoko helbidea bakarra izan behar da.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head2">{0}-(r)i buruzko inormazioa:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">Posta elektronikoko helbidea bakarra izan behar da</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Posta elektronikoko helbide bat eskatzen da</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Izena nahitaezko datua da</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Abizena nahitaezko datua da</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Ziurtagiria behar duzu</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Sar zaitezke</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Pasahitza berrezarri</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Erabiltzaile hau behin betiko ezaba dezakezu sistematik edo bere pasahitza berrezar dezakezu. Pasahitz bat berrezarritakoan, erabiltzaileak mezu bat jasoko du. Mezu honek erabiltzaileak pasahitz berri bat ezartzeko baliatu dezakeen lotura berezi bat dakar.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Ezabatu erabiltzailea</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Erabiltzaile moduan sartu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editatu erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editatu erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Erabiltzailea editatu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Beste pertsona bat ari da posta elektronikoko helbide hau erabiltzen. Posta elektronikoko helbidea bakarra izan behar da.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">{0}-(r)i buruzko inormazioa:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">Posta elektronikoko helbidea bakarra izan behar da</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Posta elektronikoko helbide bat eskatzen da</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Izena nahitaezko datua da</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Abizena nahitaezko datua da</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Ziurtagiria behar duzu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Sar zaitezke</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Pasahitza berrezarri</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Erabiltzaile hau behin betiko ezaba dezakezu sistematik edo bere pasahitza berrezar dezakezu. Pasahitz bat berrezarritakoan, erabiltzaileak mezu bat jasoko du. Mezu honek erabiltzaileak pasahitz berri bat ezartzeko baliatu dezakeen lotura berezi bat dakar.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Ezabatu erabiltzailea</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Erabiltzaile moduan sartu</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No se puede borrar este usuario debido a las siguientes restricciones Honako murrizketa hauek direla eta, erabiltzailea ezin da ezabatu:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">y</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">erabiltzaileak item bat edo gehiago bidali du.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">erabiltzaileak lan-fluxuaren bidalketa aktibo bat du</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">bukatzeke dagoen lan-fluxuaren ataza bat du</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">erabiltzaileak identifikatu gabeko murrizketa bat dauka sisteman</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">No se puede borrar este usuario debido a las siguientes restricciones Honako murrizketa hauek direla eta, erabiltzailea ezin da ezabatu:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">y</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">erabiltzaileak item bat edo gehiago bidali du.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">erabiltzaileak lan-fluxuaren bidalketa aktibo bat du</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">bukatzeke dagoen lan-fluxuaren ataza bat du</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">erabiltzaileak identifikatu gabeko murrizketa bat dauka sisteman</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Erabiltzaile hau talde hauetako kidea da:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member{0})">( taldearengatik:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">bat ere ez</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Erabiltzaile hau talde hauetako kidea da:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(via group: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">bat ere ez</message>
+
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Berretsi erabiltzailearen ezabaketa</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Egiaztatu ezabaketa</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Egiaztatu ezabaketa</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Erabiltzaile hauek ezabatuak izango dira:</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Izena</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Posta elektronikoa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Berretsi erabiltzailearen ezabaketa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Egiaztatu ezabaketa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Egiaztatu ezabaketa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Erabiltzaile hauek ezabatuak izango dira:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Izena</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Posta elektronikoa</message>
 
 	<!-- general items for all of the group classes -->
-<message key="xmlui.administrative.group.general.group_trail">Kudeatu taldeak</message>
+	<message key="xmlui.administrative.group.general.group_trail">Kudeatu taldeak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-<message key="xmlui.administrative.group.ManageGroupsMain.title">Kudeatu taldeak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Taldeen kudeaketa</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Ekintzak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Sortu talde berria</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Sakatu hemen talde berria eransteko.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Zerrendatu taldeak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Sakatu hemen talde guztiak zerrendatzeko.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Bilatu taldeak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Taldeak bilatzen dira izenaren parekatze partzialaren bidez</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Bilaketaren emaitzak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Izena</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Kideak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Komunitatea / Bilduma</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ikusi</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Ezabatu taldeak</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Bilaketak ez emaitzarik izan</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Kudeatu taldeak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Taldeen kudeaketa</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Ekintzak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Sortu talde berria</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Sakatu hemen talde berria eransteko.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Zerrendatu taldeak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Sakatu hemen talde guztiak zerrendatzeko.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Bilatu taldeak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Taldeak bilatzen dira izenaren parekatze partzialaren bidez</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Bilaketaren emaitzak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Izena</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Kideak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Komunitatea / Bilduma</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ikusi</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Ezabatu taldeak</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Bilaketak ez emaitzarik izan</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-<message key="xmlui.administrative.group.EditGroupForm.title">Taldeen editorea</message>
-<message key="xmlui.administrative.group.EditGroupForm.trail">Editatu taldea</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head">Taldeen editorea: {0} (id: {1})</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Taldeen editorea: talde berria</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Bilaketa garbitu</message>
-<message key="xmlui.administrative.group.EditGroupForm.member">Kidea</message>
-<message key="xmlui.administrative.group.EditGroupForm.cycle">Zikloa</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending">Egiteke dauden aldaketak</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: los cambios pendientes no se guardan hasta que pulsa el botón de guardar Egiteke dauden aldaketak ez dira gordeko ‘Gorde’ botoia sakatu arte.</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_add">Erantsi</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Ezabatu</message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_para">Talde hau honako bilduma honi asoziatuta dago:</message>
-<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado con la comunidad Talde hau honako komunitate honi asoziatuta dago:</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_name">Aldatu taldearen izena:</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Talde hau jakineko bilduma bati asoziatuta dago eta izena ezin da aldatu.</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_search">Bilatu kideak eransteko:</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Erabiltzaileak...</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Taldeak...</message>
-<message key="xmlui.administrative.group.EditGroupForm.no_results">Su búsqueda no produjo ningún resultado Bilaketak ez du emaitzik izan...</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Izena</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Posta elektronikoa</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Izena</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Kideak</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Bilduma</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ikusi</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_head">Kideak</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column2">Izena</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column3">Correo electrónico</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.members_group_name">taldea: {0}</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_none">Talde honek ez dauka kiderik.</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_pending">[zain]</message>
-<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Ezabatu kideak</message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Kideak ezabatu</message>
+	<message key="xmlui.administrative.group.EditGroupForm.title">Taldeen editorea</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Editatu taldea</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Taldeen editorea: {0} (id: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Taldeen editorea: talde berria</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Bilaketa garbitu</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Kidea</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Zikloa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Egiteke dauden aldaketak</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: los cambios pendientes no se guardan hasta que pulsa el botón de guardar Egiteke dauden aldaketak ez dira gordeko ‘Gorde’ botoia sakatu arte.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Erantsi</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Ezabatu</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Talde hau honako bilduma honi asoziatuta dago:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado con la comunidad Talde hau honako komunitate honi asoziatuta dago:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Aldatu taldearen izena:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Talde hau jakineko bilduma bati asoziatuta dago eta izena ezin da aldatu.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Bilatu kideak eransteko:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Erabiltzaileak...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Taldeak...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">Su búsqueda no produjo ningún resultado Bilaketak ez du emaitzik izan...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Izena</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Posta elektronikoa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Izena</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Kideak</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Bilduma</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ikusi</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Kideak</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Izena</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Correo electrónico</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">taldea: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Talde honek ez dauka kiderik.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[zain]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Ezabatu kideak</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Kideak ezabatu</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Berretsi taldearen ezabaketa</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Ezabatuko dira honako talde hauek:</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Izena</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Erabiltzaileak</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Taldeak</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Berretsi taldearen ezabaketa</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Ezabatuko dira honako talde hauek:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Izena</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Erabiltzaileak</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Taldeak</message>
 
 	<!-- general items for all of the registries classes -->
-<message key="xmlui.administrative.registries.general.format_registry_trail">Formatuen erregistroa</message>
-<message key="xmlui.administrative.registries.general.metadata_registry_trail">Metadatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Formatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Metadatuen erregistroa</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Ezabatu fitxategi-formatuak</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Ezabatu fitxategiaren formatuak</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Ziur al zaude formatu hau ezabatu nahi duzula? Formatu hau duen edozein fitxategi formatu ezezagunari lotuko zaio.</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Mota MIME</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Izena</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Ezabatu fitxategi-formatuak</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Ezabatu fitxategiaren formatuak</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Ziur al zaude formatu hau ezabatu nahi duzula? Formatu hau duen edozein fitxategi formatu ezezagunari lotuko zaio.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Mota MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Izena</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Ezabatu eremuak</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Ezabatu eremuak</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar borrado Berretsi ezabaketa</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Guztiz ziur al zaude eremu hauek ezabatu nahi dituzula? Itemen batek metadatuak badauzka eremu hauetan, errorea jazoko da eta ezabaketaren hutsegiteaz ohartaraziko zaizu. Baieztatu behar duzu sisteman ez dagoela eremu hauek erabiltzen dituen itemik.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">OHARRA:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Errorea jazoko da itemen batek eremu hauetan metadatoak badauzka.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Izena</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Ohar garrantzitsua</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Ezabatu eremuak</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Ezabatu eremuak</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar borrado Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Guztiz ziur al zaude eremu hauek ezabatu nahi dituzula? Itemen batek metadatuak badauzka eremu hauetan, errorea jazoko da eta ezabaketaren hutsegiteaz ohartaraziko zaizu. Baieztatu behar duzu sisteman ez dagoela eremu hauek erabiltzen dituen itemik.<b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">OHARRA:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Errorea jazoko da itemen batek eremu hauetan metadatoak badauzka.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Izena</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Ohar garrantzitsua</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Eskema ezabatua</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Eskema ezabatua</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Guztiz ziur al zaude eskema hau ezabatu nahi duzula? Itemen batek metadatuak badauzka eskema honetan, errorea jazoko da eta ezabaketaren hutsegiteaz ohartaraziko zaizu. Baieztatu behar duzu sisteman ez dagoela eskema honetan dauden eremuak erabiltzen dituen itemik</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">OHARRA:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Errorea jazoko da itemen batek metadatuak badauzka eskemaren edozein eremutan.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Izenetarako espazioa</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Izena</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Eskema ezabatua</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Eskema ezabatua</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Guztiz ziur al zaude eskema hau ezabatu nahi duzula? Itemen batek metadatuak badauzka eskema honetan, errorea jazoko da eta ezabaketaren hutsegiteaz ohartaraziko zaizu. Baieztatu behar duzu sisteman ez dagoela eskema honetan dauden eremuak erabiltzen dituen itemik<b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">OHARRA:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Errorea jazoko da itemen batek metadatuak badauzka eskemaren edozein eremutan.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Izenetarako espazioa</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Izena</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Fitxategiaren formatua</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Fitxategiaren formatua</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Fitxategi-formatu berria</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Fitxategiaren formatua: {0}</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Eman behar dituzu behean zehaztutako fitxategiaren formatuaren inguruko metadatu deskribatzaileak. Formatuen izenak bakarrak izan behar dira, baina MIME-Typesenak, ez. Microsoft Wordeko bertsio ezberdinetarako formatu-sarrera ezberdinak izan behar dituzu, baita MIME-Typea berbera izanda ere.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Izena</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Formatu honetarako izen bakarra (adib. Microsoft Word XP o Microsoft Word 2000)</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Eremuaren izena nahitaezkoa da.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">MIME mota</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Formatu honi lotutako MIME typea ez da bakarra izan behar.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Deskribap</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Jasate-maila</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Zure erakundeak formatu honi onartzen dion jasate-maila.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Ezezaguna</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Ezaguna</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Bateragarria</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Barnekoa</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">‘Barnekoak’ bezala markatutako formatuak erabiltzaileari ezkutatu egiten zaizkio eta administraritza-lanetarako erabiltzen dira.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Fitxategiaren luzapenak</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Fitxategien luzapenak gora kargatutako fitxategiak automatikoki identifikatzeko erabiltzen dira. Formatu bakoitzarentzat luzapen bat baino gehiago adieraz ditzakezu.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Fitxategiaren formatua</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Fitxategiaren formatua</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Fitxategi-formatu berria</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Fitxategiaren formatua: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Eman behar dituzu behean zehaztutako fitxategiaren formatuaren inguruko metadatu deskribatzaileak. Formatuen izenak bakarrak izan behar dira, baina MIME-Typesenak, ez. Microsoft Wordeko bertsio ezberdinetarako formatu-sarrera ezberdinak izan behar dituzu, baita MIME-Typea berbera izanda ere.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Izena</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Formatu honetarako izen bakarra (adib. Microsoft Word XP o Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Eremuaren izena nahitaezkoa da.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">MIME mota</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Formatu honi lotutako MIME typea ez da bakarra izan behar.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Deskribap</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Jasate-maila</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Zure erakundeak formatu honi onartzen dion jasate-maila.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Ezezaguna</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Ezaguna</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Bateragarria</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Barnekoa</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">‘Barnekoak’ bezala markatutako formatuak erabiltzaileari ezkutatu egiten zaizkio eta administraritza-lanetarako erabiltzen dira.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Fitxategiaren luzapenak</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Fitxategien luzapenak gora kargatutako fitxategiak automatikoki identifikatzeko erabiltzen dira. Formatu bakoitzarentzat luzapen bat baino gehiago adieraz ditzakezu.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-<message key="xmlui.administrative.registries.EditMetadataSchema.title">Metadatuen eskema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Metadatuen eskema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadatuen eskema: "{0}"</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Hau da "{0}"-(a)ren eskema. Eskema honetan dauden metadatuen eremuak erantsi edo aldatu ditzakezu. Era berean, eremuak markatu ditzakezu ezabatzeko edo beste eskema batera mugitzeko.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Eskemaren metadatuen eremuak</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Eremua</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Ohar garrantzitsua</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Ez dago metadatuen eremurik</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Ezabatu eremuak</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mugitu eremuak beste eskema batetara</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Erantsi metadatu-eremu berria</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.name">Eremuaren izena</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note">Ohar garrantzitsua</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Metadatu-eremu honi buruzko ohar gehigarriak.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Erantsi metadatu-eremu berria</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aldatu eremua: {0}</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aldatu eremua</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error">Errorea</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Eremuaren izena erabiltzen ari da jada. Elementu eta kualifikatzaile guztiak bakarrak izan behar dira.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">Eremuaren elementua nahitaezkoa da .</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Eremuaren elementuak karaktere arraro bat dauka, elementuak EZIN du eduki: punturik, azpimarraketarik edo hutsunerik.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">Eremuaren elementua luzeegia da, 32 karaktere baino gutxiago izan behar du.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Eremuaren kualifikatzailea luzeegia da, 32 karaktere baino gutxiago izan behar du.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Eremuaren kualifikatzaileak karaktere arraro bat dauka, elementuak EZIN du eduki: punturik, azpimarraketarik edo hutsunerik.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Metadatuen eskema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Metadatuen eskema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadatuen eskema: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Hau da "{0}"-(a)ren eskema. Eskema honetan dauden metadatuen eremuak erantsi edo aldatu ditzakezu. Era berean, eremuak markatu ditzakezu ezabatzeko edo beste eskema batera mugitzeko.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Eskemaren metadatuen eremuak</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Eremua</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Ohar garrantzitsua</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Ez dago metadatuen eremurik</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Ezabatu eremuak</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mugitu eremuak beste eskema batetara</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Erantsi metadatu-eremu berria</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Eremuaren izena</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Ohar garrantzitsua</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Metadatu-eremu honi buruzko ohar gehigarriak.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Erantsi metadatu-eremu berria</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aldatu eremua: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aldatu eremua</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Errorea</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Eremuaren izena erabiltzen ari da jada. Elementu eta kualifikatzaile guztiak bakarrak izan behar dira.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">Eremuaren elementua nahitaezkoa da .</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Eremuaren elementuak karaktere arraro bat dauka, elementuak EZIN du eduki: punturik, azpimarraketarik edo hutsunerik.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">Eremuaren elementua luzeegia da, 32 karaktere baino gutxiago izan behar du.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Eremuaren kualifikatzailea luzeegia da, 32 karaktere baino gutxiago izan behar du.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Eremuaren kualifikatzaileak karaktere arraro bat dauka, elementuak EZIN du eduki: punturik, azpimarraketarik edo hutsunerik.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
-<message key="xmlui.administrative.registries.FormatRegistryMain.title">Formatuen erregistroa</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.head">Fitxategi-formatuen erregistroa</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Fitxategi-zerrenda honek ezagututako fitxategi-formatuen  eta beraien jasate-mailaren inguruko informazioa eskaintzen du. Lanabes honekin fitxategi-formatuak erantsi edo edita ditzakezu. ‘Barnekoak’ bezala markatutako formatuak erabiltzaileari ezkutatu egiten zaizkio eta administraritza-lanetarako erabiltzen dira .</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Erantsi fitxategi-formatu berria</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Izena</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME mota</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Jasate-maila</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Ezezaguna</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Ezaguna</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Euskarria</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Ezabatu formatuak</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Formatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Fitxategi-formatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Fitxategi-zerrenda honek ezagututako fitxategi-formatuen  eta beraien jasate-mailaren inguruko informazioa eskaintzen du. Lanabes honekin fitxategi-formatuak erantsi edo edita ditzakezu. ‘Barnekoak’ bezala markatutako formatuak erabiltzaileari ezkutatu egiten zaizkio eta administraritza-lanetarako erabiltzen dira .</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Erantsi fitxategi-formatu berria</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Izena</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME mota</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Jasate-maila</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Ezezaguna</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Ezaguna</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Euskarria</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Ezabatu formatuak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadatuen erregistroa</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadatuen erregistroa</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Metadatuen erregistroak gordailuan eskuragarri dauden eremu guztien zerrenda bat mantentzen du. Eremu hauek askotariko eskematan zabalduak izan daitezke, baina Dspace-k Dublin Core-ko sailkapen-eskema behar du. Dublin Core eskema eremu gehigarrien bidez zabal dezakezu edo erregistroari eskema berriak erantsi ahal dizkiozu.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Izenetarako espazioa</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Izena</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Eskema ezabatua</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Erantsi eskema berria</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Izenetarako espazioa</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">Izenetarako espazioak URL berria zehaztu behar du eskema berriarentzat.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Eremu hau nahitaezkoa da</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Izena</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Eskemaren izen laburtua, eremu-izenen aurrizki bezala erabiliko da(adib. dc.element.qualifier). Izenak, gutxienez, 32 karaktere izan behar du eta ezin du eduki hutsunerik, punturik edo azpimarraketarik</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Eremu hau nahitaezkoa da, gutxienez, 32 karaktere izan behar du eta ezin du eduki hutsunerik, punturik edo azpimarraketarik .</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Erantsi eskema berri bat</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadatuen erregistroa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Metadatuen erregistroak gordailuan eskuragarri dauden eremu guztien zerrenda bat mantentzen du. Eremu hauek askotariko eskematan zabalduak izan daitezke, baina Dspace-k Dublin Core-ko sailkapen-eskema behar du. Dublin Core eskema eremu gehigarrien bidez zabal dezakezu edo erregistroari eskema berriak erantsi ahal dizkiozu.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Izenetarako espazioa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Izena</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Eskema ezabatua</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Erantsi eskema berria</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Izenetarako espazioa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">Izenetarako espazioak URL berria zehaztu behar du eskema berriarentzat.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Eremu hau nahitaezkoa da</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Izena</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Eskemaren izen laburtua, eremu-izenen aurrizki bezala erabiliko da(adib. dc.element.qualifier). Izenak, gutxienez, 32 karaktere izan behar du eta ezin du eduki hutsunerik, punturik edo azpimarraketarik</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Eremu hau nahitaezkoa da, gutxienez, 32 karaktere izan behar du eta ezin du eduki hutsunerik, punturik edo azpimarraketarik .</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Erantsi eskema berri bat</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-<message key="xmlui.administrative.registries.MoveMetadataField.title">Mugitu eremuak</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mugitu eremuak</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mugitu metadatuen eremuak</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para1">Eremu bat edo gehiago mugitzeko, hautatu eremuak (multipleak hautatzeko kontrol-tekla erabili) eta helburu-eskema. Helburu-eskemak izen berdinak dituzten eremuak baditu, eremuak ez dira mugituko.
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Mugitu eremuak</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mugitu eremuak</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mugitu metadatuen eremuak</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Eremu bat edo gehiago mugitzeko, hautatu eremuak (multipleak hautatzeko kontrol-tekla erabili) eta helburu-eskema. Helburu-eskemak izen berdinak dituzten eremuak baditu, eremuak ez dira mugituko.
 . .</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column2">Izena</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column3">Ohar garrantzitsua</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mugitu honako eskema honetara:</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mugitu eremuak</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Izena</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Ohar garrantzitsua</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mugitu honako eskema honetara:</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mugitu eremuak</message>
+
+
+
 
 	<!-- general authorization keywords -->
-<message key="xmlui.administrative.authorization.general.authorize_trail">Baimena</message>
-<message key="xmlui.administrative.authorization.general.policyList_trail">Pribilegioen zerrenda</message>
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Baimena</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Pribilegioen zerrenda</message>
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-<message key="xmlui.administrative.authorization.AuthorizationMain.title">Baimentze-pribilegioak kudeatu</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Baimentze-pribilegioak kudeatu</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Itemaren baimenak</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Sartu duzun Id-a ezin da erlazionatu item bakar batekin ere.</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Bilatu item bat</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Itemak handleren bidez edo barne IDaren bidez bilatzen dira</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Aurkitu</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Baimenak kudeatzeko lanabes aurreratua</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Sakatu hemen baimenak kudeatzeko lanabesa erabiltzeko</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Komunitateen/bilmumen baimenak</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Sakatu komunitate edo bilduma batean baimenak editatzeko.</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Baimentze-pribilegioak kudeatu</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Baimentze-pribilegioak kudeatu</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Itemaren baimenak</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Sartu duzun Id-a ezin da erlazionatu item bakar batekin ere.</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Bilatu item bat</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Itemak handleren bidez edo barne IDaren bidez bilatzen dira</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Aurkitu</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Baimenak kudeatzeko lanabes aurreratua</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Sakatu hemen baimenak kudeatzeko lanabesa erabiltzeko</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Komunitateen/bilmumen baimenak</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Sakatu komunitate edo bilduma batean baimenak editatzeko.</message>
+
+
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
-<message key="xmlui.administrative.authorization.EditContainerPolicies.title">B aimenak editatu</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Baimenen zerrenda</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">"{0}" ({1},ID: {2}) bildumaren pribilegioak</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegios para la comunidad "{0}" ({1},ID: {2})bildumaren pribilegioak</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Sakatu hemen pribilegio berri bat eransteko.</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Erantsi</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Izena</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Ekintza</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Taldea</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Hasiera-data</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Amaiera-data</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Ezabatu aukeratutakoak</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editatu</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">B aimenak editatu</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Baimenen zerrenda</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">"{0}" ({1},ID: {2}) bildumaren pribilegioak</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilegios para la comunidad "{0}" ({1},ID: {2})bildumaren pribilegioak</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Sakatu hemen pribilegio berri bat eransteko.</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Erantsi</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Izena</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Ekintza</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Taldea</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Hasiera-data</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Amaiera-data</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Ezabatu aukeratutakoak</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editatu</message>
+
+
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
-<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editatu itemaren baimenak</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Baimenen zerrenda</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">{0} (ID={1}) itemaren baimenak</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Editore honi esker item baten pribilegioak bistaratu eta alda ditzakezu. Horretaz gain, item baten osagai indibidualen politikak alda ditzakezu: bundleak eta bitstreamak. Labur esanda, item bat bundlen edukiontzi bat da eta bundleak bitstreamen edukiontziak dira.  Edukiontziek normalean ERANSTEKO/KENTZEKO/IRAKURTZEKO/IDAZTEKO politikak dituzte, bitstreamek, aldiz, IRAKURTZEKO/IDAZTEKO politikak soilik dituzte.
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editatu itemaren baimenak</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Baimenen zerrenda</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">{0} (ID={1}) itemaren baimenak</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Editore honi esker item baten pribilegioak bistaratu eta alda ditzakezu. Horretaz gain, item baten osagai indibidualen politikak alda ditzakezu: bundleak eta bitstreamak. Labur esanda, item bat bundlen edukiontzi bat da eta bundleak bitstreamen edukiontziak dira.  Edukiontziek normalean ERANSTEKO/KENTZEKO/IRAKURTZEKO/IDAZTEKO politikak dituzte, bitstreamek, aldiz, IRAKURTZEKO/IDAZTEKO politikak soilik dituzte.
 .</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Ikusiko duzu item bakoitzeko bundle eta bitstream gehigarri bat dagoela, eta haiek itemerako lizentziaren testua dute.
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Ikusiko duzu item bakoitzeko bundle eta bitstream gehigarri bat dagoela, eta haiek itemerako lizentziaren testua dute.
  .</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Itemaren pribilegioak</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">{0} ({1})bundlearen pribilegioak</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Archivo{0} ({1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Erantsi itemaren pribilegio berri bat</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Erantsi bundlearen pribilegio berri bat</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Erantsi fitxategiaren pribilegio berri bat</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Itemaren pribilegioak</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">{0} ({1})bundlearen pribilegioak</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Archivo{0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Erantsi itemaren pribilegio berri bat</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Erantsi bundlearen pribilegio berri bat</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Erantsi fitxategiaren pribilegio berri bat</message>
 
-<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Ez da aurkitu objektu honi asoziatutako pribilegiorik</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Ez da aurkitu objektu honi asoziatutako pribilegiorik</message>
+
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
-<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editatu pribilegioa</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editatu pribilegioa</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Sortu pribilegio berria erabiltzaile honentzat {0} {1}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editatu pribilegio {0} erabiltzaile  honentzat {1} {2}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Ez da talderik aukeratu</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Ez da ekintzarik aukeratu</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Izena</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Baliabide honetarko ekintzak</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editatu pribilegioa</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editatu pribilegioa</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Sortu pribilegio berria erabiltzaile honentzat {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editatu pribilegio {0} erabiltzaile  honentzat {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Ez da talderik aukeratu</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Ez da ekintzarik aukeratu</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Izena</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Baliabide honetarko ekintzak</message>
 
-<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Taldea</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">unekoa</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Bilaketaren emaitzak</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Aukeratu talde bat</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Bilatu talde bat</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Bilatu</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Aukeratu ekintza</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Taldea</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">unekoa</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Bilaketaren emaitzak</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Aukeratu talde bat</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Bilatu talde bat</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Bilatu</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Aukeratu ekintza</message>
 
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Izena</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Deskribap</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Hasiera-data</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Amaiera-data</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Data baliogabea da</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Talde honentzat eta ekintza honentzat, dagoeneko badaude pribilegio berdinak.</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Hasiera-data amaiera data baino beranduagokoa da.</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Onartutako formatuak: uuuu, uuuu-hh, uuuu-hh-ee</message>
-    
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Pribilegioen kudeatzaile aurreratua</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Baimen aurreratuak</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Pribilegioen kudeatzaile aurreratua</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Bilduma bateko eduki-moteei pribilegioak erantsi eta kentzen ahalbidetzen du. Kontuz, arriskutsua da: item bat IRAKURTZEKO baimena ezabatzeak item hori ezkuta dezake!.</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Markatutako talde guztientzat...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">... honako ekintza hau burutzeko gaitasuna ematen du...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">... objektu mota guzti hauentzat...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...honako bilduma guzti hauetan.</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Taldea</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Ekintza</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Eduki mota</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Bilduma</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Añadir privilegios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilegios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Onartutako formatuak: aaaa, aaaa-hh, aaaa-hh-ee</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Izena</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Deskribap</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Hasiera-data</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Amaiera-data</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Data baliogabea da</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Talde honentzat eta ekintza honentzat, dagoeneko badaude pribilegio berdinak.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Hasiera-data amaiera data baino beranduagokoa da.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Onartutako formatuak: uuuu, uuuu-hh, uuuu-hh-ee</message>
 
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Izena</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Deskribap</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Hasiera-data</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Amaiera-data</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Data baliagabea</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización Hasiera-data amaiera data baino beranduagokoa da</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Aukeratu, gutxienez, talde bat</message>
-<message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Aukeratu, gutxienez, bilduma bat</message>
-    
-    	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Berretsi pribilegioen ezabaketa</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Los siguientes privilegios serán eliminados Ezabatuko dira honako pribilegio hauek:</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Ekintza</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Taldea</message>
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Pribilegioen kudeatzaile aurreratua</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Baimen aurreratuak</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Pribilegioen kudeatzaile aurreratua</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Bilduma bateko eduki-moteei pribilegioak erantsi eta kentzen ahalbidetzen du. Kontuz, arriskutsua da: item bat IRAKURTZEKO baimena ezabatzeak item hori ezkuta dezake!.</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Markatutako talde guztientzat...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">... honako ekintza hau burutzeko gaitasuna ematen du...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">... objektu mota guzti hauentzat...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...honako bilduma guzti hauetan.</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Taldea</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Ekintza</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Eduki mota</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Bilduma</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Añadir privilegios</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilegios</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Onartutako formatuak: aaaa, aaaa-hh, aaaa-hh-ee</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Izena</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Deskribap</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Hasiera-data</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Amaiera-data</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Data baliagabea</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Fecha de comienzo posterior a fecha de finalización Hasiera-data amaiera data baino beranduagokoa da</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Aukeratu, gutxienez, talde bat</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Aukeratu, gutxienez, bilduma bat</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Berretsi pribilegioen ezabaketa</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Los siguientes privilegios serán eliminados Ezabatuko dira honako pribilegio hauek:</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Ekintza</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Taldea</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
 
 	<!-- general edit item messages -->
-<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
-<message key="xmlui.administrative.item.general.template_head">Editatu itemaren txantiloia honako bilduma honetarako: {0}</message>
-<message key="xmlui.administrative.item.general.option_head">Editatu itema</message>
-<message key="xmlui.administrative.item.general.option_status">Itemaren egoera</message>
-<message key="xmlui.administrative.item.general.option_bitstreams">Item honetako fitxategiak</message>
-<message key="xmlui.administrative.item.general.option_metadata">Itemaren metadatuak</message>
-<message key="xmlui.administrative.item.general.option_view">Ikusi itema</message>
-<message key="xmlui.administrative.item.general.option_curate">Curar</message>
-<message key="xmlui.administrative.item.general.option_queue">Encolar</message>
+	<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
+	<message key="xmlui.administrative.item.general.template_head">Editatu itemaren txantiloia honako bilduma honetarako: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Editatu itema</message>
+	<message key="xmlui.administrative.item.general.option_status">Itemaren egoera</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Item honetako fitxategiak</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Itemaren metadatuak</message>
+	<message key="xmlui.administrative.item.general.option_view">Ikusi itema</message>
+        <message key="xmlui.administrative.item.general.option_curate">Curar</message>
+        <message key="xmlui.administrative.item.general.option_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-<message key="xmlui.administrative.item.AddBitstreamForm.title">Fitxategia igo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.trail">Fitxategia igo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.head1">Fitxategi berri bat igo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Blokea</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Eduki-fitxategiak (lehenetsiak)</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadatuen fitxategiak</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturak</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Baimenak</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons baimenak</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fichero</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Deskribap</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Artikulu nagusia</i>", edota "<i>Dokumentuaren datuen irakurketa</i>"  .</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Igo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Fitxategi berriak igo ahal izateko, ERANSTEKO eta IDAZTEKO pribilegioak behar dituzu, gutxienez bloke batean.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Fitxategia igo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Fitxategia igo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Fitxategi berri bat igo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Blokea</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Eduki-fitxategiak (lehenetsiak)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadatuen fitxategiak</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturak</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Baimenak</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons baimenak</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fichero</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Mesedez, sartu zure ordenagailuan itemari dagokion fitxategiaren bide-izen osoa. “Arakatu...” botoia sakatzen baduzu, zure ordenagailuko fitxategi bat aukeratzen ahalbidetuko dizun leihoa zabalduko da.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Deskribap</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Igo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Fitxategi berriak igo ahal izateko, ERANSTEKO eta IDAZTEKO pribilegioak behar dituzu, gutxienez bloke batean.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Berretsi ezabaketa(k)</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Ziur al zaude fitxategi hauek ezabatu nahi dituzula? :</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Izena</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Deskribap</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formatua</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Berretsi ezabaketa(k)</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Ziur al zaude fitxategi hauek ezabatu nahi dituzula? :</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Izena</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Deskribap</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formatua</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-<message key="xmlui.administrative.item.ConfirmItemForm.title">Berretsi</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.trail">Berretsi</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.head1">Aldatu item hau: {0}</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Ziur al zude item hau guztiz ezabatu nahi duzula?. Kontuz: arrastrorik ere ez da geratuko</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Ziur al zaude item hau gordailutik kendu nahi duzula?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Ziur al zaude item hau berriro datu-basera eraman nahi duzula?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column1">Eremua</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column2">Balioa</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column3">Hizkuntza</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Kendu</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Berriro sartu</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Bihurtu pribatua</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Bihurtu publikoa</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Berretsi</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Berretsi</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Aldatu item hau: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Ziur al zude item hau guztiz ezabatu nahi duzula?. Kontuz: arrastrorik ere ez da geratuko</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Ziur al zaude item hau gordailutik kendu nahi duzula?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Ziur al zaude item hau berriro datu-basera eraman nahi duzula?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Eremua</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Balioa</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Hizkuntza</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Kendu</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Berriro sartu</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Bihurtu pribatua</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Bihurtu publikoa</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-<message key="xmlui.administrative.item.MoveItemForm.title">Mugitu</message>
-<message key="xmlui.administrative.item.MoveItemForm.trail">Mugitu</message>
-<message key="xmlui.administrative.item.MoveItemForm.head1">Mugitu item hau: {0}</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection">Bilduma</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_help">Aukeratu itema mugitua izango den bilduma.</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_default">Aukeratu bilduma bat...</message>
-<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Pribilegioak heredatu</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Heredatu helburu-bildumak lehenetsita dauzkan pribilegioak</message>
+	<message key="xmlui.administrative.item.MoveItemForm.title">Mugitu</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Mugitu</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Mugitu item hau: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Bilduma</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Aukeratu itema mugitua izango den bilduma.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Aukeratu bilduma bat...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Pribilegioak heredatu</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Heredatu helburu-bildumak lehenetsita dauzkan pribilegioak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-<message key="xmlui.administrative.item.EditBitstreamForm.title">Editatu fitxategia</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editatu fitxategia</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editatu fitxategia</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxategia</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Fitxategi nagusia</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Bai</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Ez</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Deskribap</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Artikulu nagusia</i>", edota "<i>Dokumentuaren datuen irakurketa</i>"  .</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para1">Aukeratu zerrendan fitxategiaren formatua, adibidez, "<i>Adobe PDF</i>" edo "<i>Microsoft Word</i>", <b>O</b>formatua ez badago zerrendan, mesedez, deskribatu fitxategiaren formatua zerrendaren azpian dagoen laukian.</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Aukeratutako formatua</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formatua ez dago zerrendan</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para2">Formatua ez badago zerrendan, aukeratu “Formatua ez dago zerrendan” eta deskriba ezazu azpiko laukitxoan</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Beste formatu bat</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Sartu fitxategia sortzeko erabili duzun programaren izena eta programaren bertsio-zenbakia (adibidez, "ACMESoft SuperApp version 1.5")</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_label">Fitxategiaren izena</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_help">Ezarri berriro fitxategiaren izena. Ikusiko duzu URLa aldatuko dela, baina lotura zaharrak baliogarriak izan go dira IDa aldatzen ez den bitartean.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Editatu fitxategia</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editatu fitxategia</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editatu fitxategia</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Fitxategia</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Fitxategi nagusia</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Bai</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Ez</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Deskribap</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Nahi baduzu, fitxategi honen edukia deskribatu dezakezu laburki, adibidez, "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Aukeratu zerrendan fitxategiaren formatua, adibidez, "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Aukeratutako formatua</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formatua ez dago zerrendan</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Formatua ez badago zerrendan, aukeratu “Formatua ez dago zerrendan” eta deskriba ezazu azpiko laukitxoan<strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Beste formatu bat</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Sartu fitxategia sortzeko erabili duzun programaren izena eta programaren bertsio-zenbakia (adibidez, "ACMESoft SuperApp version 1.5")<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Fitxategiaren izena</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Ezarri berriro fitxategiaren izena. Ikusiko duzu URLa aldatuko dela, baina lotura zaharrak baliogarriak izan go dira IDa aldatzen ez den bitartean.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item honetako fitxategiak</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item honetako fitxategiak</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Fitxategiak</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Izena</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Deskribap</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formatua</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ikusi</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Ordena</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bloque: {0}</strong></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ikusi</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un nuevo archivo Igo fitxategi desberdin bat</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Fitxategiak ezabatu</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Eguneratu bitstreamsen ordena</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Fitxategi berriak igo ahal izateko, itema eta blokeak ERANSTEKO eta IDAZTEKO pribilegioak behar dituzu.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Dspaceko administratzaileek baino ezin dute Dspaceko fitxategirik ezabatu.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Aurrekoa:</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Igo</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Bajar Behera kargatu</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item honetako fitxategiak</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item honetako fitxategiak</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Fitxategiak</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Izena</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Deskribap</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formatua</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ikusi</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Ordena</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ikusi</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un nuevo archivo Igo fitxategi desberdin bat</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Fitxategiak ezabatu</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Eguneratu bitstreamsen ordena</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Fitxategi berriak igo ahal izateko, itema eta blokeak ERANSTEKO eta IDAZTEKO pribilegioak behar dituzu.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Dspaceko administratzaileek baino ezin dute Dspaceko fitxategirik ezabatu.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Aurrekoa:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Igo</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Bajar Behera kargatu</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-<message key="xmlui.administrative.item.EditItemMetadataForm.title">Itemaren metadatuak</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Itemaren metadatuak</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Erantsi metadatu berri bat</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Izena</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Balioa</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Hizkuntza</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Erantsi metadatu berri bat</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.para1">OHARRA: aldaketa hauek ez dira balidatuko. Zure ardura da datuak behar den formatuan sartzea. Ziur ez bazaude, mesedez EZ egin aldaketarik.</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatuak</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Ezabatu</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Izena</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Balioa</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Hizkuntza</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Itemaren metadatuak</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Itemaren metadatuak</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Erantsi metadatu berri bat</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Izena</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Balioa</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Hizkuntza</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Erantsi metadatu berri bat</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">OHARRA: aldaketa hauek ez dira balidatuko. Zure ardura da datuak behar den formatuan sartzea. Ziur ez bazaude, mesedez EZ egin aldaketarik.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatuak</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Ezabatu</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Izena</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Balioa</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Hizkuntza</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
-<message key="xmlui.administrative.item.EditItemStatusForm.title">Itemaren egoera</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.trail">Itemaren egoera</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.para1">Ongi etorria itemen kudeaketa-orrira. Hemendik itema kendu, berriro sartu edo ezabatu ahalko duzu. Era berean, aldatu ahalko duzu edo beste erlaitzetan metadatu/fitxategi berriak gehitu ahalko dituzu.</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_id">Itemaren barne-IDa</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Azken aldaketa</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_in">Bildumetan</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Itemaren orria</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editatu itemaren baimentze-pribilegioak</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Kendu itema gordailutik</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Sartu berriro itema gordailuan</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mugitu itema beste bilduma batetara</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Ezabatu behin betiko itema</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Baimenak...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Kendu...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Berriro sartu...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mugitu...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Ezabatu behin betiko</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">( soilik sistemaren administratzaileak)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">( soilik bildumaren administratzaileak)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(ez duzu pribilegiorik ekintza hau burutzeko )</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_private">Itema pribatu egin</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_public">Itema publiko egin</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Pribatu egin...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Publiko egin...</message>
-    
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Itemaren egoera</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Itemaren egoera</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Ongi etorria itemen kudeaketa-orrira. Hemendik itema kendu, berriro sartu edo ezabatu ahalko duzu. Era berean, aldatu ahalko duzu edo beste erlaitzetan metadatu/fitxategi berriak gehitu ahalko dituzu.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">Itemaren barne-IDa</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Azken aldaketa</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">Bildumetan</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Itemaren orria</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editatu itemaren baimentze-pribilegioak</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Kendu itema gordailutik</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Sartu berriro itema gordailuan</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mugitu itema beste bilduma batetara</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Ezabatu behin betiko itema</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Baimenak...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Kendu...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Berriro sartu...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mugitu...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Ezabatu behin betiko</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">( soilik sistemaren administratzaileak)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">( soilik bildumaren administratzaileak)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(ez duzu pribilegiorik ekintza hau burutzeko )</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Itema pribatu egin</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Itema publiko egin</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Pribatu egin...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Publiko egin...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
-<message key="xmlui.administrative.item.ViewItem.title">Ikusi itema</message>
-<message key="xmlui.administrative.item.ViewItem.trail">Ikusi itema</message>
+	<message key="xmlui.administrative.item.ViewItem.title">Ikusi itema</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Ikusi itema</message>
         <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-<message key="xmlui.administrative.item.CurateItemForm.main_head">Curar Ítem: {0}</message>
-<message key="xmlui.administrative.item.CurateItemForm.title">Curar Ítem</message>
-<message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
-<message key="xmlui.administrative.item.CurateItemForm.label_name">Ataza</message>
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curar Ítem: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curar Ítem</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Ataza</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
-<message key="xmlui.administrative.item.FindItemForm.title">Aurkitu itema</message>
-<message key="xmlui.administrative.item.FindItemForm.head1">Aurkitu itema</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_label">Itemaren barne-IDa/Handle del ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_error">Ezin da identifikatzailea ebatzi.</message>
-<message key="xmlui.administrative.item.FindItemForm.find">Aurkitu</message>
+	<message key="xmlui.administrative.item.FindItemForm.title">Aurkitu itema</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Aurkitu itema</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Itemaren barne-IDa/Handle del ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Ezin da identifikatzailea ebatzi.</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Aurkitu</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport -->
-<message key="xmlui.administrative.metadataimport.general.title">Inportatu metadatuak</message>
-<message key="xmlui.administrative.metadataimport.general.head1">Inportatu metadatuak</message>
-<message key="xmlui.administrative.metadataimport.general.trail">Inportatu metadatuak</message>
-<message key="xmlui.administrative.metadataimport.general.changes">aldaketak</message>
-<message key="xmlui.administrative.metadataimport.general.no_changes">Ez da aldaketarik aurkitu</message>
-<message key="xmlui.administrative.metadataimport.general.new_item">Item berria</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_successful">Fitxategia behar bezala igo da</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_failed">Errorea fitxategia igotzerakoan</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badschema">Goiburuko metadatuen eskema ezezaguna da</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badelement">Goiburuko metadatuen elementua ezezaguna da</message>
-<message key="xmlui.administrative.metadataimport.flow.import_successful">Inportazioa behar bezala burutu da</message>
-<message key="xmlui.administrative.metadataimport.flow.import_failed">Errorea inportazioa egiterakoan</message>
-<message key="xmlui.administrative.metadataimport.flow.over_limit">Baimendutako aldaketa kopurua gainditu duzu. Mugatu aldaketak edo dspace.cfg-en bulkedit.gui-item-limit parametroa aldatu</message>
+        <message key="xmlui.administrative.metadataimport.general.title">Inportatu metadatuak</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Inportatu metadatuak</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Inportatu metadatuak</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">aldaketak</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Ez da aldaketarik aurkitu</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Item berria</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Fitxategia behar bezala igo da</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Errorea fitxategia igotzerakoan</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Goiburuko metadatuen eskema ezezaguna da</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Goiburuko metadatuen elementua ezezaguna da</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Inportazioa behar bezala burutu da</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Errorea inportazioa egiterakoan</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Baimendutako aldaketa kopurua gainditu duzu. Mugatu aldaketak edo dspace.cfg-en bulkedit.gui-item-limit parametroa aldatu</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Igo CSVa</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Igo CSVa</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Prozesua behar bezala burutu da</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Itemari egindako aldaketak</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Erantsia:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Ezabatua:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Bildumara bidalia</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado de la colección Bildumatik ezabatua</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Bildumari asoziatua</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Bildumatik askatua</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item ezabatua</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item kendua</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item berriro sartua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Prozesua behar bezala burutu da</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Itemari egindako aldaketak</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Erantsia:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Ezabatua:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Bildumara bidalia</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado de la colección Bildumatik ezabatua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Bildumari asoziatua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Bildumatik askatua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item ezabatua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item kendua</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item berriro sartua</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Erantsi:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Ezabatu:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Bidali bildumara</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Bildumatik kendu</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Bildumari asoziatu</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Bildumatik askatu</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Itemean egiteke dauden aldaketak</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Ezarri aldaketak</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Egiteke dauden aldaketak berrikuspenerako erakusten dira</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Ezabatu itema</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Kendu itema</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Itema berriro sartu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Erantsi:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Ezabatu:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Bidali bildumara</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Bildumatik kendu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Bildumari asoziatu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Bildumatik askatu</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Itemean egiteke dauden aldaketak</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Ezarri aldaketak</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Egiteke dauden aldaketak berrikuspenerako erakusten dira</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Ezabatu itema</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Kendu itema</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Itema berriro sartu</message>
 
 	<!-- general mapper messages -->
-<message key="xmlui.administrative.mapper.general.mapper_trail">Itemak erlazionatzeko tresna</message>
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Itemak erlazionatzeko tresna</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
-<message key="xmlui.administrative.mapper.MapperMain.title">Itemak erlazionatzeko tresna</message>
-<message key="xmlui.administrative.mapper.MapperMain.head1">Itemak erlazionatzeko tresna – Beste bildumetako itemak erlazionatzen ditu</message>
-<message key="xmlui.administrative.mapper.MapperMain.para1">Bilduma: "<strong>{0}</strong>"</message>
-<message key="xmlui.administrative.mapper.MapperMain.para2">Hau da itemak erlazionatzeko tresna. Beraren bidez, bildumen administratzaileek erlazionatu ditzakete beste bildumetako itemak bilduma honekin. Bilatu eta erlazionatu ahal dituzu beste bilduma bateko itemak, edo ikus dezakezu erlazionatutako itemen zerrenda.</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estatistikak</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_info">bilduma honetako<strong>{0} {1}tik item dago/daude erlazionatuta beste bilduma batzuekin</strong></message>
-<message key="xmlui.administrative.mapper.MapperMain.search_label">Bilatu</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_search">Bilatu itemak</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Zerrendatu erlazionatutako itemak</message>
-<message key="xmlui.administrative.mapper.MapperMain.no_add">(Bildumaren ADD pribilegioa behar duzu)</message>
+	<message key="xmlui.administrative.mapper.MapperMain.title">Itemak erlazionatzeko tresna</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Itemak erlazionatzeko tresna – Beste bildumetako itemak erlazionatzen ditu</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Bilduma: "<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Hau da itemak erlazionatzeko tresna. Beraren bidez, bildumen administratzaileek erlazionatu ditzakete beste bildumetako itemak bilduma honekin. Bilatu eta erlazionatu ahal dituzu beste bilduma bateko itemak, edo ikus dezakezu erlazionatutako itemen zerrenda.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estatistikak</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info">bilduma honetako<strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Bilatu</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Bilatu itemak</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Zerrendatu erlazionatutako itemak</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Bildumaren ADD pribilegioa behar duzu)</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
-<message key="xmlui.administrative.mapper.SearchItemForm.title">Biladu itemak</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.trail">Bilatu itemak</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.head1">Bilatu honekin bat datozen itemak: "{0}"</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Erlazionatu markatutako itemak</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column2">Bilduma</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column3">Egilea</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column4">Izenburua</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Biladu itemak</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Bilatu itemak</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Bilatu honekin bat datozen itemak: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Erlazionatu markatutako itemak</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Bilduma</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Egilea</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Izenburua</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-<message key="xmlui.administrative.mapper.BrowseItemForm.title">Zerrendatu erlazionatutako itemak</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Zerrendatu erlazionatutako itemak</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Erlazionatutako itemen zerrenda</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Deslotu aukeratutako itemak</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Bilduma</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Egilea</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Izenburua</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Itemak deslotzeko, bilduma honeta EZABATU delako pribilegioa izan behar duzu.</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Zerrendatu erlazionatutako itemak</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Zerrendatu erlazionatutako itemak</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Erlazionatutako itemen zerrenda</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Deslotu aukeratutako itemak</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Bilduma</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Egilea</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Izenburua</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Itemak deslotzeko, bilduma honeta EZABATU delako pribilegioa izan behar duzu.</message>
 
 	<!-- General tags for collection management -->
-<message key="xmlui.administrative.collection.general.collection_trail">Bildumak</message>
-<message key="xmlui.administrative.collection.general.options_metadata">Editatu metadatos</message>
-<message key="xmlui.administrative.collection.general.options_roles">Esleitu rolak</message>
-<message key="xmlui.administrative.collection.general.options_curate">Curar</message>
-<message key="xmlui.administrative.collection.general.options_queue">Encolar</message>
+	<message key="xmlui.administrative.collection.general.collection_trail">Bildumak</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Editatu metadatos</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Esleitu rolak</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editatu bildumaren rolak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rolak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editatu bilduma: {0}</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">bat ere ez</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Sortu...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Mugatu...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Bildumaren administratzaileek erabakitzen dute nork burutu ditzakeen honako ekintza hauek: itemak bildumara bidali, kendu, metadatuak editatu (bidali ondoren) eta erantsi (erlazionatu)beste bildumetako itemak bilduma honetara (baimenaren arabera).</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Urrats honen arduradunek onartu edo ezetsi ditzaketen egiteke dauden bidalketak. Hala ere, ezin izango dituzte editatu bidalitako itemen metadatuak.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Urrats honen arduradunek egiteke dauden bidalketen metadatuak editatu ahalko dituzte. Gainera, bidalketak onartu edo ezetsi ahalko dituzte..</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Urrats honen arduradunek egiteke dauden bidalketen metadatuak editatu ahalko dituzte baina ezin izango dituzte bidalketak ezetsi</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Bilduma honetara item berriak bidaltzeko baimena daukaten erabiltzaileak eta taldeak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Bilduma honetara bidalitako item berriak irakur ditzaketen erabiltzaileak eta taldeak. Rol honetan egindako aldaketak ez dira atzeraeraginezkoak eta item zaharrak ikusgarri mantenduko dira erantsi ziren unean beraiek ikusteko baimena zuten erabiltzaileentzat.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Bilduma honek sarbiderako ezarpen pertsonalizatua erabiltzen du.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Une honetan item eta fitxategiak irakurri ahal izateko baimen lehenetsia Anonimori esleituta dago.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editatu zuzenean baimen-pribilegioak.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rola</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Elkartutako taldea</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">AAdministratzaileak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Lan-fluxuaren urratsak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa Onartu/Ezetsi</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa Onartu/Ezetsi/Editatu metadatuak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editatu metadatoak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Argitaratzaileak</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Irakurketarako sarbide lehenetsia</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(Sistemaren administratzaileak soilik)</nobr></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br></br>(Gordailu mailako taldea, soilik sistemaren administratzaileak)</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>( Ez daukazu baimenik hemen ezarpenak egiteko)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editatu bildumaren rolak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rolak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editatu bilduma: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">bat ere ez</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Sortu...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Mugatu...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Bildumaren administratzaileek erabakitzen dute nork burutu ditzakeen honako ekintza hauek: itemak bildumara bidali, kendu, metadatuak editatu (bidali ondoren) eta erantsi (erlazionatu)beste bildumetako itemak bilduma honetara (baimenaren arabera).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Urrats honen arduradunek onartu edo ezetsi ditzaketen egiteke dauden bidalketak. Hala ere, ezin izango dituzte editatu bidalitako itemen metadatuak.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Urrats honen arduradunek egiteke dauden bidalketen metadatuak editatu ahalko dituzte. Gainera, bidalketak onartu edo ezetsi ahalko dituzte..</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Urrats honen arduradunek egiteke dauden bidalketen metadatuak editatu ahalko dituzte baina ezin izango dituzte bidalketak ezetsi</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Bilduma honetara item berriak bidaltzeko baimena daukaten erabiltzaileak eta taldeak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Bilduma honetara bidalitako item berriak irakur ditzaketen erabiltzaileak eta taldeak. Rol honetan egindako aldaketak ez dira atzeraeraginezkoak eta item zaharrak ikusgarri mantenduko dira erantsi ziren unean beraiek ikusteko baimena zuten erabiltzaileentzat.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Bilduma honek sarbiderako ezarpen pertsonalizatua erabiltzen du.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Une honetan item eta fitxategiak irakurri ahal izateko baimen lehenetsia Anonimori esleituta dago.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editatu zuzenean baimen-pribilegioak.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rola</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Elkartutako taldea</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"/>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">AAdministratzaileak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Lan-fluxuaren urratsak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa Onartu/Ezetsi</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa Onartu/Ezetsi/Editatu metadatuak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editatu metadatoak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Argitaratzaileak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Irakurketarako sarbide lehenetsia</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar Colección: {0}</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar Colección</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Ataza</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar Colección: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar Colección</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Ataza</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Berretsi</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">{0} bildumaren ezabaketa berretsi {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Ziur al zaude {0} bilduma ezabatu nahi duzula? Ezabatuko da:</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Beste bilduma batzuetan ez dauden itemak eta egiteke dauden bidalketak</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Item hauen edukia</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Esleitutako baimen-pribilegio guztiak</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Berretsi</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">{0} bildumaren ezabaketa berretsi {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Ziur al zaude {0} bilduma ezabatu nahi duzula? Ezabatuko da:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Beste bilduma batzuetan ez dauden itemak eta egiteke dauden bidalketak</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Item hauen edukia</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Esleitutako baimen-pribilegio guztiak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Berretsi rolaren ezabaketa e</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Berretsi</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">{0} rolaren ezabaketa beretsi</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Ziur zaude rol hau ezabatu nahi duzula?. Talde hau ezabatzeak hemendik aurrera bilduma honetara bidaliko diren item guztiak IRAKURTZEKO baimena emango du. Mesedez, kontuan hartu aldaketa hau ez dela atzeraeraginezkoa, eta, beraz, ezabatu behar duzun taldean zehaztutako kideek baino ez dutela izango aurreko pribilegioen arabera bidalitako itemetarako sarbidea.</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Ziur al zaude rol hau ezabatu nahi duzula?. {0} taldean egindako aldaketa eta ezarpen guztiak galduko dira eta berriro sortu beharko dira.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Berretsi rolaren ezabaketa e</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Berretsi</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">{0} rolaren ezabaketa beretsi</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Ziur zaude rol hau ezabatu nahi duzula?. Talde hau ezabatzeak hemendik aurrera bilduma honetara bidaliko diren item guztiak IRAKURTZEKO baimena emango du. Mesedez, kontuan hartu aldaketa hau ez dela atzeraeraginezkoa, eta, beraz, ezabatu behar duzun taldean zehaztutako kideek baino ez dutela izango aurreko pribilegioen arabera bidalitako itemetarako sarbidea.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Ziur al zaude rol hau ezabatu nahi duzula?. {0} taldean egindako aldaketa eta ezarpen guztiak galduko dira eta berriro sortu beharko dira.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editatu bildumaren metadatuak</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatuak</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editatu bilduma: {0}</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Izena</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Deskribapen laburra:</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Hitzaurre-testua (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Copyrightaren testua (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Berriak (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Baimena</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Jatorria</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Logo berria igo</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Uneko logoa</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Itemaren txantiloia</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Sortu...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editatu...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Ezabatu logoa</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Ezabatu bilduma</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Gorde aldaketak</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>( Sistemaren administratzaileak soilik)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editatu bildumaren metadatuak</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatuak</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editatu bilduma: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Izena</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Deskribapen laburra:</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Hitzaurre-testua (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Copyrightaren testua (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Berriak (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Baimena</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Jatorria</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Logo berria igo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Uneko logoa</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Itemaren txantiloia</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Sortu...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editatu...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Ezabatu logoa</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Ezabatu bilduma</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Gorde aldaketak</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CreateCollectionForm.title">Sortu bilduma</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Sortu bilduma</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">{0}ren bilduma berrirako metadatuak sartu</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Sortu</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Sortu bilduma</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Sortu bilduma</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">{0}ren bilduma berrirako metadatuak sartu</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Sortu</message>
 
 	<!-- General to the harvesting options under collection -->
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Bildumaren bilketa-parametroak</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Biltzen</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Edukiaren jatorria</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Edukiaren jatorria</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Hau Dspaceko bilduma estandar bat da</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Bilduma honek kanpo-iturri batetik biltzen ditu bere edukiak</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Gorde</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Bildumaren bilketa-parametroak</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Biltzen</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Edukiaren jatorria</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Edukiaren jatorria</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Hau Dspaceko bilduma estandar bat da</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Bilduma honek kanpo-iturri batetik biltzen ditu bere edukiak</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Gorde</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Bildutako bildumaren kokapena</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Bilketa-aukerak</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">HornitzaileaOAI</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadatuen formatua</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">Gordailu obektiboaren OAI zerbitzuaren hornitzailearen URLa</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Helburu-bildumaren id-a eman behar duzu.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">El identificador persistente usado por el proveedor OAI para designar la colección objetivo</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Helburu-bildumaren id-a eman behar duzu</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Edukia biltzen</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Bildu bakarrik metadatuak.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Bildu metadatuak eta fitxategien erreferentziak (ORE euskarria behar da).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Bildu metadatuak eta fitxategiak (ORE euskarria behar da).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Frogatu parametroak</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Bildutako bildumaren kokapena</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Bilketa-aukerak</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">HornitzaileaOAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadatuen formatua</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">Gordailu obektiboaren OAI zerbitzuaren hornitzailearen URLa</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Helburu-bildumaren id-a eman behar duzu.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">El identificador persistente usado por el proveedor OAI para designar la colección objetivo</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Helburu-bildumaren id-a eman behar duzu</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Edukia biltzen</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Bildu bakarrik metadatuak.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Bildu metadatuak eta fitxategien erreferentziak (ORE euskarria behar da).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Bildu metadatuak eta fitxategiak (ORE euskarria behar da).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Frogatu parametroak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Jaso den bildumaren kokapena</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Hornitzailea OAI</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadatuen formatua</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Edukia biltzen</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Bilketaren azken emaitza</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Bilduma hau oraindik ez da jasoa izan.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Bilketaren uneko egoera</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Bilduma jasoa izateko prest dago</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Bilduma jasotzen</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Bilduma jasotzeko zain</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI errorea jazo da azken bilketan</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Errorea jazo da azken bilketan</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Bildu metadatoak soilik.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Bildu metadatuak eta fitxategien erreferentziak.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Bildu metadatuak eta fitxategiak (erreplikazio osoa).</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Aldatu parametroak</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Inportatu orain</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Bilduma errestauratu eta berriro inportatu</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Jaso den bildumaren kokapena</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Hornitzailea OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadatuen formatua</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Edukia biltzen</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Bilketaren azken emaitza</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Bilduma hau oraindik ez da jasoa izan.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Bilketaren uneko egoera</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Bilduma jasoa izateko prest dago</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Bilduma jasotzen</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Bilduma jasotzeko zain</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI errorea jazo da azken bilketan</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Errorea jazo da azken bilketan</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Bildu metadatoak soilik.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Bildu metadatuak eta fitxategien erreferentziak.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Bildu metadatuak eta fitxategiak (erreplikazio osoa).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Aldatu parametroak</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Inportatu orain</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Bilduma errestauratu eta berriro inportatu</message>
 
-<message key="xmlui.administrative.ControlPanel.option_harvest">Biltzen</message>
-<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controles del planificador de Recolección Bilketaren planifikatzailearen kontrolak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_status">Egoera</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Ekintzak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Abiarazi bilketa</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado del recolector Biltzailearen egoera leheneratu</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Berrekin</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Gelditu</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Gelditu</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Jasotzeko prest dauden bildumak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_active">Bilketa aktiboak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Bilketak errenkadan</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI erroreak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Barne-erroreak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Sortzailearen parametroak</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE jatorria</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Biltzailearen parametroak</message>
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Biltzen</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controles del planificador de Recolección Bilketaren planifikatzailearen kontrolak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Egoera</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Ekintzak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Abiarazi bilketa</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado del recolector Biltzailearen egoera leheneratu</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Berrekin</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Gelditu</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Gelditu</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Jasotzeko prest dauden bildumak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Bilketa aktiboak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Bilketak errenkadan</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI erroreak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Barne-erroreak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Sortzailearen parametroak</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE jatorria</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Biltzailearen parametroak</message>
 
 	<!-- General tags for community management -->
-<message key="xmlui.administrative.community.general.community_trail">Komunitateak</message>
-<message key="xmlui.administrative.community.general.options_metadata">Editatu metadatuak</message>
-<message key="xmlui.administrative.community.general.options_roles">Rolak esleitu</message>
-<message key="xmlui.administrative.community.general.options_curate">Curar</message>
-<message key="xmlui.administrative.community.general.options_queue">Encolar</message>
+	<message key="xmlui.administrative.community.general.community_trail">Komunitateak</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Editatu metadatuak</message>
+	<message key="xmlui.administrative.community.general.options_roles">Rolak esleitu</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.community.general.options_queue">Encolar</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editatu bildumaren rolak</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Rolak</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editatu komunitatea: {0}</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">bat ere ez</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.create">Sortu...</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Komunitate-administratzaileek azpikomunitateak edo bildumak sor ditzateke, baita dagozkien baimenak kudeatu edo esleitu ere. Gainera, erabakitzen dute nork eraman dezakeen itemik bildumetara, nork edita dezakeen metadatorik eta nork mapeatu dezakeen beste bildumetako itemik (autorizazioaren menpean).</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Komunitate honek pertsonalizatutako sarbide-ezarpena erabiltzen du.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Une honetan item eta fitxategiak irakurri ahal izateko baimen lehenetsia Anonimori esleituta dago .</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editatu zuzenean baimen-pribilegioak.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Elkartutako taldea</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons"></message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administratzaileak</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>( Sistemaren administratzaileak soilik)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editatu bildumaren rolak</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Rolak</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editatu komunitatea: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">bat ere ez</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Sortu...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Komunitate-administratzaileek azpikomunitateak edo bildumak sor ditzateke, baita dagozkien baimenak kudeatu edo esleitu ere. Gainera, erabakitzen dute nork eraman dezakeen itemik bildumetara, nork edita dezakeen metadatorik eta nork mapeatu dezakeen beste bildumetako itemik (autorizazioaren menpean).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Komunitate honek pertsonalizatutako sarbide-ezarpena erabiltzen du.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Une honetan item eta fitxategiak irakurri ahal izateko baimen lehenetsia Anonimori esleituta dago .</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editatu zuzenean baimen-pribilegioak.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Elkartutako taldea</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons"/>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administratzaileak</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-<message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar Comunidad: {0}</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.title">Curar Comunidad</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.label_name">Ataza</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar Comunidad: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curar Comunidad</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Ataza</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Berretsi ezabaketa</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Berretsi</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmar borrado de la comunidad Berretsi{0} komunitatearen ezabaketa</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Ziur al zaude {0} komunitatea ezabatu nahi duzula? Honek ezabatuko du:</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Beste komunitateetan ez dauden bildumak.</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Beste komunitateetan ez dauden itemak eta egiteke dauden bidalketak</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Item hauen edukia</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Esleitutako baimen-pribilegio guztiak</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Berretsi ezabaketa</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Berretsi</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmar borrado de la comunidad Berretsi{0} komunitatearen ezabaketa</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Ziur al zaude {0} komunitatea ezabatu nahi duzula? Honek ezabatuko du:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Beste komunitateetan ez dauden bildumak.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Beste komunitateetan ez dauden itemak eta egiteke dauden bidalketak</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Item hauen edukia</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Esleitutako baimen-pribilegio guztiak</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Berretsi rolaren ezabaketa</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Berretsi</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Berretsi{0}rolaren ezabaketa</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Ziur zaude rol hau ezabatu nahi duzula?. {0} taldean egindako aldaketa eta ezarpen guztiak galduko dira eta baliteke taldea berriro sortu behar izatea.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Berretsi rolaren ezabaketa</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Berretsi</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Berretsi{0}rolaren ezabaketa</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Ziur zaude rol hau ezabatu nahi duzula?. {0} taldean egindako aldaketa eta ezarpen guztiak galduko dira eta baliteke taldea berriro sortu behar izatea.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editatu komunitatearen metadatuak</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatuak</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editatu {0} komunitatearen metadatuak e</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editatu pribilegioak</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Izena</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Deskribapen laburra</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Hitzaurre-testua (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Copyright testua (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Berriak (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Igo logo berria</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Uneko logoa</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Ezabatu logoa</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Ezabatu komunitatea</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editatu komunitatearen metadatuak</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatuak</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editatu {0} komunitatearen metadatuak e</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editatu pribilegioak</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Izena</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Deskribapen laburra</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Hitzaurre-testua (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Copyright testua (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Berriak (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Igo logo berria</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Uneko logoa</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Ezabatu logoa</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Ezabatu komunitatea</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-<message key="xmlui.administrative.community.CreateCommunityForm.title">Sortu komunitatea</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.trail">Sortu komunitatea</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">{0}komunitatearen azpikomunitate berri baterako metadatuak sartu</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editatu metadatuak lehen mailako komunitate berri baterako</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Sortu</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Sortu komunitatea</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Sortu komunitatea</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">{0}komunitatearen azpikomunitate berri baterako metadatuak sartu</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editatu metadatuak lehen mailako komunitate berri baterako</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Sortu</message>
+
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-<message key="xmlui.administrative.ControlPanel.title">Kontrol-panela</message>
-<message key="xmlui.administrative.ControlPanel.trail">Kontrol-panela</message>
-<message key="xmlui.administrative.ControlPanel.head">Kontrol panela</message>
-<message key="xmlui.administrative.ControlPanel.option_java">Javaren informazioa</message>
-<message key="xmlui.administrative.ControlPanel.option_dspace">Dspaceren ezarpenak</message>
-<message key="xmlui.administrative.ControlPanel.option_alerts">Sistemaren alertak</message>
-<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
-<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-<message key="xmlui.administrative.ControlPanel.java_head">Java eta sistema eragilea</message>
-<message key="xmlui.administrative.ControlPanel.java_version">Java Runtime Environmentaren bertsioa</message>
-<message key="xmlui.administrative.ControlPanel.java_vendor">Java Runtime Environmentaren hornitzailea</message>
-<message key="xmlui.administrative.ControlPanel.os_name">Sistema eragilearen izena</message>
-<message key="xmlui.administrative.ControlPanel.os_arch">Sistema eragilearen arkitektura</message>
-<message key="xmlui.administrative.ControlPanel.os_version">Sistema eragilearen bertsioa</message>
-<message key="xmlui.administrative.ControlPanel.runtime_head">Gauzatze-estatistikak</message>
-<message key="xmlui.administrative.ControlPanel.runtime_processors">Erabilgarri dauden prozesagailuak</message>
-<message key="xmlui.administrative.ControlPanel.runtime_max">Gehieneko memoria</message>
-<message key="xmlui.administrative.ControlPanel.runtime_total">Esleitutako memoria</message>
-<message key="xmlui.administrative.ControlPanel.runtime_used">Erabilitako memoria</message>
-<message key="xmlui.administrative.ControlPanel.runtime_free">Erabili gabeko memoria</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon Cocoonaren informazioa</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoonaren bertsioa</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoonaren Cachearen direktorioa</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoonaren direktorioa</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Cache nagusiaren tamaina ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Ezabatu Cachea berehala)</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Cache nagusiaren tamaina ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Cache iragankorraren tamaina  ({0})</message>
-<message key="xmlui.administrative.ControlPanel.dspace_head">Dspaceren parametroak</message>
-<message key="xmlui.administrative.ControlPanel.dspace_version">Dspaceren bertsioa</message>
-<message key="xmlui.administrative.ControlPanel.dspace_dir">Dspaceren instalazioaren direktorioa</message>
-<message key="xmlui.administrative.ControlPanel.dspace_url">Dspaceren oinarrizko URLa</message>
-<message key="xmlui.administrative.ControlPanel.dspace_hostname">Dspaceko hostaren izena</message>
-<message key="xmlui.administrative.ControlPanel.dspace_name">Gunearen izena</message>
-<message key="xmlui.administrative.ControlPanel.db_name">Datu-basearen izena</message>
-<message key="xmlui.administrative.ControlPanel.db_url">Datu-basearen URLa</message>
-<message key="xmlui.administrative.ControlPanel.db_driver">Driver JDBC</message>
-<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexiones a la Base de datos en Pool</message>
-<message key="xmlui.administrative.ControlPanel.db_maxwait">DBrako denbora-muga</message>
-<message key="xmlui.administrative.ControlPanel.db_maxidle">Erabili gabeko konexioen gehieneko kopurua</message>
-<message key="xmlui.administrative.ControlPanel.mail_server">SMTP zerbitzaria</message>
-<message key="xmlui.administrative.ControlPanel.mail_from_address">Posta igorlea</message>
-<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Iradokizunen hartzailea</message>
-<message key="xmlui.administrative.ControlPanel.mail_admin">Administratzaile nagusiaren posta elektronikoa</message>
-<message key="xmlui.administrative.ControlPanel.alerts_head">Sistemaren alertak</message>
-<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Advertencia para sistemas de balanceo de carga</strong>: Las alertas globales son sólo efectivas para el nodo en el que se han activado. Necesita asegurarse de que cada nodo en el grupo recibe el comando de alerta de activación.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaje de alerta</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_default">Ohiko mantentze-lanak direla eta, sistema itzali egingo da. Mesedez, gorde zure lana eta eten ezazu konexioa.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Atzerako kontaketa</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Atzerako kontaketarik gabe</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutu</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutu</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutu</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">ordu 1</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Jarraitu uneko atzerako kontaketarekin</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_label">Kudeatu saioa</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Jarraitu onartzen baimendutako saioak</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Geldiarazi baimentzea baina uneko saioei eragin gabe</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Geldiarazi baimentzea eta bukatu uneko saioak</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Oharra:</strong>Administratzaile nagusiak saioen kudeaketa egitetik salbuetsita daude.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Gaitu</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desgaitu</message>
-<message key="xmlui.administrative.ControlPanel.activity_head">Uneko aktibitatea (gehienez, {0} orrialde)</message>
-<message key="xmlui.administrative.ControlPanel.stop_anonymous">GELDITU erabiltzaile anonimoen aktibitatearen erregistroa.</message>
-<message key="xmlui.administrative.ControlPanel.start_anonymous">EMPEZAR el registro de la actividad de usuarios anónimos ABIARAZI erabiltzaile anonimoen aktibitatearen erregistroa.</message>
-<message key="xmlui.administrative.ControlPanel.stop_bot">GELDITU botsen aktibitatearen erregistroa.</message>
-<message key="xmlui.administrative.ControlPanel.start_bot">ABIARAZI botsen aktibitatearen erregistroa.</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_time">Data-zigilua</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_user">Erabiltzailea</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP helbidea</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL orria</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Nabigatzailea</message>
-<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonimoa {0}</message>
-<message key="xmlui.administrative.ControlPanel.activity_none">Orrialdeen bistaratzeak ez dira erregistratu</message>
+	<message key="xmlui.administrative.ControlPanel.title">Kontrol-panela</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Kontrol-panela</message>
+	<message key="xmlui.administrative.ControlPanel.head">Kontrol panela</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Javaren informazioa</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Dspaceren ezarpenak</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Sistemaren alertak</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java eta sistema eragilea</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Java Runtime Environmentaren bertsioa</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Java Runtime Environmentaren hornitzailea</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Sistema eragilearen izena</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Sistema eragilearen arkitektura</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Sistema eragilearen bertsioa</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Gauzatze-estatistikak</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Erabilgarri dauden prozesagailuak</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Gehieneko memoria</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Esleitutako memoria</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Erabilitako memoria</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Erabili gabeko memoria</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon Cocoonaren informazioa</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoonaren bertsioa</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoonaren Cachearen direktorioa</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoonaren direktorioa</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Cache nagusiaren tamaina ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Ezabatu Cachea berehala)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Cache nagusiaren tamaina ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Cache iragankorraren tamaina  ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Dspaceren parametroak</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Dspaceren bertsioa</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Dspaceren instalazioaren direktorioa</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">Dspaceren oinarrizko URLa</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Dspaceko hostaren izena</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Gunearen izena</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Datu-basearen izena</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">Datu-basearen URLa</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Driver JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexiones a la Base de datos en Pool</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">DBrako denbora-muga</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Erabili gabeko konexioen gehieneko kopurua</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">SMTP zerbitzaria</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Posta igorlea</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Iradokizunen hartzailea</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Administratzaile nagusiaren posta elektronikoa</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Sistemaren alertak</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaje de alerta</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Ohiko mantentze-lanak direla eta, sistema itzali egingo da. Mesedez, gorde zure lana eta eten ezazu konexioa.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Atzerako kontaketa</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Atzerako kontaketarik gabe</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutu</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutu</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutu</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">ordu 1</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Jarraitu uneko atzerako kontaketarekin</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Kudeatu saioa</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Jarraitu onartzen baimendutako saioak</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Geldiarazi baimentzea baina uneko saioei eragin gabe</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Geldiarazi baimentzea eta bukatu uneko saioak</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Gaitu</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desgaitu</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Uneko aktibitatea (gehienez, {0} orrialde)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">GELDITU erabiltzaile anonimoen aktibitatearen erregistroa.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">EMPEZAR el registro de la actividad de usuarios anónimos ABIARAZI erabiltzaile anonimoen aktibitatearen erregistroa.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">GELDITU botsen aktibitatearen erregistroa.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">ABIARAZI botsen aktibitatearen erregistroa.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Data-zigilua</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Erabiltzailea</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP helbidea</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL orria</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Nabigatzailea</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonimoa {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Orrialdeen bistaratzeak ez dira erregistratu</message>
 
-<message key="xmlui.administrative.ControlPanel.select_panel">Erabili goiko erlaitzak aukeratzeko zein informazio ikuskatuko den.</message>
+	<message key="xmlui.administrative.ControlPanel.select_panel">Erabili goiko erlaitzak aukeratzeko zein informazio ikuskatuko den.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>{0} munutu barru</strong>:</message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-<message key="xmlui.administrative.NotAuthorized.title">Baimendu gabea</message>
-<message key="xmlui.administrative.NotAuthorized.trail">Baimendu gabea</message>
-<message key="xmlui.administrative.NotAuthorized.head">Ez dago nahikoa pribilegio</message>
-<message key="xmlui.administrative.NotAuthorized.para1a">Zure kontuak ez du nahikoa pribilegio eskatzen den ekintza burutzeko. Uste baduzu errore bat dagoela edo ekintza burutu beharra badaukazu, mesedez harremanetan jarri</message>
-<message key="xmlui.administrative.NotAuthorized.para1b">sistemaren administratzaileekin.</message>
-<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-<message key="xmlui.administrative.NotAuthorized.para2">Sartu beste erabiltzaile bat moduan</message>
+	<message key="xmlui.administrative.NotAuthorized.title">Baimendu gabea</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">Baimendu gabea</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Ez dago nahikoa pribilegio</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">Zure kontuak ez du nahikoa pribilegio eskatzen den ekintza burutzeko. Uste baduzu errore bat dagoela edo ekintza burutu beharra badaukazu, mesedez harremanetan jarri</message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">sistemaren administratzaileekin.</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Sartu beste erabiltzaile bat moduan</message>
         
         <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-<message key="xmlui.administrative.CurateForm.title">Tareas de Curación de Sistema</message>
-<message key="xmlui.administrative.CurateForm.trail">Tareas de Curación</message>
-<message key="xmlui.administrative.CurateForm.object_label_name">Dspaceko objektuaren handlea</message>
-<message key="xmlui.administrative.CurateForm.object_hint">Trukoa: sartu [aurrezenbakia-handle] /0 ataza zure instalazio osoan exekutatu ahal izateko (ataza guztiek ez dute aukera hori eskaintzen)</message>
-<message key="xmlui.administrative.CurateForm.task_label_name">Tarea</message>
+        <message key="xmlui.administrative.CurateForm.title">Tareas de Curación de Sistema</message>
+        <message key="xmlui.administrative.CurateForm.trail">Tareas de Curación</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Dspaceko objektuaren handlea</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Trukoa: sartu [aurrezenbakia-handle] /0 ataza zure instalazio osoan exekutatu ahal izateko (ataza guztiek ez dute aukera hori eskaintzen)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Tarea</message>
     <!-- Used by Curate<DSO>Form classes also -->
-<message key="xmlui.administrative.CurateForm.taskgroup_label_name">Aukeratu talde hauen artean</message>
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Aukeratu talde hauen artean</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1904,64 +2061,86 @@
                      Statistics Aspect
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-<message key="xmlui.statistics.title">Estatistikak</message>
-<message key="xmlui.statistics.search.title">Bilaketen estatistikak</message>
-<message key="xmlui.statistics.search.head">Bilaketen estatistikak</message>
-<message key="xmlui.statistics.search.head-dso">Bilaketen estatistikak {0}rako</message>
-<message key="xmlui.statistics.search.error">Errorea jazo da bilaketa-estatistikak sortzerakoan. Mesedez, saiatu geroago.</message>
-<message key="xmlui.statistics.search.no-results">No se dispone de estadísticas de búsquedas para el período seleccionado Ez dago bilaketa-estatistikarik aukeratutako aldirako.</message>
-<message key="xmlui.statistics.workflow.title">Lan-fluxuaren estatistikak</message>
-<message key="xmlui.statistics.visits.total">Bisita-kopuru totala</message>
-<message key="xmlui.statistics.visits.month">Hilabeteko bisita- kopurua</message>
-<message key="xmlui.statistics.visits.views">Bistaratze-kopurua</message>
-<message key="xmlui.statistics.visits.countries">Bistaratze gehien egiten diren herrialdeak</message>
-<message key="xmlui.statistics.visits.cities">Bistaratzen gehien egiten dire hiriak</message>
-<message key="xmlui.statistics.visits.bitstreams">Fitxategiaren bisita kopurua</message>
-<message key="xmlui.statistics.Navigation.title">Estatistikak</message>
-<message key="xmlui.statistics.Navigation.usage.view">Ikusi erabilearen inguruko estatistikak</message>
-<message key="xmlui.statistics.Navigation.search.view">Ikusi bilaketen estatistikak</message>
-<message key="xmlui.statistics.Navigation.workflow.view">Ikusi lan-fluxuaren estatistikak</message>
-<message key="xmlui.statistics.trail">Estatistikak</message>
-<message key="xmlui.statistics.trail-search">Bilaketen estatistikak</message>
-<message key="xmlui.statistics.trail-workflow">Lan-fluxuaren estatistikak</message>
-<message key="xmlui.statistics.workflow.no-results">Aukeratutako aldiari dagokion lan-fluxuaren estatistikarik ez dago..</message>
-<message key="xmlui.statistics.workflow.error">Errorea jazo da lan-fluxuaren estadistikak sortzerakoan. Mesedez, saiatu geroago.</message>
-<message key="xmlui.statistics.workflow.head">Lan-fluxuaren estatistikak</message>
-<message key="xmlui.statistics.workflow.head-dso">{0}-rako lan-fluxuaren estatistikak</message>
+    <message key="xmlui.statistics.title">Estatistikak</message>
+    <message key="xmlui.statistics.search.title">Bilaketen estatistikak</message>
+    <message key="xmlui.statistics.search.head">Bilaketen estatistikak</message>
+    <message key="xmlui.statistics.search.head-dso">Bilaketen estatistikak {0}rako</message>
+    <message key="xmlui.statistics.search.error">Errorea jazo da bilaketa-estatistikak sortzerakoan. Mesedez, saiatu geroago.</message>
+    <message key="xmlui.statistics.search.no-results">No se dispone de estadísticas de búsquedas para el período seleccionado Ez dago bilaketa-estatistikarik aukeratutako aldirako.</message>
+    <message key="xmlui.statistics.workflow.title">Lan-fluxuaren estatistikak</message>
+    <message key="xmlui.statistics.visits.total">Bisita-kopuru totala</message>
+    <message key="xmlui.statistics.visits.month">Hilabeteko bisita- kopurua</message>
+    <message key="xmlui.statistics.visits.views">Bistaratze-kopurua</message>
+    <message key="xmlui.statistics.visits.countries">Bistaratze gehien egiten diren herrialdeak</message>
+    <message key="xmlui.statistics.visits.cities">Bistaratzen gehien egiten dire hiriak</message>
+    <message key="xmlui.statistics.visits.bitstreams">Fitxategiaren bisita kopurua</message>
+    <message key="xmlui.statistics.Navigation.title">Estatistikak</message>
+    <message key="xmlui.statistics.Navigation.usage.view">Ikusi erabilearen inguruko estatistikak</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">Ikusi bilaketen estatistikak</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">Ikusi lan-fluxuaren estatistikak</message>
+    <message key="xmlui.statistics.trail">Estatistikak</message>
+    <message key="xmlui.statistics.trail-search">Bilaketen estatistikak</message>
+    <message key="xmlui.statistics.trail-workflow">Lan-fluxuaren estatistikak</message>
+    <message key="xmlui.statistics.workflow.no-results">Aukeratutako aldiari dagokion lan-fluxuaren estatistikarik ez dago..</message>
+    <message key="xmlui.statistics.workflow.error">Errorea jazo da lan-fluxuaren estadistikak sortzerakoan. Mesedez, saiatu geroago.</message>
+    <message key="xmlui.statistics.workflow.head">Lan-fluxuaren estatistikak</message>
+    <message key="xmlui.statistics.workflow.head-dso">{0}-rako lan-fluxuaren estatistikak</message>
 
-<message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Bilaketa-terminorik erabilienak</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Guztira</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Aurreko hiabetea</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">aurreko 6 hilabeteak</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Aurreko urtea</message>
-<message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Guztira</message>
 
-<message key="xmlui.statistics.display.table.column-label.search-terms">Bilaketa-terminoa</message>                   
-<message key="xmlui.statistics.display.table.column-label.searches">Bilaketak</message>
-<message key="xmlui.statistics.display.table.column-label.percent-total">% del total</message>
-<message key="xmlui.statistics.display.table.column-label.views-search">Ikusitako orrialdeak / Bilaketak</message>
-<message key="xmlui.statistics.display.table.column-label.step">Urratsa</message>
-<message key="xmlui.statistics.display.table.column-label.performed">Burutua</message>
-<message key="xmlui.statistics.display.table.column-label.average">Media</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Etaparen poola Onartu/Ezetsi Etaparen poola Onartu/Ezetsi</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP1">Etapa/Onartu/Ezetsi</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Pool de Etapa de Aceptación/Rechazo/Editar Metadatos Onarpen-etaparen poola/Ezespena/Editatu metadatuak</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP2">Etapa Aceptar/Rechazar/Editar metadatos Etapa/Onartu/Ezetsi/Editatu metadatuak</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Metadatuak editatzeko urratsaren taldea</message>
-<message key="xmlui.statistics.display.table.workflow.step.STEP3">Metadatuak editatzeko urratsa</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Etaparen poola Onartu/Ezetsi</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Etapa Onartu/Ezetsii</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Etaparen poola Onartu/Ezetsi/Metadatuak editatu</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Etapa Onartu/Ezetsi/Editatu metadatuak</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Metadatuak editatzeko urratsaren taldea</message>
-<message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Metadatuak editatzeko urratsa</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Berrikuspenaren poola puntuazioarekin</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Berrikuspena puntuazioarekin</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Ebaluatu puntuazioaren bidezko berrikuspenaren arabera</message>
-<message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Puntuazioaren bidezko berrikuspenaren araberako ebaluazioaren konfigurazioa</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Erabiltzailearen araberako berrikuspenaren poola.</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Erabiltzailearren araberako autoasignazioaren ekintza</message>
-<message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Erabiltzailearen arabereako berrikuspenaren ekintza</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Bilaketa-terminorik erabilienak</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Guztira</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Aurreko hiabetea</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">aurreko 6 hilabeteak</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Aurreko urtea</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Guztira</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Bilaketa-terminoa</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Bilaketak</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% del total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Ikusitako orrialdeak / Bilaketak</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Urratsa</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Burutua</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Media</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Etaparen poola Onartu/Ezetsi Etaparen poola Onartu/Ezetsi</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Etapa/Onartu/Ezetsi</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Pool de Etapa de Aceptación/Rechazo/Editar Metadatos Onarpen-etaparen poola/Ezespena/Editatu metadatuak</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Etapa Aceptar/Rechazar/Editar metadatos Etapa/Onartu/Ezetsi/Editatu metadatuak</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Metadatuak editatzeko urratsaren taldea</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Metadatuak editatzeko urratsa</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Etaparen poola Onartu/Ezetsi</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Etapa Onartu/Ezetsii</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Etaparen poola Onartu/Ezetsi/Metadatuak editatu</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Etapa Onartu/Ezetsi/Editatu metadatuak</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Metadatuak editatzeko urratsaren taldea</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Metadatuak editatzeko urratsa</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Berrikuspenaren poola puntuazioarekin</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Berrikuspena puntuazioarekin</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Ebaluatu puntuazioaren bidezko berrikuspenaren arabera</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Puntuazioaren bidezko berrikuspenaren araberako ebaluazioaren konfigurazioa</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Erabiltzailearen araberako berrikuspenaren poola.</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Erabiltzailearren araberako autoasignazioaren ekintza</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Erabiltzailearen arabereako berrikuspenaren ekintza</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1971,186 +2150,193 @@
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
+
+
+
 	<!-- structural.xsl -->
-<message key="xmlui.dri2xhtml.structural.footer-promotional">
+	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo"></span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-XMLUI, una interfaz para Dspace creada por Texas A&amp;M University Libraries. 
-Para más infomación, visite XMLUI, Texas AM University Libraries-ek Dspacerako sortutako interfazea. Informazio gehiago nahi baduzu, bisitatu XMLUI
-        
-   <a href="http://di.tamu.edu">http://di.tamu.edu</a>y
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
-		</p></message>
-<message key="xmlui.dri2xhtml.structural.contact-link">Kontaktua</message>
-<message key="xmlui.dri2xhtml.structural.feedback-link">Iradokizunak</message>
+		</p>
+	</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Kontaktua</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Iradokizunak</message>
 
-<message key="xmlui.dri2xhtml.structural.head-subtitle">EIMA Gordailua</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">EIMA Gordailua</message>
 
-<message key="xmlui.dri2xhtml.structural.profile">Profila:</message>
-<message key="xmlui.dri2xhtml.structural.logout">Irten</message>
-<message key="xmlui.dri2xhtml.structural.login">Nire Dspace</message>
+	<message key="xmlui.dri2xhtml.structural.profile">Profila:</message>
+	<message key="xmlui.dri2xhtml.structural.logout">Irten</message>
+	<message key="xmlui.dri2xhtml.structural.login">Nire Dspace</message>
 
-<message key="xmlui.dri2xhtml.structural.search">Bilatu Gordailuan</message>
-<message key="xmlui.dri2xhtml.structural.search-advanced">Bilaketa aurreratua</message>
-<message key="xmlui.dri2xhtml.structural.search-in-community">Komunitate honetan</message>
-<message key="xmlui.dri2xhtml.structural.search-in-collection">Bilduma honetan</message>
+	<message key="xmlui.dri2xhtml.structural.search">Bilatu Gordailuan</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Bilaketa aurreratua</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Komunitate honetan</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">Bilduma honetan</message>
 
-<message key="xmlui.dri2xhtml.structural.pagination-previous">Aurrekoa</message>
-<message key="xmlui.dri2xhtml.structural.pagination-info">{2}-tik {0}-{1} emaitza erakusten</message>
-<message key="xmlui.dri2xhtml.structural.pagination-next">Hurrengoa</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Aurrekoa</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">{2}-tik {0}-{1} emaitza erakusten</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Hurrengoa</message>
 
-<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-<message key="xmlui.dri2xhtml.structural.link_original_license">Jatorrizko baimena</message>
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Jatorrizko baimena</message>
 
 
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Aurrebista ez dago erabilgarri</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-title">Izenbururik gabea</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-author">Egile ezezaguna</message>
-<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Hau ez da METS1.0 profilarekin bat datorren Dspace-objektu bat eta, beraz, ezin da behar bezala interpretatua izan.   Beharrezkoa den funtzioa hobetzeko, dri2xhtml kasu orokorra kudeatzen duen txantiloia ordezkatu dezakezu edo sortu dezakezu erabilitako profilarekin bat datorren txantiloi bat.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Aurrebista ez dago erabilgarri</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Izenbururik gabea</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Egile ezezaguna</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Hau ez da METS1.0 profilarekin bat datorren Dspace-objektu bat eta, beraz, ezin da behar bezala interpretatua izan.   Beharrezkoa den funtzioa hobetzeko, dri2xhtml kasu orokorra kudeatzen duen txantiloia ordezkatu dezakezu edo sortu dezakezu erabilitako profilarekin bat datorren txantiloi bat.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Aurrebista</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-title">Izenburua</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-author">Egilea</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Laburpena</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-description">Deskribap</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editorea</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Aurrebista</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Izenburua</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Egilea</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Laburpena</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Deskribap</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editorea</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Item honetako fitxategiak</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxategiak</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Izena</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaina</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formatua</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ikusi</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Deskribap</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ikusi/<wbr></wbr>Ireki</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Item honek ez dauka asoziatutako fitxategirik.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Item honetako fitxategiak</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fitxategiak</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Izena</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaina</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formatua</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ikusi</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Deskribap</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ikusi/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Item honek ez dauka asoziatutako fitxategirik.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.license-text">El ítem tiene asociados los siguientes ficheros de licencia Item honek honako baimen-fitxategi hauek dauzka asoziatuta:</message>
-<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Bestelakorik adierazi ezean, itemaren baimena horrela deskribatzen da:</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">El ítem tiene asociados los siguientes ficheros de licencia Item honek honako baimen-fitxategi hauek dauzka asoziatuta:</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Bestelakorik adierazi ezean, itemaren baimena horrela deskribatzen da:</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Bildumaren laburpen-ikuspegia une honetan ez dago erabilgarri edo inplementaturik. Arazo hau konpon daiteke collectionSummaryView izeneko dri2xhtml txantiloia berridatziz.</message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">Komunitatearen laburpen-ikuspegia une honetan ez dago erabilgarri edo inplementaturik. Arazo hau konpon daiteke collectionSummaryView izeneko dri2xhtml txantiloia berridatziz.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Bildumaren laburpen-ikuspegia une honetan ez dago erabilgarri edo inplementaturik. Arazo hau konpon daiteke collectionSummaryView izeneko dri2xhtml txantiloia berridatziz.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">Komunitatearen laburpen-ikuspegia une honetan ez dago erabilgarri edo inplementaturik. Arazo hau konpon daiteke collectionSummaryView izeneko dri2xhtml txantiloia berridatziz.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Bildumaren logoa</message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Komunitatearen logoa</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Logorik gabe</message>
-<message key="xmlui.dri2xhtml.METS-1.0.news">Berriak</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Bildumaren logoa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Komunitatearen logoa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Logorik gabe</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Berriak</message>
 
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Une honetan ezin zaie aplikatu Dspaceko komunitate eta bildumeei Qualified Dublin Corea (QDC). QDCa erabiltzen denean Dspaceko elementuetarako, crosswalks QDCa erabiltzea gomendatzen da edo DIM edo MODS erabiltzea komunitate eta bildumak prozesatzeko.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Une honetan ezin zaie aplikatu Dspaceko komunitate eta bildumeei Qualified Dublin Corea (QDC). QDCa erabiltzen denean Dspaceko elementuetarako, crosswalks QDCa erabiltzea gomendatzen da edo DIM edo MODS erabiltzea komunitate eta bildumak prozesatzeko.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dubllin Core elementuak</message>
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terminoak</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dubllin Core elementuak</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terminoak</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
 
 	<!-- Special pioneer model related text, wherever it might end up -->
-<message key="xmlui.dri2xhtml.pioneer.preview">Aurrebista</message>
-<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
-<message key="xmlui.dri2xhtml.pioneer.title">Izenburua</message>
-<message key="xmlui.dri2xhtml.pioneer.author">Egilea</message>
+	<message key="xmlui.dri2xhtml.pioneer.preview">Aurrebista</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Izenburua</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Egilea</message>
 
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
-<message key="xmlui.dri2xhtml.default.textarea.value"></message>
+	<message key="xmlui.dri2xhtml.default.textarea.value"/>
 
   <!--###### File Format MIME Type Mappings ######-->
 
   <!-- Application-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.application/marc">MARC erregistroa</message>
-<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Matematika</message>
-<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-<message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Ezezaguna</message>
-<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">MARC erregistroa</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Matematika</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Ezezaguna</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
   <!-- Audio-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
 
   <!-- Image-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.image/gif">GIF irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jp2">JPEG 2000 irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jpeg">JPEG irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/png">PNG irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/tiff">TIFF irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP irudia</message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">GIF irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">JPEG 2000 irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">JPEG irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">PNG irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">TIFF irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP irudia</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
 
   <!-- Text-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.text/css">CSS fitxategia</message>
-<message key="xmlui.dri2xhtml.mimetype.text/csv">CSV fitxategia</message>
-<message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-<message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-<message key="xmlui.dri2xhtml.mimetype.text/plain">Testu-fitxategia</message>
-<message key="xmlui.dri2xhtml.mimetype.text/richtext">RTF fitxategia</message>
-<message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/css">CSS fitxategia</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">CSV fitxategia</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Testu-fitxategia</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">RTF fitxategia</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
   <!-- Video-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.video/avi">AVI bideoa</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG bideoa</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 bideoa</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 bideoa</message>
-<message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime bideoa</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">AVI bideoa</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG bideoa</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 bideoa</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 bideoa</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime bideoa</message>
 
   <!-- explanatory messages for choice authority confidence values -->
-<message key="xmlui.authority.confidence.description.cf_unset">Ez da eratu balio honetarako konfidantzarik</message>
-<message key="xmlui.authority.confidence.description.cf_novalue">Autoritateak ez du itzili arrazoizkoa den konfiantza-balorerik</message>
-<message key="xmlui.authority.confidence.description.cf_rejected">Autoritateen kontrolak gomendatzen du bidalketa hau ezestea</message>
-<message key="xmlui.authority.confidence.description.cf_failed">Autoritateen kontrolak barne-errorea aurkitu du</message>
-<message key="xmlui.authority.confidence.description.cf_notfound">Ez dago autoritatearekin bat datorren emaitzarik</message>
-<message key="xmlui.authority.confidence.description.cf_ambiguous"></message>
-<message key="xmlui.authority.confidence.description.cf_uncertain">El valor es único y válido, pero no ha sido visto ni aceptado por ningún usuario por lo que es aún incierto Balioa bakarra eta baliagarria da, baina oraindik ez-ziurra da. Izan ere,  oraindik ez dago bera ikusi eta onartu duen erabiltzailerik.</message>
-<message key="xmlui.authority.confidence.description.cf_accepted">Erabiltzaile batek berretsi du autoritate-balio honen baliozkotasuna</message>
+  <message key="xmlui.authority.confidence.description.cf_unset">Ez da eratu balio honetarako konfidantzarik</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">Autoritateak ez du itzili arrazoizkoa den konfiantza-balorerik</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">Autoritateen kontrolak gomendatzen du bidalketa hau ezestea</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">Autoritateen kontrolak barne-errorea aurkitu du</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">Ez dago autoritatearekin bat datorren emaitzarik</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous"/>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">El valor es único y válido, pero no ha sido visto ni aceptado por ningún usuario por lo que es aún incierto Balioa bakarra eta baliagarria da, baina oraindik ez-ziurra da. Izan ere,  oraindik ez dago bera ikusi eta onartu duen erabiltzailerik.</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">Erabiltzaile batek berretsi du autoritate-balio honen baliozkotasuna</message>
   <!-- help message on "unlock" button in EditItemMetadata display -->
-<message key="xmlui.authority.confidence.unlock.help">Desblokeatu eskuzko edizioa egiteko Autoritatearen klabearen balioa, edo aldatu berriro blokeatu ahal izateko</message>
+  <message key="xmlui.authority.confidence.unlock.help">Desblokeatu eskuzko edizioa egiteko Autoritatearen klabearen balioa, edo aldatu berriro blokeatu ahal izateko</message>
 
   <!-- Choice Lookup popup window -->
   <!-- NOTE: These messages necessarily use a *different* format for
@@ -2158,107 +2344,141 @@ Para más infomación, visite XMLUI, Texas AM University Libraries-ek Dspacerako
      - JavaScript (AJAX) that completes the lookup popup window.
      - So, positional parameters are @1@, @2@, etc.
     -->
-<message key="xmlui.ChoiceLookupTransformer.title">Dspaceko bilaketaren balioa</message>
-<message key="xmlui.ChoiceLookupTransformer.accept">Onartu</message>
-<message key="xmlui.ChoiceLookupTransformer.add">Erantsi</message>
-<message key="xmlui.ChoiceLookupTransformer.cancel">Utzi</message>
-<message key="xmlui.ChoiceLookupTransformer.more">Ver más resultados Ikusi emaitza gehiago</message>
+  <message key="xmlui.ChoiceLookupTransformer.title">Dspaceko bilaketaren balioa</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Onartu</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Erantsi</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Utzi</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">Ver más resultados Ikusi emaitza gehiago</message>
   <!-- params are: start, end, total-count, search-value -->
-<message key="xmlui.ChoiceLookupTransformer.results">"@4@"rako emaitzak @1@-tik @2@-ra @3@ guztira</message>
-<message key="xmlui.ChoiceLookupTransformer.fail">Ezin izan dira kargatu aukeraketaren datuak:</message>
+  <message key="xmlui.ChoiceLookupTransformer.results">"@4@"rako emaitzak @1@-tik @2@-ra @3@ guztira</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Ezin izan dira kargatu aukeraketaren datuak:</message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Editorearen izena</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Bilatu editorea</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Editorearen izena</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Bilatu editorea</message>
   <!-- Params are: search-value -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Ez da Autoritate-balioa: @1@</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Ez da Autoritate-balioa: @1@</message>
 
   <!-- Choice Lookup - sample config for dc.contributor.author field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Izenaren formatua: “Abizena, Izena”</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Abizena, adibib. “López”</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Izena(k), adibib. “Alfredo”</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Egileen bilaketa LC Name Authorithyn</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local "@1@" (no se encuentra en la Autoridad) G</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Izenaren formatua: “Abizena, Izena”</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Abizena, adibib. “López”</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Izena(k), adibib. “Alfredo”</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Egileen bilaketa LC Name Authorithyn</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local "@1@" (no se encuentra en la Autoridad) G</message>
 
-     <!-- mobile theme -->
-<message key="xmlui.mobile.home_mobile">Dspace mugikorra</message>
-<message key="xmlui.mobile.search_all">Bilatu GUZTIA</message>
-<message key="xmlui.mobile.browse_all">Zerrendatu GUZTIA honako honen arabera</message>
-<message key="xmlui.mobile.browse_date">Data</message>
-<message key="xmlui.mobile.browse_author">Egilea</message>
-<message key="xmlui.mobile.browse_title">Izenburua</message>
-<message key="xmlui.mobile.browse_subject">Materia</message>
-<message key="xmlui.mobile.related_google_scholar">Erlazionatuta</message>
-<message key="xmlui.mobile.items_in_google_scholar">Itemak Google Scholaren</message>
-<message key="xmlui.mobile.download">Descargar Deskargatu</message>
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">Dspace mugikorra</message>
+  <message key="xmlui.mobile.search_all">Bilatu GUZTIA</message>
+  <message key="xmlui.mobile.browse_all">Zerrendatu GUZTIA honako honen arabera</message>
+  <message key="xmlui.mobile.browse_date">Data</message>
+  <message key="xmlui.mobile.browse_author">Egilea</message>
+  <message key="xmlui.mobile.browse_title">Izenburua</message>
+  <message key="xmlui.mobile.browse_subject">Materia</message>
+  <message key="xmlui.mobile.related_google_scholar">Erlazionatuta</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Itemak Google Scholaren</message>
+  <message key="xmlui.mobile.download">Descargar Deskargatu</message>
+
 
     <!-- Versioning -->
-<message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Sortu item honen bertsioa</message>
-<message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Ikusi bertsioen historiala</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Sortu item honen bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Ikusi bertsioen historiala</message>
 
-<message key="xmlui.aspect.versioning.VersionItemForm.title">Sortu bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.trail">Bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.head1">Sortu item honen bertsio berri bat: {0}</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Eguneratu bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionItemForm.summary">Bertsio berria sortzeko arrazoia</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Sortu bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Sortu item honen bertsio berri bat: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Eguneratu bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Bertsio berria sortzeko arrazoia</message>
 
-<message key="xmlui.aspect.versioning.VersionUpdateForm.title">Eguneratu bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Eguneratu item honen bertsioa: {0}</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Eguneratu bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Resumen</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Eguneratu bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Eguneratu item honen bertsioa: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Eguneratu bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Resumen</message>
 
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Berretsi ezabaketa</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Berretsi ezabaketa</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Berretsi ezabaketa(k)</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Ziur al zaude bertsio hauek ezabatu nahi dituzula?</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">OHARRA: bertsio hauek ezabatuz gero, asoziatutako itemak ez dira eskuragarri egongo.</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Bertsioa</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Itema</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editorea</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Data</message>
-<message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Laburpena</message>
 
-<message key="xmlui.aspect.versioning.RestoreVersionForm.title">Leheneratu bertsioa</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Leheneratu bertsioa</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Lehenartu bertsioa</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.para1">ziur al zaude bertsio hau leheneratu nahi duzula?:</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Bertsioa</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editorea</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Data</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Laburpena</message>
-<message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Leheneratu</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Berretsi ezabaketa</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Berretsi ezabaketa</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Berretsi ezabaketa(k)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Ziur al zaude bertsio hauek ezabatu nahi dituzula?</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">OHARRA: bertsio hauek ezabatuz gero, asoziatutako itemak ez dira eskuragarri egongo.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Itema</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editorea</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Data</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Laburpena</message>
 
-<message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Bertsioen historiala</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Itema</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editorea</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Data</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Laburpena</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Ekintzak</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Leheneratu</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.update">Eguneratu</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Aukeratutako bertsioa</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Ezabatu bertsioak</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.return">Itzuli</message>
-<message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">( soilik bilduma-administratzaileak)</message>
 
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Oharra</message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Hau ez da item honen azken bertsioa. Azken bertsioa hemen dago:</message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Oharra</message>
-<message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Item honen bertsio berriago bat lan-fluxuan dago.</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Leheneratu bertsioa</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Leheneratu bertsioa</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Lehenartu bertsioa</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">ziur al zaude bertsio hau leheneratu nahi duzula?:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editorea</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Data</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Laburpena</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Leheneratu</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Bertsioen historiala</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Itema</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editorea</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Data</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Laburpena</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Ekintzak</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Leheneratu</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Eguneratu</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Aukeratutako bertsioa</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Ezabatu bertsioak</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Itzuli</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">( soilik bilduma-administratzaileak)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Oharra</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Hau ez da item honen azken bertsioa. Azken bertsioa hemen dago:</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Oharra</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Item honen bertsio berriago bat lan-fluxuan dago.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
-    <!--Metadata descriptions by Tomas-->                                                                                                                                    
-    <message key="metadata.dc.type">Material mota</message>                                                                                                                  
-    <message key="metadata.dc.publisher">Argitalpena</message>                                                                                                               
-    <message key="metadata.dc.description">Deskribap</message>                                                                                                            
-    <message key="metadata.dc.subject">Gaia(k)</message>                                                                                                                     
-    <message key="metadata.dc.description.abstract">Laburpena</message>
-    <message key="metadata.dcterms.educationLevel">Adina / Maila</message>
-    <message key="metadata.dc.identifier.citation">EIMA Katalogoan</message>
-    <!--/ Metadata descriptions by Tomas-->
 
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_fi.xml
+++ b/src/main/webapp/i18n/messages_fi.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0"?>
-<!--
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="fi" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -77,31 +68,56 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-	          ArtifactBrowser Aspect
-        NOTE: As of DSpace 6.0, the ArtifactBrowser Aspect was removed (in favor
-        of the ViewArtifacts, BrowseArtifacts and SearchArtifacts aspects). 
-        However, many of its classes and corresponding i18n keys still exist as 
-        they are used by other aspects.
-	!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-        <!-- Note: As of DSpace 6.0, org.dspace.app.xmlui.aspect.artifactbrowser.AbstractSearch has been removed. -->
-        <!-- The following keys are still in use by Discovery's AbstractSearch -->
-	
-        <message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Ei tuloksia.</message>
+
+		             ArtifactBrowser Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Search Results for Community: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Search Results for Collection: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Search Results</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Your query "{0}" produced {1} result(s).</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Communities or Collections matching your query</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Items matching your query</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Ei tuloksia.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Kaikki aineistot</message>
 
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">title</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">issue date</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">submit date</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">relevance</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Sort items by</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">in order</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascending</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descending</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Results/page</message>
+
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <!-- Note: As of DSpace 6.0, org.dspace.app.xmlui.aspect.artifactbrowser.AdvancedSearch has been removed. -->
-    <!-- The following "type_*" i18n keys will be left as is as they're referenced by the Discovery's SidebarFacetsTransformer
-         but in future, they should be refactored to a more relevant key prefix -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Tekijä</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Nimeke</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Asiasana</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Abstrakti</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sarja</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Rahoittaja</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Tunniste</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Kielikoodi (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Avainsana</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Advanced Search</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Advanced Search</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Advanced Search</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Search scope</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limit your search to a community or collection.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjunction</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Search type</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Search for</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Tekijä</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Nimeke</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Asiasana</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Abstrakti</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Sarja</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Rahoittaja</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Tunniste</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Kielikoodi (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Avainsana</message>
+
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Avustaja</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Tekijä</message>
@@ -113,6 +129,10 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Laitos</message>
 
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Kokoteksti</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
+
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Tai anna muutama alkukirjain:</message>
@@ -241,9 +261,6 @@
         <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Aineisto on poistettu käytöstä eikä ole enää saatavissa.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-        <!-- Note: As of DSpace 6.0, org.dspace.app.xmlui.aspect.artifactbrowser.Navigation has been removed. -->
-        <!-- The following i18n keys will be left as is as they're referenced by the Discovery's Navigation
-         but in future, they should be refactored to a more relevant key prefix -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Selaa</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Kaikki aineistot</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Yhteisöt ja kokoelmat</message>
@@ -256,9 +273,6 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Tämä yhteisö</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-        <!-- Note: As of DSpace 6.0, org.dspace.app.xmlui.aspect.artifactbrowser.SimpleSearch has been removed. -->
-        <!-- The following i18n keys will be left as is as they're referenced by the Discovery's SimpleSearch
-         but in future, they should be refactored to a more relevant key prefix -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Haku</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Haku</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Haku</message>
@@ -434,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Rekisteröityminen ei ole käytössä</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Rekisteröityminen ei ole käytössä</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Rekisteröityminen ei ole käytössä tässä DSpace-julkaisuarkistossa. Jos sinulla on kysyttävää, ota yhteyttä sivuston <a href="../contact">ylläpitäjään</a>.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Rekisteröityminen ei ole käytössä tässä DSpace-julkaisuarkistossa. Jos sinulla on kysyttävää, ota yhteyttä sivuston <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Päivitä tietoja</message>
@@ -632,13 +646,13 @@
 	<message key="xmlui.Submission.Submissions.title">Tallennus &amp; käsittely</message>
 	<message key="xmlui.Submission.Submissions.trail">Tallennukset</message>
 	<message key="xmlui.Submission.Submissions.head">Tallennukset &amp; käsittely</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Nimetön</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">sähköposti: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Tehtävät</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Aineisto pitää hyväksyä ennenkuin se liitetään kokoelmiin. Toisessa listassa näkyy aineisto, jonka olet ottanut hyväksyttäviksi, toisessa listassa on aineisto, joita kukaan ei ole vielä ottanut käsiteltäviksi.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Omat tehtävät</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Tehtävä</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Nimeke</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Kokoelma</message>
@@ -657,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Nämä ovat keskeneräisiä tallennuksia. Voit myös </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">aloittaa uuden nimekkeen tallennukset</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Nimeke</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Kokoelma</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Lähettäjä</message>
@@ -726,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Useita nimekkeitä</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Aineistolla on useita nimekkeitä, <i>esim. eri kielisiä nimekkeitä</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Aineistolla on useita nimekkeitä, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Jos ylläolevaa valintaruutua ei ole valittu, niin seuraavia tietoja ei kysytä: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Julkaistu</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Aineisto on julkaistu aiemmin jossain muussa yhteydessä</message>
@@ -739,8 +753,8 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Kuvaile aineisto</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Virhe: tuntematon kenttätyyppi</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Pakollinen kenttä</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Sukunimi, <i>esim. Virtanen</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Etunimet, <i>esim. Ville</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Sukunimi, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Etunimet, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Vuosi</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Kuukausi</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Päivä</message>
@@ -803,7 +817,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Tiedostoa ei ole ladattu, koska se näyttää olevan viruksen saastuttama. Ota yhteyttä järjestelmänvalvojaan.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Tiedoston virustarkastuksessa tapahtui virhe. Ota yhteyttä järjestelmänvalvojaan.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Tiedoston kuvaus</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>"Pääartikkeli"</i>, <i>"Tutkimusdata"</i>. Vapaaehtoinen tieto.</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Lataa tiedosto &amp; lisää uusi tiedosto</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Tiedostoja ladattu</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Ensisijainen</message>
@@ -812,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Koko</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Kuvaus</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Tiedostomuoto</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Tuntematon</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">tuntematon tiedostomuoto</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Tuettu)</message>
@@ -832,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Tiedostoa ei ole ladattu, koska se näyttää sisältävän viruksen. Ota yhteyttä järjestelmänvalvojaan.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Tiedoston virustarkastuksessa tapahtui virhe. Ota yhteyttä järjestelmänvalvojaan.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Tiedoston kuvaus</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>"Pääartikkeli"</i>, <i>"Tutkimusdata"</i>. Vapaaehtoinen tieto.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Lataa tiedosto &amp; lisää uusi tiedosto</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Tiedostoja ladattu</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Ensisijainen</message>
@@ -841,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Koko</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Kuvaus</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Tiedostomuoto</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Tuntematon</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">tuntematon tiedostomuoto</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Tuettu)</message>
@@ -857,14 +871,14 @@
 	<message key="xmlui.Submission.submit.EditFileStep.head">Muokkaa tiedostoa</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Tiedosto</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Tiedoston kuvaus</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>"Pääartikkeli"</i>, <i>"Tutkimusdata"</i>. Vapaaehtoinen tieto.</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Valitse tiedostomuoto allaolevasta luettelosta. Esim. "<i>Adobe PDF</i>" tai "<i>Microsoft Word</i>." <strong>Jos tiedostomuotoa ei ole luettelossa</strong>, kuvaile se luettelon allaolevaan kenttään.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Lyhyt kuvaus tiedoston sisällöstä. Esim. <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Valitse tiedostomuoto allaolevasta luettelosta. Esim. "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Tunnistettu tiedostomuoto</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Valittu tiedostomuoto</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Muu tiedostomuoto</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Jos tiedostomuoto ei ole ylläolevassa luettelossa, <strong>valitse "Muu tiedostomuoto"</strong> ja kuvaile tiedostomuoto allaolevaan kenttään.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Jos tiedostomuoto ei ole ylläolevassa luettelossa, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Muu tiedostomuoto</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Sovellus, jota on käytetty tiedoston luomiseen ja sovelluksen versionumero (esimerkiksi, "<i>ACMESoft SuperApp, versio 1.5</i>").</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Sovellus, jota on käytetty tiedoston luomiseen ja sovelluksen versionumero (esimerkiksi, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Tiedostoon pääsy</message>
@@ -889,7 +903,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Tapahtui virhe ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Lisensioi aineisto</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Voit halutessasi liittää aineistoon <a href="http://creativecommons.org/">Creative Commons</a>-lisenssin. <strong>Creative Commons-lisenssi määrittää miten aineistoa voi jatkokäyttää.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Voit halutessasi liittää aineistoon <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Valitse lisenssi</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Siirry Creative Commons-sivustolle valitsemaan lisenssi</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Lisenssin tyyppi</message>
@@ -899,7 +913,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Julkaisulisenssi</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Viimeinen askel:</strong> jotta aineisto voidaan tallentaa, sinun täytyy hyväksyä seuraavat ehdot.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Hyväksy julkaisulisenssi valitsemalla 'Hyväksyn lisenssin'; ja valitse sitten 'Valmis'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Jos sinulla on kysyttävää julkaisulisenssistä, ota yhteyttä ylläpitäjiin.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Julkaisulisenssi</message>
@@ -927,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Hyväksy</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Kun olet muokannut aineistoa, lisää se julkaisuarkistoon tästä.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Lisää arkistoon</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Kun olet tarkastanut aineiston, mutta sitä <strong>ei</strong> voi lisätä kokoelmiin, valitse "Hylkää". Tämän jälkeen voit kirjoittaa alkuperäiselle syöttäjälle viestin, jossa kerrotaan hylkäämisen syy ja mahdolliset korjauspyynnöt.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Kun olet tarkastanut aineiston, mutta sitä <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Hylkää</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Muokkaa aineiston metadataa.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Muokkaa metadataa</message>
@@ -1000,7 +1014,6 @@
         <message key="xmlui.administrative.Navigation.context_export_collection">Vie kokoelma</message>
         <message key="xmlui.administrative.Navigation.context_export_community">Vie yhteisö</message>
         <message key="xmlui.administrative.Navigation.context_export_metadata">Vie metadataa</message>
-        <message key="xmlui.administrative.Navigation.context_search_export_metadata">Vie hakumetadataa</message>
 
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Hallinnointi</message>
@@ -1018,8 +1031,8 @@
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Hallintanäkymä</message>
     <message key="xmlui.administrative.Navigation.statistics">Tilastot</message>
     <message key="xmlui.administrative.Navigation.administrative_batch_import">Tuo useita aineistoja (ZIP)</message>
-    <message key="xmlui.administrative.Navigation.administrative_import_metadata">Tuo metadataa</message>
-    <message key="xmlui.administrative.Navigation.administrative_curation">Kuratointitehtävät</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Tuo metadataa</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Kuratointitehtävät</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Omat viennit</message>
@@ -1052,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Käyttäjiä haetaan nimien tai sähköpostiosoitteiden perusteella</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Lista löydetyistä käyttäjistä. Jos haluat poistaa käyttäjän, valitse 'Poista käyttäjä'. Jos haluat muokata käyttäjää, valitse käyttäjän nimi tai sähköpostiosoite.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Hakutulokset</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">Id</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nimi</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Sähköposti</message>
@@ -1127,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Hae ryhmiä</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Ryhmiä haetaan niiden nimien perusteella</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Hakutulokset</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">Id</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nimi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Jäsenet</message>
@@ -1159,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">Id</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Sähköpostiosoite</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">Id</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Jäsenet</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Kokoelma</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">katso</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Jäsenet</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">Id</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nimi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Sähköpostiosoite</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">ryhmä: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Ryhmässä ei ole jäseniä.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[odottaa vahvistusta]</message>
@@ -1204,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Poista kenttiä</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Poista kenttiä</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Vahvista poisto</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Oletko <b>täysin</b> varma, että haluat poistaa nämä kentät? Jos kyseiset kentät ovat käytössä yhdenkään aineiston metadatassa, ei kenttiä voi poistaa. Sinun täytyy itse varmistaa, että kentät eivät ole käytössä missään aineistossa.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Oletko <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">VAROITUS: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Poisto aiheuttaa virheen, jos jonkin aineiston metadata käyttää kyseisiä kenttiä.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">Id</message>
@@ -1215,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Poista skeema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Poista skeema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Vahvista poisto</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Oletko <b>täysin</b> varma, että haluat poistaa tämän skeeman? Jos kyseinen skeema sisältää metadatakenttiä, jotka ovat käytössä yhdenkin aineiston metadatassa, ei skeemaa vo poistaa. Sinun täytyy itse varmistaa, että skeeman metadatakentät eivät ole käytössä missään aineistossa.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Oletko <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">VAROITUS: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Poisto aiheuttaa virheen, jos jonkin aineiston metadata käyttää kyseisen skeeman metadatakenttiä.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">Id</message>
@@ -1250,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadataskeema: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Tämä on metadataskeema "{0}". Voit lisätä uusia tai päivittää olemassaolevia metadatakenttiä. Voit myös poistaa kenttiä tai siirtää niitä toiseen skeemaan. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Skeeman metadatakentät</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">Id</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Kenttä</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Lisätietoja (TODO: Scope?)</message>
@@ -1277,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Tiedostomuotorekisteri</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Tässä tiedostomuotorekisterissä on luettelo tiedostomuodoista ja niille tukitasoista. Voit lisätä tai muokata tiedostomuotoja tällä työkalulla. Sisäiseen käyttöön merkityt tiedostomuodot eivät näy käyttäjille, mutta niitä voidaan käyttää ylläpidon apuna.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Lisää uusi tiedostomuoto</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">Id</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nimi</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME-tyyppi</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Tukitaso</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>sisäiseen käyttöön</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Tuntematon</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Tunnettu</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Tuettu</message>
@@ -1292,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadatarekisteri</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadatarekisteri</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Metadatarekisterissä on luettelo tässä julkaisuarkistossa käytössä olevista metadatakentistä. Kentät saattavat olla jaettuna eri skeemoihin. DSpace edellyttää hyväksytyn Dublin Core-skeeman käyttöä. Voit laajentaa Dublin Core-skeemaa lisäämällä yksittäisiä metadatakenttiä tai skeemoja rekisteriin.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">Id</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Nimiavaruus</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nimi</message>
@@ -1380,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Muokkaa käyttöoikeutta {0} {1}:lle {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Ryhmää ei valittu</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Toimintoa ei valittu</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">Id</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nimi</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Toiminnot</message>
@@ -1496,7 +1509,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Tiedosto</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Anna tiedostonimi. Jos valitset "Selaa", niin voit valita ladattavan tiedoston omalta tietokoneeltasi.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Kuvaus</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Voit halutessasi antaa lyhyen kuvauksen tiedostosta, esimerkiksi <i>Pääartikkeli</i>, tai <i>Tutkimusdata</i></message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Voit halutessasi antaa lyhyen kuvauksen tiedostosta, esimerkiksi <i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Lataa</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Tarvitset LISÄÄ ja KIRJOITA -käyttöoikeudet vähintään yhteen nippuun, jotta voit ladata uusia tiedostoja.</message>
 
@@ -1544,13 +1557,13 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">kyllä</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">ei</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Kuvaus</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Voit halutessasi antaa lyhyen kuvauksen tiedostosta, esimerkiksi <i>Pääartikkeli</i>, tai <i>Tutkimusdata</i></message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Valitse tiedostomuoto allaolevasta luettelosta, esimerkiksi "<i>Adobe PDF</i>" tai "<i>Microsoft Word</i>", <b>TAI</b> jos tiedostomuotoa ei ole luettelossa, kuvaile se allaolevaan kenttään.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Voit halutessasi antaa lyhyen kuvauksen tiedostosta, esimerkiksi <i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Valitse tiedostomuoto allaolevasta luettelosta, esimerkiksi "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Valittu tiedostomuoto</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Tiedostomuoto ei ole luettelossa</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Jos tiedostomuoto ei ole ylläolevassa luettelossa, <strong>valitse "Tiedostomuoto ei ole luettelossa"</strong> ja kuvaile se allaolevaan kenttään.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Jos tiedostomuoto ei ole ylläolevassa luettelossa, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Muu tiedostomuoto</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Sovellus, jota tiedoston luomisessa on käytetty ja sovelluksen versionumero (esimerkiksi, "<i>ACMESoft SuperApp versio 1.5</i>").</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Sovellus, jota tiedoston luomisessa on käytetty ja sovelluksen versionumero (esimerkiksi, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Tiedoston nimi</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Muuta tiedoston nimeä. Huomaa, että tämä muuttaa myös tiedostoon viittaavia URLeja, mutta myös vanhat URLit toimivat, jos tiedoston Id-numero ei muutu.</message>
 
@@ -1558,14 +1571,14 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Aineistoon kuuluvat tiedostot</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Aineistoon kuuluvat tiedostot</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Tiedostot</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nimi</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Kuvaus</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Tiedostomuoto</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Katso</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Järjestys</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Nippu: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (ensisijainen) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">katso</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Lataa uusi tiedosto</message>
@@ -1692,7 +1705,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Kokoelma: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Tällä työkalulla kokoelmien ylläpitäjät pystyvät liittämään aineistoja toisista kokoelmista tähän kokoelmaan. Voit etsiä aineistoja toisista kokoelmista ja liittää ne tähän kokoelmaan tai selata luetteloa tähän kokoelmaan liitetyistä aineistoista.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Tilastot</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0}/{1}</strong> aineistoa tässä kokoelmassa on liitetty tänne toisista kokoelmista</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Hae</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Hae aineistoja</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Selaa liitettyjä aineistoja</message>
@@ -1703,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Hae aineistoja</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Hae aineistoja ehdolla: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Liitä valitut aineistot</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Kokoelma</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Tekijä</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Nimeke</message>
@@ -1713,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Selaa liitettyjä aineistoja</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Selaa liitettyjä aineistoja</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Poista valittujen aineistojen liitokset</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Kokoelma</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Tekijä</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Nimeke</message>
@@ -1752,9 +1765,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Vaihe: Muokkaa metadataa</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Syöttäjät</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Oletuslukuoikeudet</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(vain ylläpitäjät)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(koko arkiston tason ryhmä, vain ylläpitäjät)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(et voi muuttaa tätä)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Kuratoi kokoelmaa: {0}</message>
@@ -1797,7 +1810,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Poista logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Poista kokoelma</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Tallenna muutokset</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(vain järjestelmänvalvojat)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Luo kokoelma</message>
@@ -1854,7 +1867,6 @@
 	<message key="xmlui.administrative.ControlPanel.option_harvest">Kerääminen</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Keräämisen aikataulumääritykset</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Tila</message>
-        <message key="xmlui.administrative.ControlPanel.harvest_status_refresh">(päivitä)</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Toiminnot</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Aloita kerääminen</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Palauta keräämistila alkuasetuksiin</message>
@@ -1892,7 +1904,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Rooliin liittyvä ryhmä</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Ylläpitäjät</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(vain järjestelmänvalvojat)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Kuratoi yhteisöä: {0}</message>
@@ -1986,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Palautteen saaja</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Sivuston ylläpidon sähköpostiosoite</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Järjestelmän hälytykset</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Huomio! Kuormantasatuissa järjestelmissä</strong>: Hälytykset ovat voimassa vain siinä palvelinsolmussa, jossa ne on asetettu päälle. Hälytykset pitää aktivoida jokaisessa palvelinsolmussa erikseen.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Hälytysviesti</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Järjestelmä sulkeutuu huoltotoimenpiteitä varten. Tallenna työsi ja kirjaudu ulos.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Laskuri</message>
@@ -2000,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Salli edelleen kirjautuneet istunnot</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Estä kirjautuminen, mutta nykyiset istunnot</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Estä kirjautuminen ja lopeta nykyiset istunnot</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Huom:</strong> Istuntojen hallinta ei vaikuta järjestelmänvalvojan istuntoihin.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktivoi</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Deaktivoi</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Sivuston käyttö (korkeintaan {0} sivua)</message>
@@ -2015,23 +2027,11 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Selain (User-Agent)</message>
 	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Nimetön {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Sivunäyttöjä ei ole tallennettu.</message>
-        <message key="xmlui.administrative.ControlPanel.detail">Yksityiskohdat</message>
-	<message key="xmlui.administrative.ControlPanel.show_hide">piilota/näytä</message>
-	<message key="xmlui.administrative.ControlPanel.host">Palvelin: {0}</message>
-	<message key="xmlui.administrative.ControlPanel.puser">Pääasiallinen käyttäjä: {0}</message>
-	<message key="xmlui.administrative.ControlPanel.headers">Otsakkeet (headers): {0}</message>
-	<message key="xmlui.administrative.ControlPanel.cookies">Evästeet (cookies): {0}</message>
 
 	<message key="xmlui.administrative.ControlPanel.select_panel">Valitse välilehdiltä haluttu tieto</message>
 
-	<message key="xmlui.administrative.ControlPanel.tabs.Java Information">Tietoa Javasta</message>
-	<message key="xmlui.administrative.ControlPanel.tabs.Configuration">Asetukset</message>
-	<message key="xmlui.administrative.ControlPanel.tabs.SystemWide Alerts">Järjestelmän hälytykset</message>
-	<message key="xmlui.administrative.ControlPanel.tabs.Harvesting">Kerääminen</message>
-	<message key="xmlui.administrative.ControlPanel.tabs.Current Activity">Nykyinen käyttö</message>
-
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>{0} minuutin päästä</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Ei pääsyä</message>
@@ -2152,13 +2152,13 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Tämä sivusto käyttää Manakinia, uutta DSpace-käyttöliittymää, jonka ovat tehneet Texas A&amp;M yliopiston
-			kirjastot. Käyttöliittymää voi muokata Manakinin näkymien XSL-teemojen avulla. 
-			Lisätietoja
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> ja
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
@@ -2213,7 +2213,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Tiedostomuoto</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Katso</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Kuvaus</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Katso/<wbr/>Avaa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Katso/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Aineistoon ei liity tiedostoja.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">tavua</message>
@@ -2362,7 +2362,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Tulokset @1@ - @2@ / @3@ haulle "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Valintojen lataaminen epäonnistui: </message>
-  <message key="xmlui.ChoiceLookupTransformer.lookup">Haku</message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Hae</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Julkaisijan nimi</message>
@@ -2450,7 +2450,7 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Huomautus</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Uudempi versio aineistosta on työnkulussa.</message>
 
-    <message key="xmlui.aspect.sherpa.submission.consult">Tarkasta julkaisijan tai julkaisun tekijänoikeus- ja rinnakkaistallennuspolitiikka <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>sta.</message>
+    <message key="xmlui.aspect.sherpa.submission.consult">Tarkasta julkaisijan tai julkaisun tekijänoikeus- ja rinnakkaistallennuspolitiikka <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
     <message key="xmlui.aspect.sherpa.submission.title">Julkaisijan tiedot</message>
     <message key="xmlui.aspect.sherpa.submission.journal">Lehti: </message>
     <message key="xmlui.aspect.sherpa.submission.publisher">Julkaisijan tiedot: </message>
@@ -2491,288 +2491,4 @@
     <message key="xmlui.mirage2.choice-authority-control.loading">Lataa...</message>
 
     <message key="xmlui.mirage2.item-list.thumbnail">Pikkukuva</message>
-
-    <!-- org.dspace.app.xmlui.Submission.submit.StartSubmissionLookupStep -->
-    <message key="xmlui.Submission.submit.StartSubmissionLookupStep.submit_lookup">Hae</message>
-    <message key="xmlui.Submission.submit.StartSubmissionLookupStep.title">Julkaisuhaku</message>
-    <message key="xmlui.Submission.submit.StartSubmissionLookupStep.lookup_help">Täytä julkaisun ID, DOI, nimeke tai tekijä ja paina 'Hae'. Saat luettelon hakuehdot täyttävistä julkaisuista ja voit jatkaa tallennusta.</message>
-    <message key="xmlui.Submission.submit.StartSubmissionLookupStep.submit_publication_item">Haettu julkaisuhistoria</message>
-    <message key="xmlui.Submission.submit.progressbar.lookup">Hae</message>
-    <message key="xmlui.ChoiceLookupTransformer.lookup">Hae</message>
-
-    <!--
-	*** KEYS NOT ORIGINALLY IN THE messages.xml FILE ***
-	*** see ORIGINAL FILE for origin                 ***
-    -->
-	
-    <!-- *** ORIGINAL FILE DSpace/dspace-xmlui/src/main/resources/aspects/Discovery/i18n/messages.xml  -->
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <!-- Note: As of DSpace 6.0, org.dspace.app.xmlui.aspect.artifactbrowser.AdvancedSearch has been removed.
-         The following i18n keys will be left as is as they're referenced by the Discovery SidebarFacetsTransformer
-         but in future, they should be refactored to a more relevant key prefix -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Tekijä</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Asiasana</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Sisällön tyyppi</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Julkaisupäivä</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Julkaisupäivä</message>
-    
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_has_content_in_original_bundle">Sisältää tiedosot</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.value_has_content_in_original_bundle_true">Kyllä</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.value_has_content_in_original_bundle_false">Ei</message>
-
-
-    <!-- Site Level Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Viimeksi lisätty</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Näytä lisää</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: viimeistä lisäystä</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Viimeiset lisäykset</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Viimeksi lisätty</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Tyyppi</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Julkaisija</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Kuuluu</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Tulosten järjestäminen</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Ei järjestetty</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Julkaisu</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Yhteisö</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Kokoelma</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Sarja</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Selaus tekijän mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Selaus nimekkeen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Selaus asiasanan mukaan</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Selaus yhteenvedon mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Selaus sarjan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Selaus rahoittajan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Selaus tunnisteen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Selaus ISO-kielikoodin mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Selaus avainsanan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Selaus tieteellisen nimen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Selaus myötävaikuttajan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Selaus tekijän mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Selaus asiasanan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Selaus kuvauksen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Selaus suhteen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Selaus Mime-tyypin mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Selaus muun myötävaikuttajan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Selaus ohjaajan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Selaus laitoksen mukaan</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Selaus julkaisupäivän mukaan</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Nimeke</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">JulkaisupäiväDate issued</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.has_content_in_original_bundle">Sisältää tiedostot</message>
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Näytetään aineistot {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Suodata tekijän mukaan</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Tekijä</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Tekijä</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Suodata asiasanan mukaan</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Asiasana</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Asiasana</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Julkaisupäivä</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Alkaa kirjaimilla</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Syötä muutama kirjain alusta:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Lajitteluvaihtoehdot:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Merkittävyys</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Nimeke (laskeva)</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Julkaisupäivä (laskeva)</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Nimeke (nouseva)</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Julkaisupäivä (nouseva)</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Tuloksia per sivu:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Lisää suodatin</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Ota käyttöön</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Poista</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Uudet suodattimet:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Nykyiset suodattimet:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Lisää suodatin</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">Arvoja ei löytynyt</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Löydä</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... Näytä lisää</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Haku</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Haku</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Suodattimet</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Käytä suodattimia tulosten karsintaan.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">sisältää</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">on</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">ei sisällä</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">ei ole</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">ei-ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Samankaltainen aineisto</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Näytetään aineistoa, joilla on samankaltaisia nimekkeitä, tekijöitä tai asiasanoija.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Näytetään {0}/{1} tulosta yhteisöstä: {2}. <span class="searchTime">({3} sekuntia)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_collection">Näytetään {0}/{1} tulosta kokoelmasta: {2}. <span class="searchTime">({3} sekuntia)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Näytetään {0}/{1} tulosta. <span class="searchTime">({2} sekuntia)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Yhteisöt ja kokoelmat, jotka täyttävät hakuehtosi</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Aineistot, jotka täyttävät hakuehtosi</message>
-	
-    <message key="xmlui.Discovery.SimpleSearch.did_you_mean">Tarkoititko: </message>
-
-    <!-- *** ORIGINAL FILE DSpace/dspace-xmlui/src/main/resources/aspects/SwordClient/i18n/messages.xml -->
-	 
-    <!--   Sword Client  -->
-    <message key="xmlui.swordclient.Navigation.context_head">(Sword) Kopioi</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">Kopioi aineisto toiseen julkaisuarkistoon</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">(Sword) Kopioi</message>
-    <message key="xmlui.swordclient.general.main_head">Kopio aineisto: {0}</message>
-
-
-    <message key="xmlui.swordclient.SelectTarget.title">(Sword) Kohde</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">Valitse kohde</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">Vaihtoehtoinen URL</message>
-    <message key="xmlui.swordclient.SelectTarget.username">Käyttäjätunnus</message>
-    <message key="xmlui.swordclient.SelectTarget.password">Salasana</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">Toimeksiantaja</message>
-
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">Väärä URL</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">Väärä käyttäjätunnus</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">Väärä salasana</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Palveludokumentin (Sword Service Document) haku epäonnistui: {0}</message>
-
-    <message key="xmlui.swordclient.SelectCollection.title">(Sword) Kohdekokoelmat</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">Valitse kokoelmat</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">Kokoelma: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">Nimeke: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">Oikeudet: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">Välitystieto: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">Tiedostotyypit: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Pakkausformaatti: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Talleta tänne</message>
-
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">Alikohde</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Nouda alikohteen palveludokumentti (Sub Service Document)</message>
-
-    <message key="xmlui.swordclient.SelectPackagingAction.head">Kokoelma: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">Nimeke: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">Oikeudet: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">Välitystieto: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">Tiedostotyypit</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Pakkausformaatti</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Pakkausformaattia ei tueta</message>
-
-    <message key="xmlui.swordclient.DepositAction.success">Aineisto kopioitu</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Virhe pakkausformaatissa</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">Virheellinen handle-tunniste</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Aineiston pakkaamisessa tapahtui virhe</message>
-    <message key="xmlui.swordclient.DepositAction.error">Aineiston tallettamissa tapahtui virhe:: {0}</message>
-
-    <message key="xmlui.swordclient.SwordResponse.title">(Sword) Vastaus</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">(Sword) vastaus</message>
-
-    <!-- *** ORIGINAL FILE: DSpace/dspace-xmlui/src/main/resources/aspects/XMLWorkflow/i18n/messages.xml -->
-    
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Voit valita seuraavista toiminnoista:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Ota tehtävä itsellesi.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Ota tehtävä</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Jätä tehtävä tehtäväjonoon.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Jätä tehtävä</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Palaa</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Hyväksy tai hylkää tehtävä</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Suorita tehtävä: Hyväksy tai hylkää aineisto</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Voit valita seuraavista toiminnoista:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Jos olet tarkastanut aineiston, eikä sitä voida sisällyttää kokoelmaan, valitse "Hylkää". Sinun pitää tällöin kirjoittaa viesti, jossa kerrot aineiston syöttäjälle miksi aineistoa ei voi sisällyttää kokoelmaan, ja voisiko aineiston tietoja korjata ja lähettää uudestaan hyväksyttäväksi.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Hylkää</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Jos olet tarkastanut aineiston ja se voidaan sisällyttää kokoelmaan, valitse "Hyväksy"</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Hyväksy</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Suorita tehtävä: Hyväksy tai hylkää ainesto; muokkaa ainestoa</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Voit valita seuraavista toiminnoista:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Jos olet tarkastanut aineiston, eikä sitä voida sisällyttää kokoelmaan, valitse "Hylkää". Sinun pitää tällöin kirjoittaa viesti, jossa kerrot aineiston syöttäjälle miksi aineistoa ei voi sisällyttää kokoelmaan, ja voisiko aineiston tietoja korjata ja lähettää uudestaan hyväksyttäväksi.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Hylkää</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Jos olet tarkastanut aineiston ja se voidaan sisällyttää kokoelmaan, valitse "Hyväksy".</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Hyväksy</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Valitse "Muokkaa metadataa" muokataksesi aineiston metadataa.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Muokkaa metadataa</message>
-
-    <message key="xmlui.XMLWorkflow.step.unknown">Tuntematon tila</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Suorita tehtävä: Valitse tarkastaja</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Käytä allaolevaa hakulaatikkoa ja valitse käyttäjä, joka tarkastaa aineiston.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Hae tarkastaja</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Hae käyttäjä</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Valitse tarkastajaksi</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Jos et halua tarkastaa aineistoa, voit hylätä tehtävän valitsemalla "Hylkää tarkastuspyyntö".</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Hylkää tarkastuspyyntö</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Tarkasta syötetty aineisto</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Tarkasta syötetty aineisto</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Anna syötetylle aineistolle pisteet</message>
-
-
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Työnkulun yleiskuva</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Työnkulun yleiskuva</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Työnkulun yleiskuva</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Vaihe</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Aineisto</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Kokoelma</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Lisääjä</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Lähetä aineisto takaisin lisääjälle</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Poista aineisto</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Ei hakutuloksia</message>
-
-
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Näytä aineisto: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Näytä aineisto</message>
-
-    <message key="xmlui.XMLWorkflow.default.reviewstep">Hyväksymys- tai hylkäysvaihe</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Hyväksy/Hylkää</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Hyväksy/Hylkää</message>
-
-    <message key="xmlui.XMLWorkflow.default.editstep">Hyväksymys-, hylkäys- tai muokkausvaihe</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Hyväksy/Hylkää/Muokkaa</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">Hyväksy/Hylkää/Muokkaa</message>
-
-    <message key="xmlui.XMLWorkflow.default.finaleditstep">Lopullinen hyväksymys- tai muokkausvaihe</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Lopullinen Hyväksy/Muokkaa</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Lopullinen Hyväksy/Muokkaa</message>
-
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Tarkastajan valintavaihe</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Valitse tarkastaja</message>
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Yhden käyttäjän tarkastusvaihe</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Tarkasta syötetty aineisto</message>
-
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Pisteytä aineisto</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Pisteytä aineisto</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Pisteytä aineisto</message>
-    
-  </catalogue>
+</catalogue>

--- a/src/main/webapp/i18n/messages_fi.xml
+++ b/src/main/webapp/i18n/messages_fi.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="fi">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_fr.xml
+++ b/src/main/webapp/i18n/messages_fr.xml
@@ -1,166 +1,152 @@
-<?xml version="1.0"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="fr" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
-	<!-- Correctif relatif a DS-1159 : "Hardcoded button display text in several XMLUI themes makes i18n difficult" -->
-	<message key="xmlui.general.addbutton">Ajouter</message>
 	<message key="xmlui.general.dspace_home">Accueil de DSpace</message>
 	<message key="xmlui.general.search">Recherche</message>
 	<message key="xmlui.general.go">Aller</message>
-	<message key="xmlui.general.go_home">Aller &#224; la page d'accueil de DSpace</message>
+	<message key="xmlui.general.go_home">Aller à la page d'accueil de DSpace</message>
 	<message key="xmlui.general.save">Sauvegarder</message>
 	<message key="xmlui.general.cancel">Annuler</message>
 	<message key="xmlui.general.return">Retour</message>
-	<message key="xmlui.general.update">Mettre &#224; jour</message>
+	<message key="xmlui.general.update">Mettre à jour</message>
 	<message key="xmlui.general.delete">Supprimer</message>
 	<message key="xmlui.general.next">Suivant</message>
 	<message key="xmlui.general.untitled">[Sans titre]</message>
-    <message key="xmlui.general.perform">Effectuer</message>
-    <message key="xmlui.general.queue">Mettre en file d'attente</message>	
-	
-	<!-- Correctif relatif a DS-1159 : "Hardcoded button display text in several XMLUI themes makes i18n difficult" -->
-	<message key="xmlui.general.removebutton">Supprimer la s&#233;lection</message>
+        <message key="xmlui.general.perform">Effectuer</message>
+        <message key="xmlui.general.queue">Mettre en file d'attente</message>
 
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
+	<!--
+		Page not found keys
 
-	
-	<!-- 
-		Page not found keys 
-		
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">Page introuvable</message>
 	<message key="xmlui.PageNotFound.head">Page introuvable</message>
-	<message key="xmlui.PageNotFound.para1">Nous ne pouvons pas trouver la page que vous avez demand&#233;e.</message>
-	
+	<message key="xmlui.PageNotFound.para1">Nous ne pouvons pas trouver la page que vous avez demandée.</message>
+
 
 	<!--
 	   The "utils" non-aspect
        -->
-    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Seuls les administrateurs du site peuvent se connecter &#224; la place d'un autre utilisateur.</message>
-    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Seuls les utilisateur authentifi&#233;s qui ont des droits d'administrateur peuvent se connecter &#224; la place d'un autre utilisateur.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Seuls les administrateurs du site peuvent se connecter à la place d'un autre utilisateur.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Seuls les utilisateur authentifiés qui ont des droits d'administrateur peuvent se connecter à la place d'un autre utilisateur.</message>
     <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Vous ne pouvez vous connecter en tant qu'un autre administrateur.</message>
 
-	
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+		This section is for feed syndications (RSS, atom, etc)
 	-->
-	<message key="xmlui.feed.general_description">Le syst&#232;me de d&#233;p&#244;t num&#233;rique DSpace collecte, emmagasine, indexe, archive, et diffuse du mat&#233;riel de recherche en format num&#233;rique.</message>
+	<message key="xmlui.feed.general_description">Le système de dépôt numérique DSpace collecte, emmagasine, indexe, archive, et diffuse du matériel de recherche en format numérique.</message>
     <message key="xmlui.feed.header">Fils RSS</message>
 	<message key="xmlui.feed.logo_title">L'image du canal</message>
 	<message key="xmlui.feed.untitled">[Sans titre]</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">Avis</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">R&#233;sultats de recherche pour la communaut&#233;&#160;: {0}</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">R&#233;sultats de recherche pour la collection&#160;: {0}</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">R&#233;sultats de recherche</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Votre requ&#234;te "{0}" a g&#233;n&#233;r&#233; {1} r&#233;sultat(s).</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Communaut&#233;s ou collections correspondant &#224; votre recherche</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Documents correspondant &#224; votre recherche</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La recherche n'a produit aucun r&#233;sultat.</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tout le d&#233;p&#244;t DSpace</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Résultats de recherche pour la communauté : {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Résultats de recherche pour la collection : {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Résultats de recherche</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Votre requête "{0}" a généré {1} résultat(s).</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Communautés ou collections correspondant à votre recherche</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Documents correspondant à votre recherche</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La recherche n'a produit aucun résultat.</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tout le dépôt DSpace</message>
 
    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">titre</message>
    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">date de publication</message>
-   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">date de d&#233;p&#244;t</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">date de dépôt</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinence</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Trier les &#233;l&#233;ments par</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Trier les éléments par</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en ordre</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendant</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendant</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">R&#233;sultats/page</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Résultats/page</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Recherche avanc&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Recherche avanc&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Recherche avanc&#233;e</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Recherche avancée</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Recherche avancée</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Recherche avancée</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Rechercher dans</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiter votre recherche &#224; une communaut&#233; ou une collection.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limiter votre recherche à une communauté ou une collection.</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conjonction</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Type de recherche</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Rechercher</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Auteur</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Titre</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Sujet</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">R&#233;sum&#233;</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">S&#233;rie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Résumé</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Série</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Subventionnaire</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identifiant</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Langue (ISO)</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Mot-cl&#233;</message>
-   
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Mot-clé</message>
+
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Collaborateur</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Cr&#233;ateur</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Sujet</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Créateur</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Description</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relation</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Type MIME</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Autre collaborateur</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Directeur de recherche</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">D&#233;partement</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Département</message>
 
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texte int&#233;gral</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texte intégral</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">ET</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OU</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">SAUF</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ou entrer les premi&#232;res lettres&#160;:</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Rechercher des r&#233;sultats qui commencent par ces lettres</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Aller directement &#224; une entr&#233;e de l'index&#160;:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Choisir le mois)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Choisir l'ann&#233;e)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ou saisir une ann&#233;e&#160;:</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Rechercher des documents de l'ann&#233;e sp&#233;cifi&#233;e.</message>
-        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">D&#233;sol&#233;, il n'y a aucun r&#233;sultat pour cette entr&#233;e.</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Trier par&#160;: </message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordre&#160;: </message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> R&#233;sultats&#160;: </message><!-- /Page -->
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Auteurs/Document&#160;: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ou entrer les premières lettres :</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Rechercher des résultats qui commencent par ces lettres</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Aller directement à une entrée de l'index :</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Choisir le mois)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Choisir l'année)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ou saisir une année :</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Rechercher des documents de l'année spécifiée.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Désolé, il n'y a aucun résultat pour cette entrée.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Trier par : </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordre : </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Résultats : </message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Auteurs/Document : </message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Tous</message>
 
@@ -179,148 +165,163 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Parcourir {0} par sujet {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Parcourir {0} par sujet</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Parcourir {0} par titre {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Parcourir {0} par titre</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Parcourir {0} par {1} date de publication</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Parcourir {0} par date de publication</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Parcourir {0} par date de soumission {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Parcourir {0} par date de soumission</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Port&#233;e de la recherche</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Portée de la recherche</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tout DSpace</message>
-	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Rechercher dans cette collection&#160;:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Rechercher dans cette collection :</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Parcourir par</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Titres</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Auteurs</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Dates</message>
-	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Recherche avanc&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Soumissions r&#233;centes</message>
-	
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Recherche avancée</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Soumissions récentes</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Liste de communaut&#233;s</message>
-	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Liste de communaut&#233;s</message>
-	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Communaut&#233;s dans DSpace</message>
-	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">S&#233;lectionner une communaut&#233; pour parcourir ses collections.</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Liste de communautés</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Liste de communautés</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Communautés dans DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Sélectionner une communauté pour parcourir ses collections.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Port&#233;e de la recherche</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Portée de la recherche</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Tout DSpace</message>
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Rechercher dans cette communaut&#233; et ses collections&#160;:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Rechercher dans cette communauté et ses collections :</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Parcourir par</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Titres</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Auteurs</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Dates</message>
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Recherche avanc&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Sous-communaut&#233;s au sein de cette communaut&#233;</message>
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Collections dans cette communaut&#233;</message>
-	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Soumissions r&#233;centes</message>
-	
-	
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Recherche avancée</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Sous-communautés au sein de cette communauté</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Collections dans cette communauté</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Soumissions récentes</message>
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Contactez-nous</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Contactez-nous</message>
 	<message key="xmlui.ArtifactBrowser.Contact.head">Contactez-nous</message>
-	<message key="xmlui.ArtifactBrowser.Contact.para1">Les administrateurs de {0} peuvent &#234;tre contact&#233;s &#224;&#160;:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">Les administrateurs de {0} peuvent être contactés à :</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulaire en ligne</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Faire parvenir un commentaire</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">Courriel</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Soumettre un commentaire</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Soumettre un commentaire</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Soumettre un commentaire</message>
-	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Merci de nous faire part de vos commentaires sur le syst&#232;me DSpace; ils sont appr&#233;ci&#233;s!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Merci de nous faire part de vos commentaires sur le système DSpace; ils sont appréciés!</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Votre courriel</message>
-	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Cette adresse sera utilis&#233;e pour effectuer un suivi de votre commentaire.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Cette adresse sera utilisée pour effectuer un suivi de votre commentaire.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Commentaires</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Envoyer votre commentaire</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Soumettre un commentaire</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Soumettre un commentaire</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Commentaire soumis</message>
-	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Votre commentaire a &#233;t&#233; re&#231;u.</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Recherche dans le d&#233;p&#244;t DSpace</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Entrer des termes de recherche dans la case ci-dessous pour rechercher dans le d&#233;p&#244;t DSpace.</message>
-	
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Votre commentaire a été reçu.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Voir le document</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Ce document figure dans la(les) collection(s) suivante(s)</message>
-	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Afficher la notice abr&#233;g&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Afficher la notice compl&#232;te</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Afficher la notice abrégée</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Afficher la notice complète</message>
 
-        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Ce document a &#233;t&#233; retir&#233; et n'est plus disponible.</message>
-	
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Ce document a été retiré et n'est plus disponible.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Parcourir</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tout DSpace</message>
-	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Communaut&#233;s &amp; Collections</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Communautés &amp; Collections</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Titres</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Auteurs</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Sujets</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Par date de publication</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Par date de soumission</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Cette collection</message>
-	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Cette communaut&#233;</message>
-	
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Cette communauté</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Recherche</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Recherche</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Recherche</message>
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Port&#233;e de la recherche</message>
-	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Recherche en texte int&#233;gral</message>
-	
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Portée de la recherche</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Recherche en texte intégral</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">L'acc&#232;s &#224; cette ressource est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Acc&#232;s restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">L'acc&#232;s &#224; cette ressource est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">L'acc&#232;s &#224; cette communaut&#233; est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">L'acc&#232;s &#224; cette collection est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">L'acc&#232;s &#224; ce document est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">L'acc&#232;s &#224; ce fichier est restreint</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Vous n'avez pas les autorisations n&#233;cessaires pour acc&#233;der &#224; la ressource &#224; acc&#232;s restreint.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Vous n'avez pas les autorisations n&#233;cessaires pour acc&#233;der &#224; la communaut&#233; {0} &#224; acc&#232;s restreint.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Vous n'avez pas les autorisations n&#233;cessaires pour acc&#233;der &#224; la collection {0} &#224; acc&#232;s restreint.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Vous n'avez pas les autorisations n&#233;cessaires pour acc&#233;der au document {0} &#224; acc&#232;s restreint.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Vous n'avez pas les autorisations n&#233;cessaires pour acc&#233;der au fichier {0} &#224; acc&#232;s restreint.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">L'accès à cette ressource est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Accès restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">L'accès à cette ressource est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">L'accès à cette communauté est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">L'accès à cette collection est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">L'accès à ce document est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">L'accès à ce fichier est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Vous n'avez pas les autorisations nécessaires pour accéder à la ressource à accès restreint.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Vous n'avez pas les autorisations nécessaires pour accéder à la communauté {0} à accès restreint.<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Vous n'avez pas les autorisations nécessaires pour accéder à la collection {0} à accès restreint.<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Vous n'avez pas les autorisations nécessaires pour accéder au document {0} à accès restreint.<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Vous n'avez pas les autorisations nécessaires pour accéder au fichier {0} à accès restreint.<b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">collection</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">communaut&#233;</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">communauté</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">fichier</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">document</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">ressource</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">inconnu</message>
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Faire afficher l'&#233;cran d'ouverture de session</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Faire afficher l'écran d'ouverture de session</message>
 
-
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Ce document &#233;t&#233; retir&#233;.</message>
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Le document s&#233;lectionn&#233; a &#233;t&#233; retir&#233; et n'est plus disponible.</message>
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">L'acc&#232;s au document s&#233;lectionn&#233; est restreint et n&#233;cessite des autorisations pour pouvoir &#234;tre consult&#233;. Veuillez vous connecter pour avoir acc&#232;s au document.</message>
-        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Votre compte d'utilisateur ne dispose pas des autorisation appropri&#233;es pour pouvoir consulter ce document. Pri&#232;re de contacter l'administrateur du syst&#232;me si des questions subsistent.</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Ce document été retiré.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Le document sélectionné a été retiré et n'est plus disponible.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">L'accès au document sélectionné est restreint et nécessite des autorisations pour pouvoir être consulté. Veuillez vous connecter pour avoir accès au document.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Votre compte d'utilisateur ne dispose pas des autorisation appropriées pour pouvoir consulter ce document. Prière de contacter l'administrateur du système si des questions subsistent.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'acc&#232;s &#224; ce document est restreint</message>	
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Le document auquel vous tentez d'acc&#233;der est en acc&#232;s restreint et des autorisations d'acc&#232;s sont requises. Veuillez vous connecter ci-dessous pour avoir acc&#232;s au document.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'accès à ce document est restreint</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Le document auquel vous tentez d'accéder est en accès restreint et des autorisations d'accès sont requises. Veuillez vous connecter ci-dessous pour avoir accès au document.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Rapports mensuels</message>
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Statistiques en bref</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Aucun rapport disponible</message>
-    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Il n'y a pas de rapports disponibles pour ce service actuellement. Veuillez r&#233;essayer plus tard.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Il n'y a pas de rapports disponibles pour ce service actuellement. Veuillez réessayer plus tard.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-	<message key="xmlui.BitstreamReader.auth_header">L'acc&#232;s &#224; ce fichier est restreint</message>	
-	<message key="xmlui.BitstreamReader.auth_message">Le fichier auquel vous tentez d'acc&#233;der est en acc&#232;s restreint et n&#233;cessite des autorisations d'acc&#232;s. Veuillez vous connecter ci-dessous pour avoir acc&#232;s au fichier.</message>
-	
+	<message key="xmlui.BitstreamReader.auth_header">L'accès à ce fichier est restreint</message>
+	<message key="xmlui.BitstreamReader.auth_message">Le fichier auquel vous tentez d'accéder est en accès restreint et nécessite des autorisations d'accès. Veuillez vous connecter ci-dessous pour avoir accès au fichier.</message>
+
 	<!-- Export Archive download messages -->
-	<message key="xmlui.ItemExportDownloadReader.auth_header">L'acc&#232;s &#224; l'exportation de ce fichier d'archive est restreint.</message>
-	<message key="xmlui.ItemExportDownloadReader.auth_message">Le fichier d'archive auquel vous tentez d'acc&#233;der est en acc&#232;s restreint et n&#233;cessite des autorisations d'acc&#232;s. Veuillez vous connecter ci-dessous pour avoir acc&#232;s au fichier d'archive et permettre son exportation.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_header">L'accès à l'exportation de ce fichier d'archive est restreint.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">Le fichier d'archive auquel vous tentez d'accéder est en accès restreint et nécessite des autorisations d'accès. Veuillez vous connecter ci-dessous pour avoir accès au fichier d'archive et permettre son exportation.</message>
 
 
 	<!-- REQUEST COPY -->
@@ -328,39 +329,43 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Demander une copie de ce document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Demander une copie de ce document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Demander une copie de ce document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Intrer l'information suivante pour demander une copie de ce document &#224; la personne responsable</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Intrer l'information suivante pour demander une copie de ce document à la personne responsable</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Votre adresse e-mail</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Cette adresse e-mail est utilis&#233;e pour faire parvenir ce document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Cette adresse e-mail est utilisée pour faire parvenir ce document.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Adresse est obligatoire</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message est obligatoire</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Fichiers</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Tous fichiers (de ce document) All files (of this document) dans acc&#232;s restreint.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Seulement le fichier demand&#233;.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">Tous fichiers (de ce document) All files (of this document) dans accès restreint.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Seulement le fichier demandé.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Nom</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Nom est obligatoire</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Demander une copie</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
-	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Votre demande a &#233;t&#233; envoy&#233;e.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Votre demande a &#233;t&#233; envoy&#233;e.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Votre demande a &#233;t&#233; envoy&#233;e.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Votre demande a &#233;t&#233; envoy&#233; &#224; la personne responsable.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Votre demande a été envoyée.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Votre demande a été envoyée.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Votre demande a été envoyée.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Votre demande a été envoyé à la personne responsable.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Demande d'une copie du document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI VOUS &#202;TES L'AUTEUR (OU UN DES AUTEURS) DU DOCUMENT &quot;{0} utilise le bouton pour r&#233;pondre &#224; la demande de l'utilisateur.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Ce d&#233;p&#244;t proposera une r&#233;ponse mod&#232;le appropri&#233;e, laquelle vous pouvez modifier.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Envoyez la copie</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">SI VOUS ÊTES L'AUTEUR (OU UN DES AUTEURS) DU DOCUMENT "{0} utilise le bouton pour répondre à la demande de l'utilisateur.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Ce dépôt proposera une réponse modèle appropriée, laquelle vous pouvez modifier.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Envoyez la copie</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">N'envoyez pas la copie</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Demande d'une copie du document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Ceci est le texte qui sera envoy&#233; au demandeur (avec le document)</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Ceci est le texte qui sera envoyé au demandeur (avec le document)</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Suject</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Envoyer</message>
@@ -370,7 +375,7 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Demande d'une copie du document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Demande d'une copie du document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Ceci est le texte qui sera envoy&#233; au demandeur (avec le document)</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">Ceci est le texte qui sera envoyé au demandeur (avec le document)</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Suject</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Envoyer</message>
@@ -380,124 +385,153 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Demande de chargement des permissions</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Demande de chargement des permissions</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Demande de chargement des permissions</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Vous pouvez utiliser cette occasion pour reconsid&#233;rer les restrictions d'acc&#232;s du document (pour &#233;viter ces demandes-ci), si les restrictions ne sont pas n&#233;cessaire. Pour changer les restrictions, remplissez votre nom et adresse e-mail (pour authentication), puis cliquez le bouton &quot;Changer vers libre acc&#232;s&quot;.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">Vous pouvez utiliser cette occasion pour reconsidérer les restrictions d'accès du document (pour éviter ces demandes-ci), si les restrictions ne sont pas nécessaire. Pour changer les restrictions, remplissez votre nom et adresse e-mail (pour authentication), puis cliquez le bouton "Changer vers libre accès".</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Nom</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">Adresse e-mail</message>
     <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">Le nom est obligatoire</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">L'adresse e-mail est obligatoire</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Changer vers libre acc&#232;s</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Changer vers libre accès</message>
 	        
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
-	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Demande envoy&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Demande envoy&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Votre demande de changement des permissions a &#233;t&#233; envoy&#233;e</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Votre demande a &#233;t&#233; envoy&#233;e &#224; votre administrateur</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Demande envoyée</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Demande envoyée</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Votre demande de changement des permissions a été envoyée</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Votre demande a été envoyée à votre administrateur</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Merci beaucoup</message>
 
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Nouvelle inscription d'utilisateur</message>
-	<message key="xmlui.EPerson.trail_forgot_password">Mot de passe oubli&#233;</message>
-	
+	<message key="xmlui.EPerson.trail_forgot_password">Mot de passe oublié</message>
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Inscription non disponible</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Inscription non disponible</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">La configuration de ce d&#233;p&#244;t DSpace ne permet pas de s'inscrire dans ce contexte. Pri&#232;re de contacter <a href="../contact">l'administrateur du site</a> si vous avez des questions ou des commentaires.</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">La configuration de ce dépôt DSpace ne permet pas de s'inscrire dans ce contexte. Prière de contacter <a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-	<message key="xmlui.EPerson.EditProfile.title_update">Mettre &#224; jour le profil</message>
-	<message key="xmlui.EPerson.EditProfile.title_create">Cr&#233;er un profil</message>
-	<message key="xmlui.EPerson.EditProfile.trail_update">Mettre &#224; jour le profil</message>
-	<message key="xmlui.EPerson.EditProfile.head_update">Mettre &#224; jour le profil</message>
-	<message key="xmlui.EPerson.EditProfile.head_create">Cr&#233;er un profil</message>
+	<message key="xmlui.EPerson.EditProfile.title_update">Mettre à jour le profil</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Créer un profil</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Mettre à jour le profil</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Mettre à jour le profil</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Créer un profil</message>
 	<message key="xmlui.EPerson.EditProfile.email_address">Adresse courriel</message>
-	<message key="xmlui.EPerson.EditProfile.first_name">Pr&#233;nom</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Prénom</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Nom de famille</message>
-	<message key="xmlui.EPerson.EditProfile.telephone">T&#233;l&#233;phone</message>
-	        <message key="xmlui.EPerson.EditProfile.Language">Langue</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Téléphone</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Langue</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Abonnements</message>
-	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Vous pouvez vous abonner &#224; des collections afin de recevoir quotidiennement, par courriel, des alertes des nouveaux documents ajout&#233;s. Vous pouvez vous abonner &#224; autant de collections que vous le souhaitez. Une autre alternative aux alertes quotidiennes par courriel est d'utiliser les fils RSS disponibles pour toutes les collections.</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Vous pouvez vous abonner à des collections afin de recevoir quotidiennement, par courriel, des alertes des nouveaux documents ajoutés. Vous pouvez vous abonner à autant de collections que vous le souhaitez. Une autre alternative aux alertes quotidiennes par courriel est d'utiliser les fils RSS disponibles pour toutes les collections.</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Abonnements par courriel</message>
 	<message key="xmlui.EPerson.EditProfile.select_collection">( Choisir la collection )</message>
-	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Optionnellement, vous pouvez entrer un nouveau mot de passe dans la case ci-dessous, et le confirmer en le tapant de nouveau dans la seconde case. Le mot de passe doit &#234;tre constitu&#233; d'au moins six caract&#232;res.</message>
-	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Pri&#232;re d'entrer un mot de passe dans la case ci-dessous, et confirmer le tapant de nouveau dans la seconde case. Le mot de passe doit &#234;tre constitu&#233;s d'au moins six caract&#232;res.</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Optionnellement, vous pouvez entrer un nouveau mot de passe dans la case ci-dessous, et le confirmer en le tapant de nouveau dans la seconde case. Le mot de passe doit être constitué d'au moins six caractères.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Prière d'entrer un mot de passe dans la case ci-dessous, et confirmer le tapant de nouveau dans la seconde case. Le mot de passe doit être constitués d'au moins six caractères.</message>
 	<message key="xmlui.EPerson.EditProfile.password">Mot de passe</message>
 	<message key="xmlui.EPerson.EditProfile.confirm_password">Confirmer le mot de passe en le saisissant de nouveau</message>
-	<message key="xmlui.EPerson.EditProfile.submit_update">Compl&#233;ter l'inscription</message>
-	<message key="xmlui.EPerson.EditProfile.submit_create">Mettre &#224; jour le profil</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Compléter l'inscription</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Mettre à jour le profil</message>
 	<message key="xmlui.EPerson.EditProfile.error_required">Ce champ est obligatoire</message>
-	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Choisir un mot de passe d'au moins 6 caract&#232;res</message>
-	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Pri&#232;re de retaper votre mot de passe afin de le confirmer</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Choisir un mot de passe d'au moins 6 caractères</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Prière de retaper votre mot de passe afin de le confirmer</message>
 	<message key="xmlui.EPerson.EditProfile.head_auth">Groupes d'autorisation auquels vous appartenez</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Identification</message>
-	<message key="xmlui.EPerson.EditProfile.head_security">S&#233;curit&#233;</message>
-	
+	<message key="xmlui.EPerson.EditProfile.head_security">Sécurité</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">V&#233;rifier l'adresse courriel</message>
-	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Cr&#233;er un profil</message>
-	<message key="xmlui.EPerson.EPersonUtils.register_finished">Termin&#233;</message>
-	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">V&#233;rifier l'adresse courriel</message>
-	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">R&#233;initialiser le mot de passe</message>
-	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Termin&#233;</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Vérifier l'adresse courriel</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Créer un profil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Terminé</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Vérifier l'adresse courriel</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Réinitialiser le mot de passe</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Terminé</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Mot de passe r&#233;initialis&#233;</message>
-	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Mot de passe r&#233;initialis&#233;</message>
-	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Votre mot de passe a &#233;t&#233; r&#233;initialis&#233;.</message>
-	
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Mot de passe réinitialisé</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Mot de passe réinitialisé</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Votre mot de passe a été réinitialisé.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Identifiant invalide</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Identifiant invalide</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Identifiant invalide</message>
-	<message key="xmlui.EPerson.InvalidToken.para1">L'URL que vous avez fourni n'est pas valide. L'URL peut avoir &#233;t&#233; scind&#233;e en plusieurs lignes dans votre client de messagerie, comme ceci&#160;:</message>
-	<message key="xmlui.EPerson.InvalidToken.para2">Si c'est le cas, copier et coller l'URL compl&#232;te directement dans la barre d'adresse de votre navigateur, plut&#244;t que de tenter d'y acc&#233;der simplement en cliquant sur le lien. La barre d'adresse doit alors contenir quelque chose comme&#160;:</message>
-	
+	<message key="xmlui.EPerson.InvalidToken.para1">L'URL que vous avez fourni n'est pas valide. L'URL peut avoir été scindée en plusieurs lignes dans votre client de messagerie, comme ceci :</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Si c'est le cas, copier et coller l'URL complète directement dans la barre d'adresse de votre navigateur, plutôt que de tenter d'y accéder simplement en cliquant sur le lien. La barre d'adresse doit alors contenir quelque chose comme :</message>
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">Mon compte</message>
 	<message key="xmlui.EPerson.Navigation.profile">Profil</message>
-	<message key="xmlui.EPerson.Navigation.logout">D&#233;connexion</message>
+	<message key="xmlui.EPerson.Navigation.logout">Déconnexion</message>
 	<message key="xmlui.EPerson.Navigation.login">Ouvrir une session</message>
 	<message key="xmlui.EPerson.Navigation.register">S'inscrire</message>
 
 	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
 	<message key="xmlui.EPerson.PasswordLogin.title">Ouverture de session</message>
 	<message key="xmlui.EPerson.PasswordLogin.trail">Ouverture de session</message>
-	<message key="xmlui.EPerson.PasswordLogin.head1">Identifiez-vous pour acc&#233;der &#224; DSpace</message>
-
+	<message key="xmlui.EPerson.PasswordLogin.head1">Identifiez-vous pour accéder à DSpace</message>
 	<message key="xmlui.EPerson.PasswordLogin.email_address">Adresse courriel</message>
 	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">L'adresse courriel et/ou le mot de passe fourni ne sont pas valides.</message>
 	<message key="xmlui.EPerson.PasswordLogin.password">Mot de passe</message>
-	<message key="xmlui.EPerson.PasswordLogin.forgot_link"> Mot de passe oubli&#233;?</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link"> Mot de passe oublié?</message>
 	<message key="xmlui.EPerson.PasswordLogin.submit">Identifiez-vous</message>
 	<message key="xmlui.EPerson.PasswordLogin.head2">Inscrire un nouvel utilisateur</message>
-	<message key="xmlui.EPerson.PasswordLogin.para1">Cr&#233;er un compte afin de pouvoir vous abonner &#224; des alertes courriel et soumettre de nouveaux documents dans DSpace.</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Créer un compte afin de pouvoir vous abonner à des alertes courriel et soumettre de nouveaux documents dans DSpace.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Cliquer ici pour vous inscrire.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Ouverture de session</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Ouverture de session</message>
-	<message key="xmlui.EPerson.LDAPLogin.head1">Identifiez-vous pour acc&#233;der &#224; DSpace</message>
-
+	<message key="xmlui.EPerson.LDAPLogin.head1">Identifiez-vous pour accéder à DSpace</message>
 	<message key="xmlui.EPerson.LDAPLogin.username">Nom d'utilisateur</message>
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Le nom d'utilisateur et/ou mot de passe fourni ne sont pas valides.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Mot de passe</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Identifiez-vous</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-	<message key="xmlui.EPerson.LoginChooser.title">Choisir une m&#233;thode de connexion</message>
-	<message key="xmlui.EPerson.LoginChooser.trail">Choisir une m&#233;thode de connexion</message>
-	<message key="xmlui.EPerson.LoginChooser.head1">Choisir une m&#233;thode de connexion</message>
-	<message key="xmlui.EPerson.LoginChooser.para1">Connectez-vous via&#160;:</message>
+	<message key="xmlui.EPerson.LoginChooser.title">Choisir une méthode de connexion</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Choisir une méthode de connexion</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Choisir une méthode de connexion</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Connectez-vous via :</message>
 	<message key="org.dspace.authenticate.ShibAuthentication.title">Authentification Shibboleth</message>
 	<message key="org.dspace.eperson.LDAPAuthentication.title">Authentification LDAP</message>
 	<message key="org.dspace.eperson.PasswordAuthentication.title">Authentification par mot de passe</message>
@@ -505,66 +539,66 @@
 
 	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
 	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Les informations d'identification fournies ne sont pas valides.</message>
-	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Impossible de s'authentifier en raison des arguments non valides re&#231;us.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Impossible de s'authentifier en raison des arguments non valides reçus.</message>
 	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Aucun utilisateur ne correspond aux informations d'identification fournies.</message>
-	<message key="xmlui.EPerson.FailedAuthentication.title">&#201;chec de l'authentification</message>
-    <message key="xmlui.EPerson.FailedAuthentication.trail">&#201;chec de l'authentification</message>
-    <message key="xmlui.EPerson.FailedAuthentication.h1">&#201;chec de l'authentification</message>
-	
+	<message key="xmlui.EPerson.FailedAuthentication.title">Échec de l'authentification</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Échec de l'authentification</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Échec de l'authentification</message>
+
 	<!-- Login xml files -->
-	<message key="xmlui.eperson.noAuthMethod.head">Aucune m&#233;thode d'authentification trouv&#233;e</message>
-	<message key="xmlui.eperson.noAuthMethod.p1">Aucune m&#233;thode d'authentification a &#233;t&#233; trouv&#233;e. Pri&#232;re de contacter l'administrateur du site.</message>
-	<message key="xmlui.eperson.shibbLoginFailure.head">L'authetification Shibboleth a &#233;chou&#233;e</message>
-	<message key="xmlui.eperson.shibbLoginFailure.p1">L'authentification Shibboleth pas disponible en ce moment. Pri&#232;re de contacter l'administrateur du site.</message>
-	
+	<message key="xmlui.eperson.noAuthMethod.head">Aucune méthode d'authentification trouvée</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">Aucune méthode d'authentification a été trouvée. Prière de contacter l'administrateur du site.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">L'authetification Shibboleth a échouée</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">L'authentification Shibboleth pas disponible en ce moment. Prière de contacter l'administrateur du site.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-	<message key="xmlui.EPerson.ProfileUpdated.title">Profil mis &#224; jour</message>
-	<message key="xmlui.EPerson.ProfileUpdated.trail">Mise &#224; jour du profil</message>
-	<message key="xmlui.EPerson.ProfileUpdated.head">Profil mis &#224; jour</message>
-	<message key="xmlui.EPerson.ProfileUpdated.para1">Les informations de votre profil ont &#233;t&#233; mises &#224; jour.</message>
-	
+	<message key="xmlui.EPerson.ProfileUpdated.title">Profil mis à jour</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Mise à jour du profil</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Profil mis à jour</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">Les informations de votre profil ont été mises à jour.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-	<message key="xmlui.EPerson.RegistrationFinished.title">Inscription termin&#233;e</message>
-	<message key="xmlui.EPerson.RegistrationFinished.head">Inscription termin&#233;e</message>
-	<message key="xmlui.EPerson.RegistrationFinished.para1">Vous &#234;tes maintenant inscrit dans le syst&#232;me DSpace. Vous pouvez vous abonner &#224; des collections pour recevoir des alertes par courriel au sujet des nouveaux documents.</message>
-	
+	<message key="xmlui.EPerson.RegistrationFinished.title">Inscription terminée</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Inscription terminée</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Vous êtes maintenant inscrit dans le système DSpace. Vous pouvez vous abonner à des collections pour recevoir des alertes par courriel au sujet des nouveaux documents.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-	<message key="xmlui.EPerson.ResetPassword.title">R&#233;initialiser le mot de passe</message>
-	<message key="xmlui.EPerson.ResetPassword.head">R&#233;initialiser le mot de passe</message>
-	<message key="xmlui.EPerson.ResetPassword.para1">Pri&#232;re d'entrer un mot de passe dans la case ci-dessous, et le confirmer en le tapant de nouveau dans la seconde case. Le mot de passe doit &#234;tre constitu&#233; d'au moins six caract&#232;res.</message>
+	<message key="xmlui.EPerson.ResetPassword.title">Réinitialiser le mot de passe</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Réinitialiser le mot de passe</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Prière d'entrer un mot de passe dans la case ci-dessous, et le confirmer en le tapant de nouveau dans la seconde case. Le mot de passe doit être constitué d'au moins six caractères.</message>
 	<message key="xmlui.EPerson.ResetPassword.email_address">Adresse courriel</message>
 	<message key="xmlui.EPerson.ResetPassword.new_password">Nouveau mot de passe</message>
 	<message key="xmlui.EPerson.ResetPassword.confirm_password">Confirmer le mot de passe en le saisissant de nouveau</message>
-	<message key="xmlui.EPerson.ResetPassword.submit">R&#233;initialiser le mot de passe</message>
-	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Choisir un mot de passe d'au moins 6 caract&#232;res</message>
-	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Pri&#232;re de retaper votre mot de passe pour le confirmer</message>
-	
+	<message key="xmlui.EPerson.ResetPassword.submit">Réinitialiser le mot de passe</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Choisir un mot de passe d'au moins 6 caractères</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Prière de retaper votre mot de passe pour le confirmer</message>
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-	<message key="xmlui.EPerson.StartForgotPassword.title">Mot de passe oubli&#233;</message>
-	<message key="xmlui.EPerson.StartForgotPassword.head">Mot de passe oubli&#233;</message>
-	<message key="xmlui.EPerson.StartForgotPassword.para1">Entrer l'adresse courriel indiqu&#233;e lors de votre inscription dans DSpace. Un courriel vous sera envoy&#233; &#224; cette adresse avec de nouvelles instructions.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.title">Mot de passe oublié</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Mot de passe oublié</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Entrer l'adresse courriel indiquée lors de votre inscription dans DSpace. Un courriel vous sera envoyé à cette adresse avec de nouvelles instructions.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.email_address">Adresse courriel</message>
-	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Entrer la m&#234;me adresse courriel que celle utilis&#233;e lors de votre inscription.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Entrer la même adresse courriel que celle utilisée lors de votre inscription.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Adresse courriel inconnue</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Envoyer info</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Nouvelle inscription</message>
-	<message key="xmlui.EPerson.StartRegistration.head1">Courrier &#233;lectronique d&#233;j&#224; en service</message>
-	<message key="xmlui.EPerson.StartRegistration.para1">Cette adresse courriel est d&#233;j&#224; utilis&#233; par un autre compte. Si vous souhaitez r&#233;initialiser le mot de passe pour ce compte, cliquez sur le bouton de r&#233;initialisation de mot de passe ci-dessous.</message>
-	<message key="xmlui.EPerson.StartRegistration.reset_password_for">R&#233;initialiser mot de passe pour</message>
-	<message key="xmlui.EPerson.StartRegistration.submit_reset">R&#233;initialiser mot de passe</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Courrier électronique déjà en service</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Cette adresse courriel est déjà utilisé par un autre compte. Si vous souhaitez réinitialiser le mot de passe pour ce compte, cliquez sur le bouton de réinitialisation de mot de passe ci-dessous.</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Réinitialiser mot de passe pour</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Réinitialiser mot de passe</message>
 	<message key="xmlui.EPerson.StartRegistration.head2">Nouvelle inscription</message>
-	<message key="xmlui.EPerson.StartRegistration.para2">Cr&#233;er un compte afin de pouvoir vous abonner &#224; des alertes courriel et soumettre de nouveaux documents dans DSpace.</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Créer un compte afin de pouvoir vous abonner à des alertes courriel et soumettre de nouveaux documents dans DSpace.</message>
 	<message key="xmlui.EPerson.StartRegistration.email_address">Adresse courriel</message>
-	<message key="xmlui.EPerson.StartRegistration.email_address_help">Cette adresse sera v&#233;rifi&#233;e et devra &#234;tre utilis&#233;e pour ouvrir une session.</message>
-	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Impossible d'envoyer un courriel &#224; cette adresse.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Cette adresse sera vérifiée et devra être utilisée pour ouvrir une session.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Impossible d'envoyer un courriel à cette adresse.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">S'inscrire</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-	<message key="xmlui.EPerson.VerifyEmail.title">Courriel de v&#233;rification envoy&#233;</message>
-	<message key="xmlui.EPerson.VerifyEmail.head">Courriel de v&#233;rification envoy&#233;</message>
-	<message key="xmlui.EPerson.VerifyEmail.para">Un courriel a &#233;t&#233; envoy&#233; &#224; {0} contenant une URL sp&#233;cifique et des instructions suppl&#233;mentaires.</message>
+	<message key="xmlui.EPerson.VerifyEmail.title">Courriel de vérification envoyé</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Courriel de vérification envoyé</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">Un courriel a été envoyé à {0} contenant une URL spécifique et des instructions supplémentaires.</message>
 
 
 
@@ -572,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -585,251 +619,251 @@
 
 	<!-- general submission aspect messages -->
 	<message key="xmlui.Submission.general.mydspace_home">Mon compte Accueil</message>
-	<message key="xmlui.Submission.general.go_mydspace">Aller &#224; la page d'accueil de Mon compte</message>
+	<message key="xmlui.Submission.general.go_mydspace">Aller à la page d'accueil de Mon compte</message>
 	<message key="xmlui.Submission.general.submission.title">Soumission d'un document</message>
 	<message key="xmlui.Submission.general.submission.trail">Soumission d'un document</message>
-	<message key="xmlui.Submission.general.submission.head">Soumission d'un document</message>	
-	<message key="xmlui.Submission.general.submission.previous">&lt; Pr&#233;c&#233;dent</message>
+	<message key="xmlui.Submission.general.submission.head">Soumission d'un document</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Précédent</message>
 	<message key="xmlui.Submission.general.submission.save">Sauvegarder et quitter</message>
 	<message key="xmlui.Submission.general.submission.next">Suivant &gt;</message>
 	<message key="xmlui.Submission.general.submission.complete">Finaliser la soumission</message>
 	<message key="xmlui.Submission.general.workflow.title">Soumission d'un document</message>
 	<message key="xmlui.Submission.general.workflow.trail">Soumission d'un document</message>
 	<message key="xmlui.Submission.general.workflow.head">Soumission d'un document</message>
-	<message key="xmlui.Submission.general.showfull">Afficher la notice compl&#232;te du document</message>
-	<message key="xmlui.Submission.general.showsimple">Afficher la notice abr&#233;g&#233;e du document</message>
+	<message key="xmlui.Submission.general.showfull">Afficher la notice complète du document</message>
+	<message key="xmlui.Submission.general.showsimple">Afficher la notice abrégée du document</message>
 	<message key="xmlui.Submission.general.default.title">Soumission</message>
 	<message key="xmlui.Submission.general.default.trail">Soumission</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-	<message key="xmlui.Submission.CollectionViewer.link1">Soumettre un nouveau document &#224; cette collection</message>
-	
+	<message key="xmlui.Submission.CollectionViewer.link1">Soumettre un nouveau document à cette collection</message>
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Soumissions</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
-	<message key="xmlui.Submission.Submissions.title">Soumissions et t&#226;ches de validation</message>
+	<message key="xmlui.Submission.Submissions.title">Soumissions et tâches de validation</message>
 	<message key="xmlui.Submission.Submissions.trail">Soumissions</message>
-	<message key="xmlui.Submission.Submissions.head">Soumissions et t&#226;ches de validation</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>[Sans titre]</i></message>
-	<message key="xmlui.Submission.Submissions.email">courriel&#160;:</message>
+	<message key="xmlui.Submission.Submissions.head">Soumissions et tâches de validation</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">courriel :</message>
 	<!-- Same transformer, workflow section -->
-	<message key="xmlui.Submission.Submissions.workflow_head1">T&#226;ches de validation</message>
-	<message key="xmlui.Submission.Submissions.workflow_info1">Ces t&#226;ches concernent les documents qui sont en attente d'approbation avant qu'ils ne soient ajout&#233;s au d&#233;p&#244;t. Il y a deux files d'attente: une pour les t&#226;ches que vous avez accept&#233;es et l'autre pour des t&#226;ches qui n'ont pas encore &#233;t&#233; attribu&#233;es.</message>
-	<message key="xmlui.Submission.Submissions.workflow_head2">T&#226;ches qui vous sont attribu&#233;es</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
-	<message key="xmlui.Submission.Submissions.workflow_column2">T&#226;che</message>
+	<message key="xmlui.Submission.Submissions.workflow_head1">Tâches de validation</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Ces tâches concernent les documents qui sont en attente d'approbation avant qu'ils ne soient ajoutés au dépôt. Il y a deux files d'attente: une pour les tâches que vous avez acceptées et l'autre pour des tâches qui n'ont pas encore été attribuées.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Tâches qui vous sont attribuées</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Tâche</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Document</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Collection</message>
 	<message key="xmlui.Submission.Submissions.workflow_column5">Soumis par</message>
-	<message key="xmlui.Submission.Submissions.workflow_submit_return">Retourner les t&#226;ches s&#233;lectionn&#233;es &#224; l'&#233;quipe de validation</message>
-	<message key="xmlui.Submission.Submissions.workflow_info2">Aucune t&#226;che ne vous est assign&#233;e</message>
-	<message key="xmlui.Submission.Submissions.workflow_head3">T&#226;ches de l'&#233;quipe de validation</message>
-	<message key="xmlui.Submission.Submissions.workflow_submit_take">Effectuer les t&#226;ches s&#233;lectionn&#233;es</message>
-	<message key="xmlui.Submission.Submissions.workflow_info3">Aucune t&#226;che ne doit &#234;tre effectu&#233;e par l'&#233;quipe de validation</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Retourner les tâches sélectionnées à l'équipe de validation</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">Aucune tâche ne vous est assignée</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Tâches de l'équipe de validation</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Effectuer les tâches sélectionnées</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">Aucune tâche ne doit être effectuée par l'équipe de validation</message>
 	<!-- Same transformer, submissions section -->
 	<message key="xmlui.Submission.Submissions.submit_head1">Soumissions</message>
 	<message key="xmlui.Submission.Submissions.submit_info1a">Vous pouvez </message>
 	<message key="xmlui.Submission.Submissions.submit_info1b">initier une nouvelle soumission. </message>
-	<message key="xmlui.Submission.Submissions.submit_info1c">Le processus de soumission implique la description du document et le t&#233;l&#233;chargement du(des) fichier(s) qui le compose(nt). Chaque communaut&#233; ou collection peut &#233;tablir sa propre politique de soumission.</message>
-	<message key="xmlui.Submission.Submissions.submit_head2">Soumissions inachev&#233;es</message>
-	<message key="xmlui.Submission.Submissions.submit_info2a">Ces soumissions sont incompl&#232;tes. Vous pouvez &#233;galement </message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">Le processus de soumission implique la description du document et le téléchargement du(des) fichier(s) qui le compose(nt). Chaque communauté ou collection peut établir sa propre politique de soumission.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Soumissions inachevées</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Ces soumissions sont incomplètes. Vous pouvez également </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">initier une autre soumission</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Titre</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Collection</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Soumis par</message>
-	<message key="xmlui.Submission.Submissions.submit_head3">Cr&#233;ation&#160;:</message>
-	<message key="xmlui.Submission.Submissions.submit_info3">Aucune soumission n'a &#233;t&#233; laiss&#233;e incompl&#232;te.</message>
-	<message key="xmlui.Submission.Submissions.submit_head4">Supervision&#160;:</message>
-	<message key="xmlui.Submission.Submissions.submit_submit_remove">Supprimer les soumissions s&#233;lectionn&#233;es</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Création :</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">Aucune soumission n'a été laissée incomplète.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Supervision :</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Supprimer les soumissions sélectionnées</message>
 	<!-- Same transformer, inprogress section -->
-	<message key="xmlui.Submission.Submissions.progress_head1">Soumissions en cours de r&#233;vision</message>
-	<message key="xmlui.Submission.Submissions.progress_info1">Ces soumissions sont actuellement en cours de r&#233;vision par les responsables de la collection de d&#233;p&#244;t.</message>
+	<message key="xmlui.Submission.Submissions.progress_head1">Soumissions en cours de révision</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Ces soumissions sont actuellement en cours de révision par les responsables de la collection de dépôt.</message>
 	<message key="xmlui.Submission.Submissions.progress_column1">Titre</message>
 	<message key="xmlui.Submission.Submissions.progress_column2">Collection</message>
 	<message key="xmlui.Submission.Submissions.progress_column3">Statut</message>
 	<!-- Same transformer, workflow status -->
 	<message key="xmlui.Submission.Submissions.status_0">Soumis</message>
-	<message key="xmlui.Submission.Submissions.status_1">En attente de validation par l'&#233;quipe de r&#233;vision</message>
-	<message key="xmlui.Submission.Submissions.status_2">Soumission en cours de validation par l'&#233;quipe de r&#233;vision</message>
-	<message key="xmlui.Submission.Submissions.status_3">En attente de validation par l'&#233;quipe d'&#233;dition</message>
-	<message key="xmlui.Submission.Submissions.status_4">Soumission en cours de validation par l'&#233;quipe d'&#233;dition</message>
-	<message key="xmlui.Submission.Submissions.status_5">En attente de validation par l'&#233;quipe de r&#233;daction</message>
-	<message key="xmlui.Submission.Submissions.status_6">Soumission en cours de validation par l'&#233;quipe de r&#233;daction</message>
-	<message key="xmlui.Submission.Submissions.status_7">La soumission a &#233;t&#233; archiv&#233;e</message>
-	<message key="xmlui.Submission.Submissions.status_unknown">&#233;tat inconnu</message>
+	<message key="xmlui.Submission.Submissions.status_1">En attente de validation par l'équipe de révision</message>
+	<message key="xmlui.Submission.Submissions.status_2">Soumission en cours de validation par l'équipe de révision</message>
+	<message key="xmlui.Submission.Submissions.status_3">En attente de validation par l'équipe d'édition</message>
+	<message key="xmlui.Submission.Submissions.status_4">Soumission en cours de validation par l'équipe d'édition</message>
+	<message key="xmlui.Submission.Submissions.status_5">En attente de validation par l'équipe de rédaction</message>
+	<message key="xmlui.Submission.Submissions.status_6">Soumission en cours de validation par l'équipe de rédaction</message>
+	<message key="xmlui.Submission.Submissions.status_7">La soumission a été archivée</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">état inconnu</message>
         <!-- Same transformer, completed submissions section -->
-        <message key="xmlui.Submission.Submissions.completed.head">Soumissions archiv&#233;es</message>
-        <message key="xmlui.Submission.Submissions.completed.info">Ces soumissions ont &#233;t&#233; accept&#233;es dans le d&#233;p&#244;t DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.head">Soumissions archivées</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Ces soumissions ont été acceptées dans le dépôt DSpace.</message>
         <message key="xmlui.Submission.Submissions.completed.column1">Date d'acceptation</message>
         <message key="xmlui.Submission.Submissions.completed.column2">Titre</message>
         <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
-        <message key="xmlui.Submission.Submissions.completed.limit">Seules 50 de vos soumissions archiv&#233;es sont affich&#233;es dans la liste figurant ci-haut. </message>
-        <message key="xmlui.Submission.Submissions.completed.displayall">Faire afficher toutes mes soumissions archiv&#233;es.</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Seules 50 de vos soumissions archivées sont affichées dans la liste figurant ci-haut. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Faire afficher toutes mes soumissions archivées.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Questions initiales</message>
-	<message key="xmlui.Submission.submit.progressbar.describe">D&#233;crire</message>
-	<message key="xmlui.Submission.submit.progressbar.access">Acc&#232;s</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">T&#233;l&#233;charger</message>
-	<message key="xmlui.Submission.submit.progressbar.verify">V&#233;rifier</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Décrire</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Accès</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Télécharger</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Vérifier</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-    <message key="xmlui.Submission.submit.progressbar.CClicense">CC Licence</message>
-	<message key="xmlui.Submission.submit.progressbar.license">Licence</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC Licence</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Licence</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Fin</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Reprendre</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-	<message key="xmlui.Submission.submit.SelectCollection.head">S&#233;lectionner une collection</message>
+	<message key="xmlui.Submission.submit.SelectCollection.head">Sélectionner une collection</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection">Collection</message>
-	<message key="xmlui.Submission.submit.SelectCollection.collection_help">S&#233;lectionner la collection dans laquelle vous souhaitez soumettre un document.</message>
-	<message key="xmlui.Submission.submit.SelectCollection.collection_default">S&#233;lectionner une collection&#8230;</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Sélectionner la collection dans laquelle vous souhaitez soumettre un document.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Sélectionner une collection…</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Enregistrer ou annuler votre soumission?</message>
-	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voulez-vous supprimer la soumission, ou voulez-vous continuer &#224; y travailler plus tard? Vous pouvez revenir au processus de soumission si vous avez cliqu&#233; sur "quitter" par erreur.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Voulez-vous supprimer la soumission, ou voulez-vous continuer à y travailler plus tard? Vous pouvez revenir au processus de soumission si vous avez cliqué sur "quitter" par erreur.</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Oups, reprendre le processus de soumission</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Enregistrez-la, je vais la terminer plus tard</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Supprimer la soumission</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Questions initiales</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Note importante&#160;: </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Note importante : </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.and"> et </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">, </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Plusieurs titres</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Le document a plus d'un titre, par exemple, un titre traduit</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la case ci-dessus n'est pas coch&#233;e alors le(s) titre(s) suivant(s) sera(seront) retir&#233;(s) du document&#160;: </message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publi&#233;</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Le document a &#233;t&#233; publi&#233; ou diffus&#233; publiquement auparavant</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la case ci-dessus n'est pas coch&#233;e alors l'&#233;l&#233;ment suivant sera retir&#233; du document&#160;: </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Le document a plus d'un titre, par exemple, un titre traduit<i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Si la case ci-dessus n'est pas cochée alors le(s) titre(s) suivant(s) sera(seront) retiré(s) du document : </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publié</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Le document a été publié ou diffusé publiquement auparavant</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Si la case ci-dessus n'est pas cochée alors l'élément suivant sera retiré du document : </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Date de publication</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">R&#233;f&#233;rence bibliographique</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">&#201;diteur</message>
-	
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Référence bibliographique</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Éditeur</message>
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-	<message key="xmlui.Submission.submit.DescribeStep.head">D&#233;crire le document</message>
-	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Erreur&#160;: type de champ inconnu</message>
+	<message key="xmlui.Submission.submit.DescribeStep.head">Décrire le document</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Erreur : type de champ inconnu</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Ce champ est obligatoire</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nom de famille, par exemple, Dupont</message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Pr&#233;nom(s) (+ initiales), par exemple, Pierre A.</message>
-	<message key="xmlui.Submission.submit.DescribeStep.year">Ann&#233;e</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nom de famille, par exemple, Dupont<i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Prénom(s) (+ initiales), par exemple, Pierre A.<i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Année</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Mois</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Jour</message>
-	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la s&#233;rie/collection</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nom de la série/collection</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Vol. No/No de rapport</message>
-	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Cat&#233;gorie de sujet</message>
-	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Cat&#233;gorie de sujet</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Catégorie de sujet</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Catégorie de sujet</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtrer des sujets</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtrer</message>
-	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Veuillez attendre tandis que le vocabulaire control&#233; est charg&#233;.</message>
-	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Il &#233;tait une erreur, en chargeant le vocabulaire control&#233;, essayez encore une fois.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Veuillez attendre tandis que le vocabulaire controlé est chargé.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Il était une erreur, en chargeant le vocabulaire controlé, essayez encore une fois.</message>
 
 
-	<!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
-    <message key="xmlui.Submission.submit.AccessStep.head">Options d'acc&#232;s</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Options d'accès</message>
     <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible pour un groupe des utilisateurs sélectionnés (ceci n'est pas obligatoire pour Anonyme)</message>
-    <message key="xmlui.Submission.submit.AccessStep.open_access">Permetre l'acc&#232;s depuis l'item est accept&#233; dans le d&#233;p&#244;t</message>
-    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo jusqu'&#224; une date sp&#233;cifique</message>
-    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Acc&#232;s pour un groupe s&#233;lectionn&#233;</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Permetre l'accès depuis l'item est accepté dans le dépôt</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo jusqu'à une date spécifique</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Accès pour un groupe sélectionné</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Nom de politique</message>
-    <message key="xmlui.Submission.submit.AccessStep.name_help">Un nom court et descriptif pour la politique (30 caract&#232;res au maximum). Peut &#234;tre montr&#233; aux utilisateurs finals. Par exemple: &quot;uniquement personnel&quot;. Optionnel, mais recommand&#233;.</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">Un nom court et descriptif pour la politique (30 caractères au maximum). Peut être montré aux utilisateurs finals. Par exemple: "uniquement personnel". Optionnel, mais recommandé.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Raison de l'embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.reason_help">La raison de l'embargo, normalement seulement pour l'usage interne. Optionelle.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirmer politique &amp; ajoute une autre</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Groupe</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Erreur de format de la date</message>
-    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Quand l'embargo est s&#233;lectionn&#233;, la date est obligatoire</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Quand l'embargo est sélectionné, la date est obligatoire</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Une politique identique pour ce groupe et cet action est déjà définie.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Politiques de groupe</message>
-    <message key="xmlui.Submission.submit.AccessStep.policies_help">Les politiques list&#233;es dans cette section remplace tous les politiques d&#233;fautes pour la collection pr&#233;f&#233;r&#233;e. Si vous veuillez appliquer un embargo mais la collection permet l'acc&#232;s pour tous utilisateurs, vous devez cr&#233;er une politique qui permet l'acc&#232;s pour le groupe anonyme depuis une date sp&#233;cifique.</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Les politiques listées dans cette section remplace tous les politiques défautes pour la collection préférée. Si vous veuillez appliquer un embargo mais la collection permet l'accès pour tous utilisateurs, vous devez créer une politique qui permet l'accès pour le groupe anonyme depuis une date spécifique.</message>
     <message key="xmlui.Submission.submit.AccessStep.no_policies">Il n'y a aucune politique en vigueur pour cet item..</message>
     <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
-    <message key="xmlui.Submission.submit.AccessStep.private_settings">Item priv&#233;</message>
-    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Si s&#233;lectionn&#233;, On ne pourra pas chercher l'item</message>
-    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Priv&#233;</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Item privé</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Si sélectionné, On ne pourra pas chercher l'item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Privé</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Nom</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Groupe</message>
-    <message key="xmlui.Submission.submit.AccessStep.column3">Date de d&#233;but</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Date de début</message>
     <message key="xmlui.Submission.submit.AccessStep.column4">Date de fin</message>
-    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">&#201;diter</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Éditer</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Supprimer</message>
-    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Le premier jour depuis l'acc&#232;s est permis. Format acceptable: aaaa, aaaa-mm, aaaa-mm-qq</message>
-    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nom: {0}; action: {1}, groupe: {2}, date de d&#233;but: {3}, date de fin {4}</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Le premier jour depuis l'accès est permis. Format acceptable: aaaa, aaaa-mm, aaaa-mm-qq</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Nom: {0}; action: {1}, groupe: {2}, date de début: {3}, date de fin {4}</message>
     <message key="xmlui.Submission.submit.AccessStep.review_public_item">On ne pourra pas chercher l'item</message>
     <message key="xmlui.Submission.submit.AccessStep.review_private_item">On ne pourra pas chercher l'item</message>
 
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
-    <message key="xmlui.Submission.submit.EditPolicyStep.head">Politique d'&#233;dition</message>
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Politique d'édition</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-	<message key="xmlui.Submission.submit.UploadStep.head">T&#233;l&#233;charger le(s) fichier(s)</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+	<message key="xmlui.Submission.submit.UploadStep.head">Télécharger le(s) fichier(s)</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Fichier</message>
-	<message key="xmlui.Submission.submit.UploadStep.file_help">Pri&#232;re d'entrer le chemin complet du fichier sur votre ordinateur correspondant &#224; votre document. Si vous cliquez sur "Parcourir&#8230;", une nouvelle fen&#234;tre vous permettra de s&#233;lectionner le fichier sur votre ordinateur.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Prière d'entrer le chemin complet du fichier sur votre ordinateur correspondant à votre document. Si vous cliquez sur "Parcourir…", une nouvelle fenêtre vous permettra de sélectionner le fichier sur votre ordinateur.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Le document doit contenir au moins un fichier.</message>
-	<message key="xmlui.Submission.submit.UploadStep.upload_error">Il y a eu un probl&#232;me lors du transfert de votre fichier. Soit le nom du fichier est incorrect, soit un probl&#232;me r&#233;seau qui a emp&#234;ch&#233; le fichier de nous parvenir correctement est survenu, ou soit encore vous avez tent&#233; de t&#233;l&#233;charger un fichier dont le format est r&#233;serv&#233; &#224; l'utilisation du interne du syst&#232;me. Veuillez essayez de nouveau.</message>
-		<message key="xmlui.Submission.submit.UploadStep.virus_error">Le fichier n'a pas &#233;t&#233; charg&#233; puisqu'il semble contenir un virus. Pri&#232;re de contacter l'administrateur du syst&#232;me.</message>
-    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Un probl&#232;me technique est survenu lors de la v&#233;rification antivirus du fichierr viruses. Pri&#232;re de contacter l'administrateur du syst&#232;me.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Description du fichier</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Optionnellement, vous pouvez fournir une br&#232;ve description du fichier, par exemple "<i>Article principal</i>", ou "<i>Lectures de donn&#233;es exp&#233;rimentales</i>".</message>
-	<message key="xmlui.Submission.submit.UploadStep.submit_upload">T&#233;l&#233;charger un fichier et ajouter un autre</message>
-	<message key="xmlui.Submission.submit.UploadStep.head2">Fichiers t&#233;l&#233;charg&#233;s</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Il y a eu un problème lors du transfert de votre fichier. Soit le nom du fichier est incorrect, soit un problème réseau qui a empêché le fichier de nous parvenir correctement est survenu, ou soit encore vous avez tenté de télécharger un fichier dont le format est réservé à l'utilisation du interne du système. Veuillez essayez de nouveau.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">Le fichier n'a pas été chargé puisqu'il semble contenir un virus. Prière de contacter l'administrateur du système.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Un problème technique est survenu lors de la vérification antivirus du fichierr viruses. Prière de contacter l'administrateur du système.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Description du fichier</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Optionnellement, vous pouvez fournir une brève description du fichier, par exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Télécharger un fichier et ajouter un autre</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Fichiers téléchargés</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Primaire</message>
 	<message key="xmlui.Submission.submit.UploadStep.column1"> </message>
 	<message key="xmlui.Submission.submit.UploadStep.column2">Fichier</message>
 	<message key="xmlui.Submission.submit.UploadStep.column3">Taille</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Description</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Inconnu</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">format inconnu</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Pris en charge)</message>
 	<message key="xmlui.Submission.submit.UploadStep.known">(Connu)</message>
 	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Non pris en charge)</message>
-	<message key="xmlui.Submission.submit.UploadStep.submit_edit">&#201;diter</message>
-	<message key="xmlui.Submission.submit.UploadStep.checksum">Somme de contr&#244;le du fichier&#160;:</message>
-	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Supprimer les fichiers s&#233;lectionn&#233;s</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Éditer</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Somme de contrôle du fichier :</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Supprimer les fichiers sélectionnés</message>
 
 
 
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">T&#233;l&#233;charger un fichier</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Télécharger un fichier</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Fichier</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Veuillez entrer le chemin d'acc&#232;s complet du fichier sur votre ordinateur, correstpondant &#224;votre item. Si vous cliquez sur &quot;Parcourir...&quot;, une nouvelle fen&#234;tre vous permettra de s&#233;lectionner le fichier sur votre ordinateur.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Veuillez entrer le chemin d'accès complet du fichier sur votre ordinateur, correstpondant àvotre item. Si vous cliquez sur "Parcourir...", une nouvelle fenêtre vous permettra de sélectionner le fichier sur votre ordinateur.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Le document doit contenir au moins un fichier.</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Il y a eu un probl&#232;me lors du transfert de votre fichier. Soit le nom du fichier est incorrect, soit un probl&#232;me r&#233;seau qui a emp&#234;ch&#233; le fichier de nous parvenir correctement est survenu, ou soit encore vous avez tent&#233; de t&#233;l&#233;charger un fichier dont le format est r&#233;serv&#233; &#224; l'utilisation du interne du syst&#232;me. Veuillez essayez de nouveau.</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Le fichier n'a pas &#233;t&#233; charg&#233; puisqu'il semble contenir un virus. Pri&#232;re de contacter l'administrateur du syst&#232;me.</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Un probl&#232;me technique est survenu lors de la v&#233;rification antivirus du fichierr viruses. Pri&#232;re de contacter l'administrateur du syst&#232;me.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">Il y a eu un problème lors du transfert de votre fichier. Soit le nom du fichier est incorrect, soit un problème réseau qui a empêché le fichier de nous parvenir correctement est survenu, ou soit encore vous avez tenté de télécharger un fichier dont le format est réservé à l'utilisation du interne du système. Veuillez essayez de nouveau.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Le fichier n'a pas été chargé puisqu'il semble contenir un virus. Prière de contacter l'administrateur du système.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Un problème technique est survenu lors de la vérification antivirus du fichierr viruses. Prière de contacter l'administrateur du système.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Description du fichier</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionnellement, vous pouvez fournir une br&#232;ve description du fichier, par exemple "<i>Article principal</i>", ou "<i>Lectures de donn&#233;es exp&#233;rimentales</i>".</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">T&#233;l&#233;charger un fichier et ajouter un autre</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Fichiers t&#233;l&#233;charg&#233;s</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionnellement, vous pouvez fournir une brève description du fichier, par exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Télécharger un fichier et ajouter un autre</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Fichiers téléchargés</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primaire</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">Fichier</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Taille</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Inconnu</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">format inconnu</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Pris en charge)</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Connu)</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Non pris en charge)</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">&#201;diter</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Somme de contr&#244;le du fichier&#160;:</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Supprimer les fichiers s&#233;lectionn&#233;s</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Éditer</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">Somme de contrôle du fichier :</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Supprimer les fichiers sélectionnés</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Politiques</message>
 
 
@@ -837,343 +871,344 @@
 	<message key="xmlui.Submission.submit.EditFileStep.head">Modifier le fichier</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Fichier</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Description du fichier</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Optionnellement, vous pouvez fournir une br&#232;ve description du fichier, par exemple "<i>Article principal</i>", ou "<i>Lectures de donn&#233;es exp&#233;rimentales</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">S&#233;lectionner le format du fichier dans la liste ci-dessous, par exemple "<i>Adobe PDF</i>" ou "<i>Microsoft Word</i>". Si le format n'est pas dans la liste, pri&#232;re de le d&#233;crire dans la zone de saisie ci-dessous.</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Format d&#233;tect&#233;</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Format s&#233;lectionn&#233;</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Optionnellement, vous pouvez fournir une brève description du fichier, par exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Sélectionner le format du fichier dans la liste ci-dessous, par exemple "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Format détecté</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Format sélectionné</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">le format n'est pas dans la liste</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Si le format n'est pas dans la liste ci-dessus, <strong>s&#233;lectionner "le format n'est pas dans la liste" ci-dessus</strong> et d&#233;crire le format de fichier dans la bo&#238;te ci-dessous.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Si le format n'est pas dans la liste ci-dessus, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Autre format</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Le nom de l'application utilis&#233;e pour cr&#233;er le fichier et le num&#233;ro de version (par exemple, "ACMESoft SuperApp version 1.5").</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Le nom de l'application utilisée pour créer le fichier et le numéro de version (par exemple, "ACMESoft SuperApp version 1.5").<i>ACMESoft SuperApp version 1.5</i>").</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
-    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Acc&#232;s du fichier</message>
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Accès du fichier</message>
 
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-	<message key="xmlui.Submission.submit.ReviewStep.head">R&#233;vision de la soumission</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head">Révision de la soumission</message>
 	<message key="xmlui.Submission.submit.ReviewStep.yes">Oui</message>
 	<message key="xmlui.Submission.submit.ReviewStep.no">Aucun</message>
-	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corriger un de ces &#233;l&#233;ments</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corriger un de ces éléments</message>
 	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Ajouter ou supprimer un fichier</message>
 	<message key="xmlui.Submission.submit.ReviewStep.head1">Questions initiales</message>
-	<message key="xmlui.Submission.submit.ReviewStep.head2">D&#233;crire page {0}</message>
-	<message key="xmlui.Submission.submit.ReviewStep.head3">Fichiers t&#233;l&#233;charg&#233;s</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Décrire page {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Fichiers téléchargés</message>
 	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Plusieurs titres</message>
-	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publi&#233; auparavant</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publié auparavant</message>
 	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">inconnu</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">connu</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">soutenu</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Une erreur est survenue&#8230; {0}</message>	
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Ajouter une licence &#224; votre document</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">Si vous le souhaitez, vous pouvez ajouter une licence <a href="http://creativecommons.org/">Creative Commons</a> &#224; votre document. <strong>Les licences Creative Commons r&#233;gissent ce que les gens qui lisent vos travaux peuvent en faire.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Une erreur est survenue… {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Ajouter une licence à votre document</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Si vous le souhaitez, vous pouvez ajouter une licence <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choisir une licence</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Visiter le site de Creative Commons o&#249; vous sera pr&#233;sent&#233; plusieurs options de licence</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Type de licence</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">S&#233;lectionner ou modifier votre licence&#8230;</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Visiter le site de Creative Commons où vous sera présenté plusieurs options de licence</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Type de licence</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Sélectionner ou modifier votre licence…</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Pas de licence Creative Commons</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Vous devez cliquer sur "Suivant" pour sauvegarder vos modifications.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Licence de diffusion</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1">Derni&#232;re &#233;tape&#160;: Pour permettre &#224; DSpace de reproduire, traduire et distribuer dans le monde entier votre document, vous devez accepter les dispositions suivantes.</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info2">Accorder la licence de diffusion standard en s&#233;lectionnant "J'accorde la licence", puis en cliquant sur "Finaliser la soumission".</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info3">Si vous avez des questions concernant cette licence pri&#232;re de contacter les administrateurs syst&#232;me.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1">Dernière étape : Pour permettre à DSpace de reproduire, traduire et distribuer dans le monde entier votre document, vous devez accepter les dispositions suivantes.<strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Accorder la licence de diffusion standard en sélectionnant "J'accorde la licence", puis en cliquant sur "Finaliser la soumission".</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Si vous avez des questions concernant cette licence prière de contacter les administrateurs système.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licence de diffusion</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">J'accorde la licence</message>
-	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Vous devez accorder cette licence pour compl&#233;ter votre soumission. Si vous n'&#234;tes pas en mesure d'accorder cette licence &#224; ce moment, vous pouvez enregistrer votre soumission et y revenir plus tard ou encore annuler la soumission en cliquant sur le bouton "Sauvegarder et quitter" ci-dessous.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Vous devez accorder cette licence pour compléter votre soumission. Si vous n'êtes pas en mesure d'accorder cette licence à ce moment, vous pouvez enregistrer votre soumission et y revenir plus tard ou encore annuler la soumission en cliquant sur le bouton "Sauvegarder et quitter" ci-dessous.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-	<message key="xmlui.Submission.submit.RemovedStep.head">Soumission retir&#233;e</message>
-	<message key="xmlui.Submission.submit.RemovedStep.info1">Votre soumission a &#233;t&#233; annul&#233;e, et le document incomplet a &#233;t&#233; supprim&#233; du syst&#232;me.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Aller &#224; la page des Soumissions</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.head">Soumission retirée</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Votre soumission a été annulée, et le document incomplet a été supprimé du système.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Aller à la page des Soumissions</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Soumission finalis&#233;e</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">Votre soumission devra maintenant passer par le processus de v&#233;rification propre &#224; cette collection. Vous recevrez un avis par courriel d&#232;s que votre soumission sera archiv&#233;e ou encore s'il survient un probl&#232;me avec votre soumission. Vous pouvez &#233;galement v&#233;rifier le statut de votre soumission en visitant la page de vos Soumissions.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Aller &#224; la page de Soumissions</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Soumettre un autre document</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Soumission finalisée</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Votre soumission devra maintenant passer par le processus de vérification propre à cette collection. Vous recevrez un avis par courriel dès que votre soumission sera archivée ou encore s'il survient un problème avec votre soumission. Vous pouvez également vérifier le statut de votre soumission en visitant la page de vos Soumissions.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Aller à la page de Soumissions</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Soumettre un autre document</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Actions que vous pouvez effectuer concernant cette t&#226;che&#160;:</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Vous attribuer cette t&#226;che &#224; vous-m&#234;me.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Prendre la t&#226;che</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Laisser cette t&#226;che dans les t&#226;ches communes pour qu'un autre r&#233;viseur la prenne.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Laisser la t&#226;che</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si vous avez pass&#233; en revue le document et qu'il convient de l'inclure dans la collection, s&#233;lectionner "Approuver".</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Actions que vous pouvez effectuer concernant cette tâche :</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Vous attribuer cette tâche à vous-même.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Prendre la tâche</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Laisser cette tâche dans les tâches communes pour qu'un autre réviseur la prenne.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Laisser la tâche</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Si vous avez passé en revue le document et qu'il convient de l'inclure dans la collection, sélectionner "Approuver".</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Approuver le document</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Une fois que vous avez &#233;dit&#233; le document, utiliser cette option pour archiver le document dans le d&#233;p&#244;t.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Archiver dans le d&#233;p&#244;t</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si vous avez pass&#233; en revue la document et avez constat&#233; qu'il <strong>n'est pas appropri&#233;</strong> de l'inclure dans la collection, s&#233;lectionner "Rejeter". Vous serez alors invit&#233; &#224; saisir un message indiquant pourquoi le document n'est pas ad&#233;quat, et si le demandeur devrait corriger quelque chose et le resoumettre.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Une fois que vous avez édité le document, utiliser cette option pour archiver le document dans le dépôt.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Archiver dans le dépôt</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Si vous avez passé en revue la document et avez constaté qu'il <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rejeter le document</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">S&#233;lectionner cette option pour modifier les m&#233;tadonn&#233;es du document.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Modifier les m&#233;tadonn&#233;es</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Retourner la t&#226;che dans les t&#226;ches communes afin qu'un autre r&#233;viseur puisse ex&#233;cuter la t&#226;che.</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Retourner la t&#226;che dans les t&#226;ches communes</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Sélectionner cette option pour modifier les métadonnées du document.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Modifier les métadonnées</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Retourner la tâche dans les tâches communes afin qu'un autre réviseur puisse exécuter la tâche.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Retourner la tâche dans les tâches communes</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Pri&#232;re d'entrer le motif de rejet de la soumission dans la case ci-dessous, en indiquant si le demandeur doit corriger un probl&#232;me et resoumettre de nouveau.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Prière d'entrer le motif de rejet de la soumission dans la case ci-dessous, en indiquant si le demandeur doit corriger un problème et resoumettre de nouveau.</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Raison du refus</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Une raison est requise</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Refuser le document</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">La t&#226;che a &#233;t&#233; compl&#233;t&#233;e avec succ&#232;s.</message>
-        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">La t&#226;che s'est arr&#234;t&#233;e inopin&#233;ment ou encore elle a &#233;chou&#233;e. Pour plus d'informations pri&#232;re de contacter l'administrateur du syst&#232;me ou encore v&#233;rifier les fichiers de jounalisation (logs) du syst&#232;me.</message>
-        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">La t&#226;che a &#233;t&#233; mise en attente avec succ&#232;s.</message>
-        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">La t&#226;che n'a pu &#234;tre mise en attente. Une erreur est survenue. Pour plus d'informations pri&#232;re de contacter l'administrateur du syst&#232;me ou encore v&#233;rifier les fichiers de jounalisation (logs) du syst&#232;me.</message>
-        
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L'utilisateur a &#233;t&#233; ajout&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">L'utilisateur a &#233;t&#233; &#233;dit&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Un courriel a &#233;t&#233; envoy&#233; &#224; l'utilisateur contenant un lien URL devant &#234;tre utilis&#233; afin de choisir un nouveau mot de passe.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">L'(les) utilisateur(s) a(ont) &#233;t&#233; supprim&#233;(s) avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">L'(les) utilisateur(s) &#233;num&#233;r&#233;s ici n'ont pas &#233;t&#233; supprim&#233;s, car il existe des contraintes qui emp&#234;chent leur suppression, voir la page du d&#233;tail de l'utilisateur pour plus d'informations.</message>
-	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Le groupe a &#233;t&#233; &#233;dit&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Les groupes s&#233;lectionn&#233;s ont &#233;t&#233; supprim&#233;s avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Le nouveau sch&#233;ma a &#233;t&#233; cr&#233;&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Le(s) sch&#233;ma(s) a(ont) &#233;t&#233; supprim&#233;(s) avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Le champ de m&#233;tadonn&#233;es a &#233;t&#233; ajout&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Le champ de m&#233;tadonn&#233;es a &#233;t&#233; modifi&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Le(s) champ(s) a(ont) &#233;t&#233; d&#233;plac&#233;(s) avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Le champ(s) a(ont) &#233;t&#233; supprim&#233;(s) avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Le format a &#233;t&#233; correctement enregistr&#233;.</message>
-	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Le(s) format(s) ont &#233;t&#233; supprim&#233;(s) avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Les m&#233;tadonn&#233;es du document ont &#233;t&#233; mis &#224; jour avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Les nouvelles m&#233;tadonn&#233;es ont &#233;t&#233; ajout&#233;es.</message>
-	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Le document a &#233;t&#233; retir&#233;.</message>
-	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Le document a &#233;t&#233; r&#233;int&#233;gr&#233; dans le d&#233;p&#244;t.</message>
-		<message key="xmlui.administrative.FlowItemUtils.item_moved">Le document a &#233;t&#233; d&#233;plac&#233;.</message>
-	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">La collection de destination n'a pas pu &#234;tre localis&#233;e.</message>
-	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Le nouveau fichier a &#233;t&#233; t&#233;l&#233;charg&#233; avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Erreur lors du t&#233;l&#233;chargement du fichier.</message>
-	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Le fichier a &#233;t&#233; mis &#224; jour.</message>
-	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Le fichier s&#233;lectionn&#233; a &#233;t&#233; supprim&#233;.</message>
-	<message key="xmlui.administrative.FlowMapperUtils.map_items">Les documents ont &#233;t&#233; associ&#233;s avec succ&#232;s.</message>
-	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Les documents ont &#233;t&#233; dissoci&#233;s.</message>
-	
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">La tâche a été complétée avec succès.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">La tâche s'est arrêtée inopinément ou encore elle a échouée. Pour plus d'informations prière de contacter l'administrateur du système ou encore vérifier les fichiers de jounalisation (logs) du système.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">La tâche a été mise en attente avec succès.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">La tâche n'a pu être mise en attente. Une erreur est survenue. Pour plus d'informations prière de contacter l'administrateur du système ou encore vérifier les fichiers de jounalisation (logs) du système.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L'utilisateur a été ajouté avec succès.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">L'utilisateur a été édité avec succès.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Un courriel a été envoyé à l'utilisateur contenant un lien URL devant être utilisé afin de choisir un nouveau mot de passe.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">L'(les) utilisateur(s) a(ont) été supprimé(s) avec succès.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">L'(les) utilisateur(s) énumérés ici n'ont pas été supprimés, car il existe des contraintes qui empêchent leur suppression, voir la page du détail de l'utilisateur pour plus d'informations.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Le groupe a été édité avec succès.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Les groupes sélectionnés ont été supprimés avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Le nouveau schéma a été créé avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Le(s) schéma(s) a(ont) été supprimé(s) avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Le champ de métadonnées a été ajouté avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Le champ de métadonnées a été modifié avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Le(s) champ(s) a(ont) été déplacé(s) avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Le champ(s) a(ont) été supprimé(s) avec succès.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Le format a été correctement enregistré.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Le(s) format(s) ont été supprimé(s) avec succès.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Les métadonnées du document ont été mis à jour avec succès.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Les nouvelles métadonnées ont été ajoutées.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Le document a été retiré.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Le document a été réintégré dans le dépôt.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">Le document a été déplacé.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">La collection de destination n'a pas pu être localisée.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Le nouveau fichier a été téléchargé avec succès.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Erreur lors du téléchargement du fichier.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Le fichier a été mis à jour.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Le fichier sélectionné a été supprimé.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Les documents ont été associés avec succès.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Les documents ont été dissociés.</message>
+
 	<!-- general items for all of the eperson classes -->
-	<message key="xmlui.administrative.eperson.general.epeople_trail">G&#233;rer les individus</message>
-		
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Gérer les individus</message>
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Contexte</message>
-	<message key="xmlui.administrative.Navigation.context_edit_item">&#201;diter ce document</message>
-	<message key="xmlui.administrative.Navigation.context_edit_collection">&#201;diter cette collection </message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Éditer ce document</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Éditer cette collection </message>
 	<message key="xmlui.administrative.Navigation.context_item_mapper">Associer un document</message>
-	<message key="xmlui.administrative.Navigation.context_edit_community">&#201;diter cette communaut&#233;</message>
-	<message key="xmlui.administrative.Navigation.context_create_collection">Cr&#233;er une collection</message>
-	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Cr&#233;er une sous-communaut&#233;</message>
-	<message key="xmlui.administrative.Navigation.context_create_community">Cr&#233;er une communaut&#233;</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Éditer cette communauté</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Créer une collection</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Créer une sous-communauté</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Créer une communauté</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">Exporter le document</message>
-    <message key="xmlui.administrative.Navigation.context_export_collection">Exporter la collection</message>
-    <message key="xmlui.administrative.Navigation.context_export_community">Exporter la communaut&#233;</message>
-	  <message key="xmlui.administrative.Navigation.context_export_metadata">Exporter les m&#233;tadonn&#233;es</message>
-	  
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exporter la collection</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exporter la communauté</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Exporter les métadonnées</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Administration</message>
-	<message key="xmlui.administrative.Navigation.administrative_access_control">Contr&#244;le d'acc&#232;s</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Contrôle d'accès</message>
 	<message key="xmlui.administrative.Navigation.administrative_people">Utilisateurs</message>
 	<message key="xmlui.administrative.Navigation.administrative_groups">Groupes d'utilisateurs</message>
 	<message key="xmlui.administrative.Navigation.administrative_authorizations">Autorisations</message>
 	<message key="xmlui.administrative.Navigation.administrative_registries">Registres</message>
-	<message key="xmlui.administrative.Navigation.administrative_metadata">M&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Métadonnées</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Format</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Documents</message>
-    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Documents retir&#233;s</message>
-    <message key="xmlui.administrative.Navigation.administrative_private">Items Priv&#233;s</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Panneau de configuration</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Documents retirés</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Items Privés</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Panneau de configuration</message>
     <message key="xmlui.administrative.Navigation.statistics">Statistiques</message>
-        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importer les m&#233;tadonn&#233;es</message>
-        <message key="xmlui.administrative.Navigation.administrative_curation">T&#226;ches de conservation</message>
-        
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importer les métadonnées</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Tâches de conservation</message>
+
     <!-- my account items -->
-	<message key="xmlui.administrative.Navigation.account_export">Mes fichiers export&#233;s</message>
-	
-	
+	<message key="xmlui.administrative.Navigation.account_export">Mes fichiers exportés</message>
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Fichiers d'exportation</message>
-	<message key="xmlui.administrative.ItemExport.item.id.error">Le no d'identification du document entr&#233; n'est pas valide.</message>
-	<message key="xmlui.administrative.ItemExport.collection.id.error">Le no d'identification de la collection entr&#233; n'est pas valide.</message>
-	<message key="xmlui.administrative.ItemExport.community.id.error">Le no d'identification de la communaut&#233; entr&#233; n'est pas valide</message>
-	<message key="xmlui.administrative.ItemExport.item.not.found">Le document demand&#233; n'a pas &#233;t&#233; trouv&#233;.</message>
-	<message key="xmlui.administrative.ItemExport.collection.not.found">La collection n'a pas &#233;t&#233; trouv&#233;e.</message>
-	<message key="xmlui.administrative.ItemExport.community.not.found">La communaut&#233; n'a pas &#233;t&#233; trouv&#233;e.</message>
-	<message key="xmlui.administrative.ItemExport.item.success">Le document a &#233;t&#233; export&#233; avec succ&#232;s. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera pr&#234;t pour le t&#233;l&#233;chargement. Vous pouvez &#233;galement cliquer sur le lien "Mes fichiers export&#233;s" pour afficher la liste de vos fichiers disponibles.</message>
-	<message key="xmlui.administrative.ItemExport.collection.success">La collection a &#233;t&#233; export&#233; avec succ&#232;s. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera pr&#234;t pour le t&#233;l&#233;chargement. Vous pouvez &#233;galement cliquer sur le lien "Mes fichiers export&#233;s" pour afficher la liste de vos fichiers disponibles.</message>
-	<message key="xmlui.administrative.ItemExport.community.success">La communaut&#233; a &#233;t&#233; export&#233; avec succ&#232;s. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera pr&#234;t pour le t&#233;l&#233;chargement. Vous pouvez &#233;galement cliquer sur le lien "Mes fichiers export&#233;s" pour afficher la liste de vos fichiers disponibles.</message>
-	<message key="xmlui.administrative.ItemExport.available.head">Fichiers d'exportation disponibles pour t&#233;l&#233;chargement&#160;:</message>
-	
+	<message key="xmlui.administrative.ItemExport.item.id.error">Le no d'identification du document entré n'est pas valide.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">Le no d'identification de la collection entré n'est pas valide.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">Le no d'identification de la communauté entré n'est pas valide</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">Le document demandé n'a pas été trouvé.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">La collection n'a pas été trouvée.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">La communauté n'a pas été trouvée.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Le document a été exporté avec succès. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera prêt pour le téléchargement. Vous pouvez également cliquer sur le lien "Mes fichiers exportés" pour afficher la liste de vos fichiers disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">La collection a été exporté avec succès. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera prêt pour le téléchargement. Vous pouvez également cliquer sur le lien "Mes fichiers exportés" pour afficher la liste de vos fichiers disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">La communauté a été exporté avec succès. Vous devriez recevoir un courriel lorsque le fichier d'exportation sera prêt pour le téléchargement. Vous pouvez également cliquer sur le lien "Mes fichiers exportés" pour afficher la liste de vos fichiers disponibles.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Fichiers d'exportation disponibles pour téléchargement :</message>
+
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">G&#233;rer les utilisateurs</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Gérer les utilisateurs</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Gestionnaire d'utilisateurs</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Actions</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Cr&#233;er un nouvel utilisateur</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Créer un nouvel utilisateur</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Cliquer ici pour ajouter un nouvel utilisateur.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Parcourir la liste d'utilisateurs</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Cliquer ici pour voir tous les utilisateurs.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Recherche d'utilisateurs</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">La recherche d'utilisateurs se fait en fonction d'une correspondance partielle sur le courriel ou le nom.</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">La liste ci-dessous affiche les utilisateurs qui correspondent &#224; votre requ&#234;te de recherche. S&#233;lectionner l'utilisateur que vous souhaitez supprimer puis cliquer sur le bouton "Supprimer" ou cliquer sur le courriel ou le nom afin de pouvoir &#233;diter les informations.</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">R&#233;sultats de recherche</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">La liste ci-dessous affiche les utilisateurs qui correspondent à votre requête de recherche. Sélectionner l'utilisateur que vous souhaitez supprimer puis cliquer sur le bouton "Supprimer" ou cliquer sur le courriel ou le nom afin de pouvoir éditer les informations.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Résultats de recherche</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">No d'identification</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nom</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Courriel</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Supprimer l'utilisateur</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Votre recherche n'a pas retourn&#233; de r&#233;sultats&#8230;</message>
-		
-		
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Votre recherche n'a pas retourné de résultats…</message>
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Ajouter un utilisateur</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Ajouter un utilisateur</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Cr&#233;er un nouvel utilisateur</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Cette adresse courriel est utilis&#233;e par un autre utilisateur. Le courriel doit &#234;tre unique.</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informations relatives au nouvel utilisateur&#160;:</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L'adresse courriel doit &#234;tre unique</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Créer un nouvel utilisateur</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Cette adresse courriel est utilisée par un autre utilisateur. Le courriel doit être unique.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informations relatives au nouvel utilisateur :</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">L'adresse courriel doit être unique</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">L'adresse courriel est requise</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Le pr&#233;nom est requis</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Le prénom est requis</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Le nom est requis</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">L'utilisateur doit avoir recours &#224; un certificat</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">L'utilisateur doit avoir recours à un certificat</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">L'utilisateur peut se connecter</message>
-	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Cr&#233;er un utilisateur</message>
-	
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Créer un utilisateur</message>
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Modifier les informations de l'utilisateur</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Modifier les informations de l'utilisateur</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Modifier les informations de l'utilisateur</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Cette adresse courriel est utilis&#233; par un autre utilisateur. Les courriels doivent &#234;tre uniques.</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">{0} de l'information&#160;:</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L'adresse courriel doit &#234;tre unique</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Cette adresse courriel est utilisé par un autre utilisateur. Les courriels doivent être uniques.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">{0} de l'information :</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">L'adresse courriel doit être unique</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">L'adresse courriel est requise</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Le pr&#233;nom est requis</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Le prénom est requis</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Le nom est requis</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">L'utilisateur doit avoir recours &#224; un certificat</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">L'utilisateur doit avoir recours à un certificat</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">L'utilisateur peut se connecter</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">R&#233;initialiser le mot de passe</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Vous pouvez &#233;galement supprimer d&#233;finitivement cet utilisateur &#224; partir du syst&#232;me ou encore r&#233;initialiser son mot de passe. Lors de la r&#233;initialisation de mot de passe de l'utilisateur, un courriel lui sera envoy&#233; contenant un lien sp&#233;cifique qu'il devra suivre afin de se choisir un nouveau mot de passe.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Réinitialiser le mot de passe</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Vous pouvez également supprimer définitivement cet utilisateur à partir du système ou encore réinitialiser son mot de passe. Lors de la réinitialisation de mot de passe de l'utilisateur, un courriel lui sera envoyé contenant un lien spécifique qu'il devra suivre afin de se choisir un nouveau mot de passe.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Supprimer l'utilisateur</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Connectez-vous en tant que l'utilisateur</message>
-	
-	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Cet individu ne peut pas &#234;tre supprim&#233; en raison de la(les) contrainte(s) suivante(s)&#160;:</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Cet individu ne peut pas être supprimé en raison de la(les) contrainte(s) suivante(s) :</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">et</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">l'utilisateur a soumis un ou plusieurs documents</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l'utilisateur a une soumission en cours de v&#233;rification</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l'utilisateur a une t&#226;che attribu&#233;e en attente d'une action de sa part</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l'utilisateur a une contrainte non identifi&#233;e au sein du syst&#232;me</message>
-	
-	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Groupes dont est membre cet utilisateur&#160;:</message>
-	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(Via le groupe&#160;: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">l'utilisateur a une soumission en cours de vérification</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">l'utilisateur a une tâche attribuée en attente d'une action de sa part</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">l'utilisateur a une contrainte non identifiée au sein du système</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Groupes dont est membre cet utilisateur :</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(Via le groupe : {0})</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">aucun</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirmer la suppression de l'utilisateur</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmer la suppression de l'utilisateur</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmer la suppression de l'utilisateur</message>
-	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">L'utilisateur suivant sera supprim&#233;&#160;:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">L'utilisateur suivant sera supprimé :</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmer la suppression</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">No d'identification</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nom</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Courriel</message>
 
 	<!-- general items for all of the group classes -->
-	<message key="xmlui.administrative.group.general.group_trail">G&#233;rer les groupes</message>
+	<message key="xmlui.administrative.group.general.group_trail">Gérer les groupes</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-	<message key="xmlui.administrative.group.ManageGroupsMain.title">G&#233;rer les groupes</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Gérer les groupes</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Gestionnaire de groupes</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Actions</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Cr&#233;er un nouveau groupe</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Créer un nouveau groupe</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Cliquer ici pour ajouter un nouveau groupe.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Parcourir les groupes</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Cliquer ici pour voir tous les groupes.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Rechercher des groupes</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">La recherche de groupes se fait en fonction d'une correspondance partielle sur leur nom.</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">R&#233;sultats de recherche</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Résultats de recherche</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">No d'identification</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nom</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membres</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Communaut&#233;/Collection</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Communauté/Collection</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Vue</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Supprimer des groupes</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Votre recherche n'a pas retourn&#233; de r&#233;sultats&#8230;</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Votre recherche n'a pas retourné de résultats…</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-	<message key="xmlui.administrative.group.EditGroupForm.title">&#233;diteur de groupes</message>
+	<message key="xmlui.administrative.group.EditGroupForm.title">éditeur de groupes</message>
 	<message key="xmlui.administrative.group.EditGroupForm.trail">Modifier les informations du groupe</message>
-	<message key="xmlui.administrative.group.EditGroupForm.main_head">Modifier les informations du groupe&#160;: {0} (No d'identification&#160;: {1})</message>
-	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Modifier les informations du groupe&#160;: nouveau groupe</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Modifier les informations du groupe : {0} (No d'identification : {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Modifier les informations du groupe : nouveau groupe</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Effacer la recherche</message>
 	<message key="xmlui.administrative.group.EditGroupForm.member">Membre</message>
 	<message key="xmlui.administrative.group.EditGroupForm.cycle">Cycle</message>
 	<message key="xmlui.administrative.group.EditGroupForm.pending">En attente</message>
-	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Veuilles noter que les modifications en attente ne sont pas sauvegard&#233;es tant que vous ne cliquez sur le bouton "Sauvegarder".</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Veuilles noter que les modifications en attente ne sont pas sauvegardées tant que vous ne cliquez sur le bouton "Sauvegarder".</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Ajouter</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Supprimer</message>
-	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Ce groupe est associ&#233; &#224; la collection&#160;: </message>
-	<message key="xmlui.administrative.group.EditGroupForm.community_para">Ce groupe est associ&#233; &#224; la communaut&#233;&#160;: </message>	
-	<message key="xmlui.administrative.group.EditGroupForm.label_name">Changer le nom du groupe&#160;:</message>
-	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Ce groupe est associ&#233; &#224; une collection sp&#233;cifique et le nom ne peut &#234;tre modifi&#233;.</message>
-	<message key="xmlui.administrative.group.EditGroupForm.label_search">Recherche de membres &#224; ajouter&#160;:</message>
-	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Utilisateurs&#8230;</message>
-	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Groupes&#8230;</message>
-	<message key="xmlui.administrative.group.EditGroupForm.no_results">Votre recherche n'a pas retourn&#233; de r&#233;sultats&#8230;</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Ce groupe est associé à la collection : </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Ce groupe est associé à la communauté : </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Changer le nom du groupe :</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Ce groupe est associé à une collection spécifique et le nom ne peut être modifié.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Recherche de membres à ajouter :</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Utilisateurs…</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Groupes…</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">Votre recherche n'a pas retourné de résultats…</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">No d'identification</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nom</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Courriel</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">No d'identification</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nom</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membres</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Collection</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">vue</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membres</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">No d'identification</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nom</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Courriel</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">Le groupe&#160;: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">Le groupe : {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Ce groupe ne comporte pas de membres.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[en attente]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Supprimer des membres</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Supprimer des membres</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirmer la suppression de groupe(s)</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmer la suppression</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmer la suppression</message>
-	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Les groupes suivants seront supprim&#233;s&#160;:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Les groupes suivants seront supprimés :</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">No d'identification</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nom</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Utilisateurs</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Groupes</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Format du Registre</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de m&#233;tadonn&#233;es</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registre de métadonnées</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Supprimer les formats de fichiers</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Supprimer les formats de fichiers</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmer la suppression</message>
-	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">&#202;tes-vous certain que le format devrait &#234;tre supprim&#233;? Tous les fichiers de ce format seront identifi&#233;s comme &#233;tant de format inconnu.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Êtes-vous certain que le format devrait être supprimé? Tous les fichiers de ce format seront identifiés comme étant de format inconnu.</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">No d'identification</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Type MIME</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nom</message>
@@ -1182,9 +1217,9 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Supprimer des champs</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">supprimer des champs</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmer la suppression</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">&#202;tes-vous bien certain de vouloir supprimer ces champs? Si des documents contiennent des m&#233;tadonn&#233;es relatives &#224; ces champs, les champs ne pourront pas &#234;tre supprim&#233;s. Vous devez vous assurer qu'aucun document ne comporte ces champs.</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVERTISSEMENT&#160;:</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Cela provoquera une erreur si un document contient des m&#233;tadonn&#233;es dans ces champs.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Êtes-vous bien certain de vouloir supprimer ces champs? Si des documents contiennent des métadonnées relatives à ces champs, les champs ne pourront pas être supprimés. Vous devez vous assurer qu'aucun document ne comporte ces champs.<b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVERTISSEMENT :</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Cela provoquera une erreur si un document contient des métadonnées dans ces champs.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">No d'identification</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Espace de nommage</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nom</message>
@@ -1193,24 +1228,24 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Supprimer des schema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Supprimer des schema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmer la suppression</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">&#202;tes-vous bien certain de vouloir supprimer ce sch&#233;ma? Si des documents contiennent des m&#233;tadonn&#233;es dans des champs contenus dans ce sch&#233;ma, le sch&#233;ma ne pourra pas &#234;tre supprim&#233;. Vous devez veiller &#224; ce qu'aucun des documents ne contiennent de m&#233;tadonn&#233;es dans ce sch&#233;ma.</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVERTISSEMENT&#160;:</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Cela provoquera une erreur si un document contient des m&#233;tadonn&#233;es relatives &#224; ce sch&#233;ma.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Êtes-vous bien certain de vouloir supprimer ce schéma? Si des documents contiennent des métadonnées dans des champs contenus dans ce schéma, le schéma ne pourra pas être supprimé. Vous devez veiller à ce qu'aucun des documents ne contiennent de métadonnées dans ce schéma.<b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVERTISSEMENT :</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Cela provoquera une erreur si un document contient des métadonnées relatives à ce schéma.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">No d'identification</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espace de noms</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nom</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">&#233;diteur de format de fichier</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">&#233;diteur de format de fichier</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">éditeur de format de fichier</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">éditeur de format de fichier</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nouveau format de fichier</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format de fichier&#160;: {0}</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Fournir des m&#233;tadonn&#233;es descriptives sur le format binaire ci-dessous. Bien que les noms de formats doivent &#234;tre uniques, les types MIME ne sont pas tenus de l'&#234;tre. Vous pouvez avoir des entr&#233;es de format de fichier distinctes pour les diff&#233;rentes versions de Microsoft Word, m&#234;me si le type MIME sera le m&#234;me pour chacune d'elle.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format de fichier : {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Fournir des métadonnées descriptives sur le format binaire ci-dessous. Bien que les noms de formats doivent être uniques, les types MIME ne sont pas tenus de l'être. Vous pouvez avoir des entrées de format de fichier distinctes pour les différentes versions de Microsoft Word, même si le type MIME sera le même pour chacune d'elle.</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nom</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nom unique pour ce format (par exemple, Microsoft Word XP ou Microsoft Word 2000)</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Le champ nom est requis.</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Type MIME</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Le type MIME associ&#233; &#224; ce format, n'a pas &#224; &#234;tre unique.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Le type MIME associé à ce format, n'a pas à être unique.</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Description</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Niveau de soutien</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Le niveau de soutien auquel votre institution souscrit pour ce format.</message>
@@ -1218,266 +1253,300 @@
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Connu</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Soutenu</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Interne</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Les formats identifi&#233;s comme internes sont invisibles &#224; l'utilisateur, et sont utilis&#233;s &#224; des fins administratives.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Les formats identifiés comme internes sont invisibles à l'utilisateur, et sont utilisés à des fins administratives.</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensions de fichier</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions de fichiers sont utilis&#233;es pour identifier automatiquement le format des fichiers t&#233;l&#233;charg&#233;s. Vous pouvez sp&#233;cifier plusieurs extensions pour chaque format.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Les extensions de fichiers sont utilisées pour identifier automatiquement le format des fichiers téléchargés. Vous pouvez spécifier plusieurs extensions pour chaque format.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Sch&#233;ma de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">sch&#233;ma de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Sch&#233;ma de m&#233;tadonn&#233;es&#160;: "{0}"</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Sch&#233;ma de m&#233;tadonn&#233;es pour "{0}". Vous pouvez ajouter de nouveaux champs ou mettre &#224; jour les champs de m&#233;tadonn&#233;es de ce sch&#233;ma. Les champs peuvent aussi &#234;tre s&#233;lectionn&#233;s pour &#234;tre supprim&#233;s ou &#234;tre d&#233;plac&#233;s vers un autre sch&#233;ma.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Les champs de m&#233;tadonn&#233;es du sch&#233;ma</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Schéma de métadonnées</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">schéma de métadonnées</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Schéma de métadonnées : "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Schéma de métadonnées pour "{0}". Vous pouvez ajouter de nouveaux champs ou mettre à jour les champs de métadonnées de ce schéma. Les champs peuvent aussi être sélectionnés pour être supprimés ou être déplacés vers un autre schéma.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Les champs de métadonnées du schéma</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">No d'identification</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Champ</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Note d'application</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Aucun champs de m&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Aucun champs de métadonnées</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Supprimer des champs</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">D&#233;placer les champs vers un autre sch&#233;ma</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Ajouter un nouveau champ de m&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Déplacer les champs vers un autre schéma</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Ajouter un nouveau champ de métadonnées</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nom du champ</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Note d'application</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes compl&#233;mentaires sur ce champ de m&#233;tadonn&#233;es.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Ajouter un nouveau champ de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Mettre &#224; jour le champ&#160;: {0}</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Mettre &#224; jour le champ</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notes complémentaires sur ce champ de métadonnées.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Ajouter un nouveau champ de métadonnées</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Mettre à jour le champ : {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Mettre à jour le champ</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Erreur</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Ce nom de champ est d&#233;j&#224; en cours d'utilisation, tous les &#233;l&#233;ments et les qualificatifs doivent &#234;tre uniques.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'&#233;l&#233;ment du champ est requis.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L'&#233;l&#233;ment du champ contient un caract&#232;re erron&#233;. L'&#233;l&#233;ment ne peut contenir de&#160;: points, caract&#232;res de soulignement, ou d'espaces.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L'&#233;l&#233;ment du champ est trop long; sa longueur doit &#234;tre inf&#233;rieure &#224; 32 caract&#232;res.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Le qualificatif du champ est trop long; sa longueur doit &#234;tre inf&#233;rieure &#224; 32 caract&#232;res.</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Le qualificatif du champ contient un caract&#232;re erron&#233;. L'&#233;l&#233;ment ne peut contenir de&#160;: points, caract&#232;res de soulignement, ou d'espaces.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Ce nom de champ est déjà en cours d'utilisation, tous les éléments et les qualificatifs doivent être uniques.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'élément du champ est requis.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">L'élément du champ contient un caractère erroné. L'élément ne peut contenir de : points, caractères de soulignement, ou d'espaces.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">L'élément du champ est trop long; sa longueur doit être inférieure à 32 caractères.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Le qualificatif du champ est trop long; sa longueur doit être inférieure à 32 caractères.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Le qualificatif du champ contient un caractère erroné. L'élément ne peut contenir de : points, caractères de soulignement, ou d'espaces.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
 	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Registre des formats de fichier</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registre des formats de fichier</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Cette liste de formats de fichier fournit des informations sur les formats connus et leur niveau de soutien. Vous pouvez modifier ou ajouter de nouveaux formats de fichier avec cet outil. Les formats identifi&#233;s comme "internes" sont invisibles &#224; l'utilisateur, et sont utilis&#233;s &#224; des fins administratives.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Cette liste de formats de fichier fournit des informations sur les formats connus et leur niveau de soutien. Vous pouvez modifier ou ajouter de nouveaux formats de fichier avec cet outil. Les formats identifiés comme "internes" sont invisibles à l'utilisateur, et sont utilisés à des fins administratives.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Ajouter un nouveau format de fichier</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">No d'identification</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nom</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Type MIME</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Niveau de soutien</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(Interne)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(Interne)<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Inconnu</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Connu</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Soutien</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Supprimer des formats</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registre de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registre de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Le registre de m&#233;tadonn&#233;es pr&#233;sente une liste &#224; jour de tous les champs de m&#233;tadonn&#233;es disponibles dans le d&#233;p&#244;t. Ces champs peuvent &#234;tre r&#233;partis entre plusieurs sch&#233;mas. DSpace exige toutefois le sch&#233;ma Dublin Core qualifi&#233;. Vous pouvez &#233;tendre le sch&#233;ma Dublin Core avec des champs suppl&#233;mentaires ou encore ajouter de nouveaux sch&#233;mas dans le registre.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registre de métadonnées</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registre de métadonnées</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Le registre de métadonnées présente une liste à jour de tous les champs de métadonnées disponibles dans le dépôt. Ces champs peuvent être répartis entre plusieurs schémas. DSpace exige toutefois le schéma Dublin Core qualifié. Vous pouvez étendre le schéma Dublin Core avec des champs supplémentaires ou encore ajouter de nouveaux schémas dans le registre.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">No d'identification</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espace de nommage</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nom</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Supprimer le sch&#233;ma</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Ajouter un nouveau sch&#233;ma</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Supprimer le schéma</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Ajouter un nouveau schéma</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espace de nommage</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L'espace de nommage devrait &#234;tre un URI &#233;tabli pour le nouveau sch&#233;ma.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">L'espace de nommage devrait être un URI établi pour le nouveau schéma.</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Ce champ est obligatoire.</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nom</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notation abr&#233;g&#233;e pour le sch&#233;ma. Elle sera utilis&#233;e pour pr&#233;fixer le nom d'un champ (dc.element.qualifier, par exemple). La longueur du nom doit &#234;tre inf&#233;rieure &#224; 32 caract&#232;res et ne peut pas contenir d'espaces, de points ou de caract&#232;res de soulignement.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Ce champ est obligatoire et sa longueur doit &#234;tre inf&#233;rieure &#224; 32 caract&#232;res et ne contiennent pas d'espaces, des &#233;poques ou des caract&#232;res de soulignement.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Ajouter un nouveau sch&#233;ma</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Notation abrégée pour le schéma. Elle sera utilisée pour préfixer le nom d'un champ (dc.element.qualifier, par exemple). La longueur du nom doit être inférieure à 32 caractères et ne peut pas contenir d'espaces, de points ou de caractères de soulignement.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Ce champ est obligatoire et sa longueur doit être inférieure à 32 caractères et ne contiennent pas d'espaces, des époques ou des caractères de soulignement.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Ajouter un nouveau schéma</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-	<message key="xmlui.administrative.registries.MoveMetadataField.title">D&#233;placer des champs</message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.trail">D&#233;placer des champs</message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.head1">D&#233;placer des champs de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.para1">S&#233;lectionner un sch&#233;ma cible o&#249; ces champs seront d&#233;plac&#233;s. Si le sch&#233;ma cible poss&#232;de d&#233;j&#224; des champs avec des noms identiques, les champs ne seront pas d&#233;plac&#233;s.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Déplacer des champs</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Déplacer des champs</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Déplacer des champs de métadonnées</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Sélectionner un schéma cible où ces champs seront déplacés. Si le schéma cible possède déjà des champs avec des noms identiques, les champs ne seront pas déplacés.</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.column1">No d'identification</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nom</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Note d'application</message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.para2">D&#233;placer vers le sch&#233;ma&#160;: </message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">D&#233;placer les champs</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Déplacer vers le schéma : </message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Déplacer les champs</message>
 
-	
-	
-	
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorisations</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Liste des politiques</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-	<message key="xmlui.administrative.authorization.AuthorizationMain.title">G&#233;rer les politiques d'autorisation</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Gérer les politiques d'autorisation</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Gestionnaire des politiques d'autorisation</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autorisations du document</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Le no d'identification que vous avez entr&#233; ne correspond &#224; aucun document</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Le no d'identification que vous avez entré ne correspond à aucun document</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Rechercher un document</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Les documents peuvent &#234;tre trouv&#233;s par leur Handle ou par leur no d'identification interne</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Les documents peuvent être trouvés par leur Handle ou par leur no d'identification interne</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Trouver</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Outil de gestion avan&#231;&#233;e d'autorisations</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Cliquer ici pour acc&#233;der &#224; l'outil de gestion avan&#231;&#233;e d'autorisations des documents</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorisations des communaut&#233;s/collections</message>
-	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Cliquer sur une communaut&#233; ou une collection de modifier ses politiques d'autorisation.</message>
-	
-	
-	
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Outil de gestion avançée d'autorisations</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Cliquer ici pour accéder à l'outil de gestion avançée d'autorisations des documents</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorisations des communautés/collections</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Cliquer sur une communauté ou une collection de modifier ses politiques d'autorisation.</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Modifier les politiques d'autorisation</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Liste des politiques d'autorisation</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Politiques de la collection "{0}" ({1}, no d'identification&#160;: {2})</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Politiques de la communaut&#233; "{0}" ({1}, no d'identification&#160;: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Politiques de la collection "{0}" ({1}, no d'identification : {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Politiques de la communauté "{0}" ({1}, no d'identification : {2})</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Cliquer ici pour ajouter une nouvelle politique.</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Ajouter</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">No d'identification</message>
- 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nom</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nom</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Action</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Groupe</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Date de d&#233;but</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Date de début</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Date de fin</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Supprimer la s&#233;lection</message>
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">&#201;diter</message>
-	
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Supprimer la sélection</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Éditer</message>
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Modifier les politiques d'autorisation du document</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Liste des politiques d'autorisation</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Politiques pour le document {0} (no d'identification = {1})</message>
-	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Avec cet &#233;diteur, vous pouvez consulter et modifier les politiques d'un document, ainsi que modifier les politiques des diff&#233;rents composants d'un document&#160;: les groupements de fichiers et les fichiers. En bref, un document est constitu&#233; de groupements de fichiers, et les groupements de fichiers sont constitu&#233;s de fichiers. Les groupements de fichiers ont g&#233;n&#233;ralement des politiques d'autorisation du type AJOUT/SUPPRESSION/LECTURE/&#201;CRITURE, tandis que fichiers ont uniquement des politiques du type en LECTURE/&#201;CRITURE.</message>
-	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Vous remarquerez un groupement de fichiers ainsi qu'un fichier suppl&#233;mentaires pour chaque document qui contiennent le texte de la licence du document.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Avec cet éditeur, vous pouvez consulter et modifier les politiques d'un document, ainsi que modifier les politiques des différents composants d'un document : les groupements de fichiers et les fichiers. En bref, un document est constitué de groupements de fichiers, et les groupements de fichiers sont constitués de fichiers. Les groupements de fichiers ont généralement des politiques d'autorisation du type AJOUT/SUPPRESSION/LECTURE/ÉCRITURE, tandis que fichiers ont uniquement des politiques du type en LECTURE/ÉCRITURE.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Vous remarquerez un groupement de fichiers ainsi qu'un fichier supplémentaires pour chaque document qui contiennent le texte de la licence du document.</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Politiques du document</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Politiques du groupement de fichiers {0} ({1})</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Fichier {0} ({1})</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Ajouter une nouvelle politique de document</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Ajouter une nouvelle politique de groupement de fichier</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Ajouter une nouvelle politique de fichier</message>
-	
-	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Aucune politique trouv&#233;e pour cet objet.</message>
-	
-	
+
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Aucune politique trouvée pour cet objet.</message>
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Modifier la politique</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Modifier la politique</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Cr&#233;er une nouvelle politique pour {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Créer une nouvelle politique pour {0} {1}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Modifier la politique {0} de {1} {2}</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Aucun groupe s&#233;lectionn&#233;</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Aucune action s&#233;lectionn&#233;e</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Aucun groupe sélectionné</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Aucune action sélectionnée</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">No d'identification</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nom</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Actions pour cette ressource</message>
-	
-	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">&#201;tablir</message>
+
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Établir</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">courant</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">R&#233;sultats de recherche</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">S&#233;lectionner un groupe</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Résultats de recherche</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Sélectionner un groupe</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Chercher un groupe</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Recherche</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">S&#233;lectionner l'action</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Sélectionner l'action</message>
 
-     <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nom</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nom</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Date de d&#233;but</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Date de début</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">Date de fin</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Date non valable</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Une politique identique pour ce groupe et cette action est d&#233;j&#224; en vigueur.</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">La date de d&#233;but est plus grand que la date de fin</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Une politique identique pour ce groupe et cette action est déjà en vigueur.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">La date de début est plus grand que la date de fin</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Format acceptable: aaaa, aaaa-mm, aaaa-mm-qq</message>
-    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Outil de gestion avan&#231;&#233;e d'autorisations</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorisations avan&#231;&#233;es</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Outil de gestion avan&#231;&#233;e d'autorisations</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permettre l'utilisation de caract&#232;res g&#233;n&#233;riques de remplacement (wildcard) pour l'ajout ou la suppression de politiques pour les types de contenu dans une(des) collection(s) sp&#233;cifique(s). AVERTISSEMENT - La suppression des autorisations de LECTURE des documents les rendra non visibles!</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Pour l'ensemble des groupes s&#233;lectionn&#233;s&#8230;</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">&#8230;accorder la possibilit&#233; d'effectuer les actions suivantes&#8230;</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">&#8230;pour tous les types d'objets suivants&#8230;</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">&#8230; &#192; travers les collections suivantes.</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Outil de gestion avançée d'autorisations</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorisations avançées</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Outil de gestion avançée d'autorisations</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permettre l'utilisation de caractères génériques de remplacement (wildcard) pour l'ajout ou la suppression de politiques pour les types de contenu dans une(des) collection(s) spécifique(s). AVERTISSEMENT - La suppression des autorisations de LECTURE des documents les rendra non visibles!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Pour l'ensemble des groupes sélectionnés…</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">…accorder la possibilité d'effectuer les actions suivantes…</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">…pour tous les types d'objets suivants…</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">… À travers les collections suivantes.</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Groupe</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Action</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Type de contenu</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Collection</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Ajouter des politiques</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Supprimer des politiques</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Format acceptable: aaaa, aaaa-mm, aaaa-mm-qq</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Format acceptable: aaaa, aaaa-mm, aaaa-mm-qq</message>
 
-	 <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nom</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nom</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
-    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Date de d&#233;but</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Date de début</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">Date de fin</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Date non valable</message>
-    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">La date de d&#233;but est plus grand que la date de fin</message>
-    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">S&#233;lectionner au moins un groupe</message>
-    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">S&#233;lectionner au moins une collection</message>
-	
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">La date de début est plus grand que la date de fin</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Sélectionner au moins un groupe</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Sélectionner au moins une collection</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmer la suppression de la politique</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmer la suppression</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmer la suppression</message>
-	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Les politiques suivantes seront supprim&#233;es&#160;: </message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Les politiques suivantes seront supprimées : </message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">No d'identification</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Action</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Groupe</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Documents</message>
-	<message key="xmlui.administrative.item.general.template_head">Modifier le mod&#232;le de document pour la collection: {0}</message>
+	<message key="xmlui.administrative.item.general.template_head">Modifier le modèle de document pour la collection: {0}</message>
 	<message key="xmlui.administrative.item.general.option_head">Modifier un document</message>
 	<message key="xmlui.administrative.item.general.option_status">Statut du document</message>
 	<message key="xmlui.administrative.item.general.option_bitstreams">Fichiers du document</message>
-	<message key="xmlui.administrative.item.general.option_metadata">M&#233;tadonn&#233;es du document</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Métadonnées du document</message>
 	<message key="xmlui.administrative.item.general.option_view">Voir le document</message>
         <message key="xmlui.administrative.item.general.option_curate">Conserver</message>
         <message key="xmlui.administrative.item.general.option_queue">Mettre en file d'attente</message>
-        	
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-	<message key="xmlui.administrative.item.AddBitstreamForm.title">T&#233;l&#233;charger le fichier</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.trail">T&#233;l&#233;charger le fichier</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.head1">T&#233;l&#233;charger un nouveau fichier</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Télécharger le fichier</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Télécharger le fichier</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Télécharger un nouveau fichier</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Groupement de fichiers</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fichiers de contenu (par d&#233;faut)</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fichiers de m&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Fichiers de contenu (par défaut)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Fichiers de métadonnées</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Vignettes</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licences</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licences Creative Commons</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Fichier</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Veuillez entrer le nom du fichier sur votre ordinateur correspondant &#224; votre document. Si vous cliquez sur "Parcourir&#8230;", une nouvelle fen&#234;tre appara&#238;tra dans laquelle vous pouvez rechercher et s&#233;lectionner le fichier &#224; partir de votre ordinateur.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Veuillez entrer le nom du fichier sur votre ordinateur correspondant à votre document. Si vous cliquez sur "Parcourir…", une nouvelle fenêtre apparaîtra dans laquelle vous pouvez rechercher et sélectionner le fichier à partir de votre ordinateur.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Description</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Optionnellement, vous pouvez fournir une br&#232;ve description du fichier, par exemple "<i>Article principal</i>", ou "<i>Lectures de donn&#233;es exp&#233;rimentales</i>".</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">T&#233;l&#233;charger</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Vous devez disposer des droits d'AJOUT et d'&#201;CRITURE sur au moins un groupement de fichiers afin d'&#234;tre en mesure de t&#233;l&#233;charger de nouveaux fichiers.</message>
-	
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Optionnellement, vous pouvez fournir une brève description du fichier, par exemple "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Télécharger</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Vous devez disposer des droits d'AJOUT et d'ÉCRITURE sur au moins un groupement de fichiers afin d'être en mesure de télécharger de nouveaux fichiers.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmer la suppression</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmer la suppression</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmer la suppression (s)</message>
-	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">&#202;tes-vous certain de vouloir supprimer ces fichiers: </message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Êtes-vous certain de vouloir supprimer ces fichiers: </message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nom</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Description</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirmer</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirmer</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifier le document&#160;: {0}</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">&#202;tes-vous certain que ce document devrait &#234;tre compl&#232;tement supprim&#233;? Attention&#160;: &#192; l'heure actuelle, aucune trace n'en sera conserv&#233;e.</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">&#202;tes-vous certain que ce document devrait &#234;tre retir&#233; du d&#233;p&#244;t?</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">&#202;tes-vous certain que ce document devrait &#234;tre r&#233;int&#233;gr&#233; dans le d&#233;p&#244;t?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modifier le document : {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Êtes-vous certain que ce document devrait être complètement supprimé? Attention : À l'heure actuelle, aucune trace n'en sera conservée.</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Êtes-vous certain que ce document devrait être retiré du dépôt?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Êtes-vous certain que ce document devrait être réintégré dans le dépôt?</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Champ</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valeur</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Langue</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retirer</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">R&#233;int&#233;gr&#233;</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">D&#233;finir comme priv&#233;</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">D&#233;finir comme publique</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Réintégré</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Définir comme privé</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Définir comme publique</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-	<message key="xmlui.administrative.item.MoveItemForm.title">D&#233;placer</message>
-	<message key="xmlui.administrative.item.MoveItemForm.trail">D&#233;placer</message>
-	<message key="xmlui.administrative.item.MoveItemForm.head1">D&#233;placer le document&#160;: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.title">Déplacer</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Déplacer</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Déplacer le document : {0}</message>
 	<message key="xmlui.administrative.item.MoveItemForm.collection">Collection</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_help">S&#233;lectionner la collection vers laquelle vous voulez d&#233;placer ce document.</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_default">S&#233;lectionner une collection&#8230;</message>
-	<message key="xmlui.administrative.item.MoveItemForm.submit_move">D&#233;placer</message>
-    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">H&#233;riter des politiques</message>
-    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">H&#233;riter les politiques d'autorisation par d&#233;faut de la collection de destination</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Sélectionner la collection vers laquelle vous voulez déplacer ce document.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Sélectionner une collection…</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Déplacer</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Hériter des politiques</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Hériter les politiques d'autorisation par défaut de la collection de destination</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">Modifier les fichiers</message>
@@ -1488,49 +1557,49 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">oui</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">non</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Description</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Optionnellement, vous pouver fournir une br&#232;ve description du fichier, par exemple "<i>Article principal</i>", ou "<i>Lectures de donn&#233;es exp&#233;rimentales</i>".</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">S&#233;lectionner le format du fichier dans la liste ci-dessous, par exemple "<i>Adobe PDF</i>" ou "<i>Microsoft Word</i>". Si le format n'est pas dans la liste, pri&#232;re de le d&#233;crire dans la zone de saisie ci-dessous.</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format s&#233;lectionn&#233;</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Optionnellement, vous pouver fournir une brève description du fichier, par exemple "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Sélectionner le format du fichier dans la liste ci-dessous, par exemple "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Format sélectionné</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format absent de la liste</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si le format n'est pas dans la liste ci-dessus, <strong>s&#233;lectionner "Format absent de la liste"</strong> ci-dessus et le d&#233;crire dans la zone de saisie ci-dessous.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Si le format n'est pas dans la liste ci-dessus, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Autre format</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">L'application utilis&#233;e pour cr&#233;er le fichier et le num&#233;ro de version (par exemple, "ACMESoft SuperApp version 1.5").</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nom du fichier&#160;</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renommer le fichier. Veuiller noter que ceci modifiera l'affichage de l'URL du fichier mais les anciens liens seront toujours fonctionnels tant que le no d'identification s&#233;quentiel ne changera pas.</message>
-	
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">L'application utilisée pour créer le fichier et le numéro de version (par exemple, "ACMESoft SuperApp version 1.5").<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nom du fichier </message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renommer le fichier. Veuiller noter que ceci modifiera l'affichage de l'URL du fichier mais les anciens liens seront toujours fonctionnels tant que le no d'identification séquentiel ne changera pas.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Fichiers du document</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Fichiers du document</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Fichiers</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nom</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Description</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Vue</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Ordre</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label">Groupement de fichiers&#160;: {0}</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label">Groupement de fichiers : {0}<strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (initial) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">vue</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">T&#233;l&#233;charger un nouveau fichier</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Télécharger un nouveau fichier</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Supprimer des fichiers</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Mettre &#224; jour l'ordre des fichiers</message>	
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Vous devez disposer des droits d'AJOUT et d'&#201;CRITURE sur le document et les groupements de fichiers afin d'&#234;tre en mesure de t&#233;l&#233;charger de nouveaux fichiers.</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Seuls les administrateurs du syt&#232;me peuvent supprimer des fichiers.</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Pr&#233;c&#233;dent&#160;:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Mettre à jour l'ordre des fichiers</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Vous devez disposer des droits d'AJOUT et d'ÉCRITURE sur le document et les groupements de fichiers afin d'être en mesure de télécharger de nouveaux fichiers.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Seuls les administrateurs du sytème peuvent supprimer des fichiers.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Précédent :</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Monter</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Descendre</message>	
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Descendre</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-	<message key="xmlui.administrative.item.EditItemMetadataForm.title">M&#233;tadonn&#233;es du document</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">M&#233;tadonn&#233;es du document</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Ajouter de nouvelles m&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Métadonnées du document</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Métadonnées du document</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Ajouter de nouvelles métadonnées</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nom</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valeur</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Langue</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Ajouter de nouvelles m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">VEUILLEZ NOTER&#160;: Ces changements ne sont valid&#233;s d'aucune fa&#231;on. Vous &#234;tes responsable de la saisie des donn&#233;es dans le format ad&#233;quat. Si vous n'&#234;tes pas certain de ce que le format est, pri&#232;re de ne PAS faire des changements.</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">M&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Ajouter de nouvelles métadonnées</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">VEUILLEZ NOTER : Ces changements ne sont validés d'aucune façon. Vous êtes responsable de la saisie des données dans le format adéquat. Si vous n'êtes pas certain de ce que le format est, prière de ne PAS faire des changements.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Métadonnées</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Supprimer</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nom</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valeur</message>
@@ -1539,193 +1608,193 @@
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
 	<message key="xmlui.administrative.item.EditItemStatusForm.title">Statut du document</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Statut du document</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Bienvenue sur la page de gestion du document. &#192; partir d'ici, vous pouvez retirer, r&#233;int&#233;grer ou supprimer le document. Vous pouvez &#233;galement mettre &#224; jour ou ajouter de nouvelles m&#233;tadonn&#233;es/fichiers &#224; partir des autres onglets.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Bienvenue sur la page de gestion du document. À partir d'ici, vous pouvez retirer, réintégrer ou supprimer le document. Vous pouvez également mettre à jour ou ajouter de nouvelles métadonnées/fichiers à partir des autres onglets.</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">No d'identification interne</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Derni&#232;re mise &#224; jour</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Dernière mise à jour</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">Dans les collections</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Page du document</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Modifier les politiques d'autorisation du document</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirer le document du d&#233;p&#244;t</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">R&#233;int&#233;grer le document dans le d&#233;p&#244;t</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">D&#233;placer le document dans une autre collection</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Supprimer d&#233;finitivement le document</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorisations&#8230;</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirer&#8230;</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">R&#233;int&#233;grer&#8230;</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">D&#233;placer&#8230;</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Supprimer d&#233;finitivement</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirer le document du dépôt</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Réintégrer le document dans le dépôt</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Déplacer le document dans une autre collection</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Supprimer définitivement le document</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorisations…</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirer…</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Réintégrer…</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Déplacer…</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Supprimer définitivement</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">non disponible</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(Administrateurs syst&#232;me uniquement)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(Administrateurs système uniquement)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(Administrateurs de collection uniquement)</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(vous n'avez pas les permissions pour effectuer cette action)</message>	
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_private">D&#233;finir l'item comme priv&#233;</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">D&#233;finir l'item comme publique</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">D&#233;finir comme priv&#233;</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">D&#233;finir comme publique</message>
-	
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(vous n'avez pas les permissions pour effectuer cette action)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Définir l'item comme privé</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Définir l'item comme publique</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Définir comme privé</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Définir comme publique</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Voir le document</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Voir le document</message>
         <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-        <message key="xmlui.administrative.item.CurateItemForm.main_head">Conserver le document&#160;: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Conserver le document : {0}</message>
         <message key="xmlui.administrative.item.CurateItemForm.title">Conserver le document</message>
         <message key="xmlui.administrative.item.CurateItemForm.trail">Conservation</message>
-        <message key="xmlui.administrative.item.CurateItemForm.label_name">T&#226;che</message>
-        	
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Tâche</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Trouver un document</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Trouver un document</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_label">No d'identification interne du document/Handle</message>
-	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Impossible de r&#233;soudre les identifiants.</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Impossible de résoudre les identifiants.</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">Trouver</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport -->
-        <message key="xmlui.administrative.metadataimport.general.title">Importer les m&#233;tadonn&#233;es</message>
-        <message key="xmlui.administrative.metadataimport.general.head1">Importer les m&#233;tadonn&#233;es</message>
-        <message key="xmlui.administrative.metadataimport.general.trail">Importer les m&#233;tadonn&#233;es</message>
+        <message key="xmlui.administrative.metadataimport.general.title">Importer les métadonnées</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Importer les métadonnées</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Importer les métadonnées</message>
         <message key="xmlui.administrative.metadataimport.general.changes">modifier</message>
-        <message key="xmlui.administrative.metadataimport.general.no_changes">Aucune modification n'a &#233;t&#233; d&#233;tect&#233;e</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Aucune modification n'a été détectée</message>
         <message key="xmlui.administrative.metadataimport.general.new_item">Nouveau document</message>
-        <message key="xmlui.administrative.metadataimport.flow.upload_successful">T&#233;l&#233;chargement effectu&#233; avec succ&#232;s</message>
-        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Le t&#233;l&#233;chargement a &#233;chou&#233;</message>
-        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">L'en-t&#234;te comporte un sch&#233;ma de m&#233;tadonn&#233;es inconnu</message>
-        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">L'en-t&#234;te comporte un &#233;l&#233;ment de m&#233;tadonn&#233;es inconnu</message>
-        <message key="xmlui.administrative.metadataimport.flow.import_successful">Importation r&#233;ussie</message>
-        <message key="xmlui.administrative.metadataimport.flow.import_failed">L'importation a &#233;chou&#233;e</message>
-        <message key="xmlui.administrative.metadataimport.flow.over_limit">Le nombre de modifications exc&#232;de le maximum permis. Limiter les modifications ou changer le param&#232;tre bulkedit.gui-item-limit dans le fichier dspace.cfg</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Téléchargement effectué avec succès</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Le téléchargement a échoué</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">L'en-tête comporte un schéma de métadonnées inconnu</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">L'en-tête comporte un élément de métadonnées inconnu</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Importation réussie</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">L'importation a échouée</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Le nombre de modifications excède le maximum permis. Limiter les modifications ou changer le paramètre bulkedit.gui-item-limit dans le fichier dspace.cfg</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">T&#233;l&#233;charger fichier CSV</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Télécharger fichier CSV</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Effectu&#233; avec succ&#232;s</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Les modifications ont &#233;t&#233; apport&#233;es au document</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Ajout&#233;&#160;: </message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Supprim&#233;&#160;: </message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Ajout&#233; &#224; la collection-m&#232;re</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Supprim&#233; de la collection-m&#232;re</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Associ&#233; &#224; la collection</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Dissoci&#233; de la collection</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Document supprim&#233;</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Document retir&#233;</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Document r&#233;int&#233;gr&#233;</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Effectué avec succès</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Les modifications ont été apportées au document</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Ajouté : </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Supprimé : </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Ajouté à la collection-mère</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Supprimé de la collection-mère</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Associé à la collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Dissocié de la collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Document supprimé</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Document retiré</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Document réintégré</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Ajouter&#160;: </message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Supprimer&#160;: </message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Ajouter &#224; la collection-m&#232;re</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Supprimer de la collection-m&#232;re</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Associer &#224; la collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Ajouter : </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Supprimer : </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Ajouter à la collection-mère</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Supprimer de la collection-mère</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Associer à la collection</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Dissocier de la collection</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Modifications du document en attente</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Appliquer les modifications</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Les modifications en attente sont list&#233;es plus bas pour v&#233;rification</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Les modifications en attente sont listées plus bas pour vérification</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Supprimer le document</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Retirer le document</message>
-        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">R&#233;int&#233;rer le document</message>
-	
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Réintérer le document</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Associateur de documents</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Associateur de documents</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Associateur de documents - Associer des documents provenant d'autres collections</message>
-	<message key="xmlui.administrative.mapper.MapperMain.para1">Collection&#160;: "{0}"</message>
-	<message key="xmlui.administrative.mapper.MapperMain.para2">Cet outil d'association de documents permet aux administrateurs de collection d'associer des documents provenant d'autres collections dans cette collection. Vous pouvez rechercher des documents d'autres collections et les associer, ou consulter la liste des documents actuellement associ&#233;s.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Collection : "{0}"<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Cet outil d'association de documents permet aux administrateurs de collection d'associer des documents provenant d'autres collections dans cette collection. Vous pouvez rechercher des documents d'autres collections et les associer, ou consulter la liste des documents actuellement associés.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statistiques</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} de {1}</strong> documents de cette collection sont associ&#233;(s) &#224; partir d'autres collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Recherche</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Rechercher des documents</message>
-	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Parcourir les documents associ&#233;s</message>
-	<message key="xmlui.administrative.mapper.MapperMain.no_add">(N&#233;cessite les droits d'AJOUT pour la collection)</message>
-	
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Parcourir les documents associés</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Nécessite les droits d'AJOUT pour la collection)</message>
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Rechercher des documents</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Rechercher des documents</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Rechercher des documents correspondant &#224;&#160;: "{0}"</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Associer les documents s&#233;lectionn&#233;s</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Rechercher des documents correspondant à : "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Associer les documents sélectionnés</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Auteur</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Titre</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Parcourir les documents associ&#233;s</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Parcourir les documents associ&#233;s</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Parcours des documents associ&#233;s</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Dissocier les documents s&#233;lectionn&#233;s</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Parcourir les documents associés</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Parcourir les documents associés</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Parcours des documents associés</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Dissocier les documents sélectionnés</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Auteur</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Titre</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Vous devez disposer des droits de SUPPRESSION sur cette collection afin de pouvoir dissocier des documents de cette collection.</message>
-	
-	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">Collections</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Modifier les m&#233;tadonn&#233;es</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Attribuer des r&#244;les</message>	
-        <message key="xmlui.administrative.collection.general.options_curate">Conservation</message>
-        <message key="xmlui.administrative.collection.general.options_queue">Mettre en file d'attente</message>	
 
-<!--- ICI : -->	
+	<!-- General tags for collection management -->
+	<message key="xmlui.administrative.collection.general.collection_trail">Collections</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Modifier les métadonnées</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Attribuer des rôles</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Conservation</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Mettre en file d'attente</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">&#201;diter les r&#244;les de collection</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">R&#244;les</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">&#201;diter la collection&#160;: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Éditer les rôles de collection</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Rôles</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Éditer la collection : {0}</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">aucun</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Cr&#233;er&#8230;</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restreindre&#8230;</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Les administrateurs de collection d&#233;cident de qui peut soumettre des documents &#224; la collection, qui peut &#233;diter les m&#233;tadonn&#233;es (suite &#224; la soumission), et qui peut ajouter (associer) des documents existants provenant d'autres collections &#224; cette collection (sous r&#233;serve de l'autorisation de ces collections).</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les responsables de cette &#233;tape sont en mesure d'accepter ou de rejeter les soumissions vers&#233;es. Toutefois, ils ne sont pas en mesure de modifier les m&#233;tadonn&#233;es de la soumission.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les responsables de cette &#233;tape sont en mesure de modifier les m&#233;tadonn&#233;es des soumissions vers&#233;es, puis les accepter ou les rejeter.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Les responsables de cette &#233;tape sont en mesure de modifier les m&#233;tadonn&#233;es des soumissions vers&#233;es, mais ne seront pas en mesure de les rejeter.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Le utilisateurs et groupes d'utilisateurs qui ont la permission de soumettre de nouveaux documents &#224; cette collection.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Le utilisateurs et groupes d'utilisateurs qui ont les droits de lecture sur les nouveaux documents soumis &#224; cette collection. Les modifications &#224; ce r&#244;le ne sont pas r&#233;troactives. Les documents actuellement dans le syst&#232;me seront toujours visible par ceux qui avaient acc&#232;s en lecture au moment de leur soumission.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Cette collection utilise des param&#232;tres personnalis&#233;s d'acc&#232;s par d&#233;faut.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Par d&#233;faut, le droit d'acc&#232;s en lecture des documents et fichiers entrants est actuellement attribu&#233; &#224; Anonyme.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">&#201;diter les politiques d'autorisation directement.</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">R&#244;le</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Groupe associ&#233;</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Créer…</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restreindre…</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Les administrateurs de collection décident de qui peut soumettre des documents à la collection, qui peut éditer les métadonnées (suite à la soumission), et qui peut ajouter (associer) des documents existants provenant d'autres collections à cette collection (sous réserve de l'autorisation de ces collections).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Les responsables de cette étape sont en mesure d'accepter ou de rejeter les soumissions versées. Toutefois, ils ne sont pas en mesure de modifier les métadonnées de la soumission.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Les responsables de cette étape sont en mesure de modifier les métadonnées des soumissions versées, puis les accepter ou les rejeter.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Les responsables de cette étape sont en mesure de modifier les métadonnées des soumissions versées, mais ne seront pas en mesure de les rejeter.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Le utilisateurs et groupes d'utilisateurs qui ont la permission de soumettre de nouveaux documents à cette collection.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Le utilisateurs et groupes d'utilisateurs qui ont les droits de lecture sur les nouveaux documents soumis à cette collection. Les modifications à ce rôle ne sont pas rétroactives. Les documents actuellement dans le système seront toujours visible par ceux qui avaient accès en lecture au moment de leur soumission.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Cette collection utilise des paramètres personnalisés d'accès par défaut.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Par défaut, le droit d'accès en lecture des documents et fichiers entrants est actuellement attribué à Anonyme.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Éditer les politiques d'autorisation directement.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rôle</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Groupe associé</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"/>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administrateurs</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">&#201;tapes Workflow</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">&#201;tape Accepter/Refuser</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">&#201;tape Accepter/Refuser/Modifier les m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">&#201;tape Modifier les m&#233;tadonn&#233;es</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Étapes Workflow</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Étape Accepter/Refuser</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Étape Accepter/Refuser/Modifier les métadonnées</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Étape Modifier les métadonnées</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Soumissionnaires</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Acc&#232;s en lecture par d&#233;faut</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(Administrateurs syst&#232;me uniquement)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Groupe au niveau du d&#233;p&#244;t, Administrateurs syst&#232;me uniquement)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(Vous n'avez pas les permissions pour configurer ceci)</nobr></message>
-	
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accès en lecture par défaut</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Conserver la collection&#160;: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Conserver la collection : {0}</message>
         <message key="xmlui.administrative.collection.CurateCollectionForm.title">Conserver la collection</message>
         <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Conservateur</message>
-        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">T&#226;che</message>
-
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Tâche</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmer la suppression</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmer</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirmer la suppression de la collection {0}</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">&#202;tes-vous certain que la collection {0} devrait &#234;tre supprim&#233;e? Ceci supprimera&#160;:</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tous les documents et les soumissions incompl&#232;tes dans cette collection qui ne figurent pas dans d'autres collections</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Êtes-vous certain que la collection {0} devrait être supprimée? Ceci supprimera :</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tous les documents et les soumissions incomplètes dans cette collection qui ne figurent pas dans d'autres collections</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Le contenu de ces documents</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Toutes les politiques d'autorisation associ&#233;es</message>
-	
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Toutes les politiques d'autorisation associées</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmer la suppression du r&#244;le</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirmer la suppression du rôle</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmer</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmer la suppression du r&#244;le {0}</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">&#202;tes-vous certain de vouloir supprimer ce r&#244;le? La suppression de ce groupe donnera acc&#232;s en lecture &#224; tous les utilisateurs pour tous les documents soumis &#224; cette collection &#224; partir de maintenant. Pri&#232;re de noter que ce changement n'est pas r&#233;troactif. L'acc&#232;s aux documents actuellement dans le syst&#232;me sera toujours r&#233;serv&#233; aux membres d&#233;finis par le r&#244;le que vous &#234;tes sur le point de supprimer.</message>
-	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">&#202;tes-vous certain de vouloir supprimer ce r&#244;le? Toutes les modifications et les personnalisations apport&#233;es au groupe {0} seront perdues et devront &#234;tre recr&#233;&#233;es de nouveau.</message>
-	
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirmer la suppression du rôle {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Êtes-vous certain de vouloir supprimer ce rôle? La suppression de ce groupe donnera accès en lecture à tous les utilisateurs pour tous les documents soumis à cette collection à partir de maintenant. Prière de noter que ce changement n'est pas rétroactif. L'accès aux documents actuellement dans le système sera toujours réservé aux membres définis par le rôle que vous êtes sur le point de supprimer.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Êtes-vous certain de vouloir supprimer ce rôle? Toutes les modifications et les personnalisations apportées au groupe {0} seront perdues et devront être recréées de nouveau.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">&#201;diter les m&#233;tadonn&#233;es de la collection</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">M&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">&#201;diter la collection&#160;: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Éditer les métadonnées de la collection</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Métadonnées</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Éditer la collection : {0}</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nom</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Description succincte</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texte d'introduction (HTML)</message>
@@ -1733,155 +1802,153 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Nouvelles (HTML)</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licence</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Provenance</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">T&#233;l&#233;charger un nouveau logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Télécharger un nouveau logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actuel</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Mod&#232;le de document</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Cr&#233;er&#8230;</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">&#201;diter&#8230;</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Modèle de document</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Créer…</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Éditer…</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Supprimer le logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Supprimer la collection</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Enregistrer les mises &#224; jour</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(Administrateurs syst&#232;me uniquement)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Enregistrer les mises à jour</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Cr&#233;er une collection</message>
-	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Cr&#233;er une collection</message>
-	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Entrer les m&#233;tadonn&#233;es pour une nouvelle collection de {0}</message>
-	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Cr&#233;er</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Créer une collection</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Créer une collection</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Entrer les métadonnées pour une nouvelle collection de {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Créer</message>
 
 	<!-- General to the harvesting options under collection -->
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Param&#232;tres de moissonnage de la collection</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Paramètres de moissonnage de la collection</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Moissonnage</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Source de contenu</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Source de contenu</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Ceci est une collection standard de DSpace</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Cette collection moissonne son contenu &#224; partir d'une source externe</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Cette collection moissonne son contenu à partir d'une source externe</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Sauvegarder</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Emplacement de la collection moissonn&#233;e</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Emplacement de la collection moissonnée</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Options de moissonnage</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Fournisseur de contenu OAI</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">No d'identification de l'ensemble (Set) OAI</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Format de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">L'URL du d&#233;p&#244;t cible du fournisseur de service OAI</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Vous devez fournir un URL du d&#233;p&#244;t cible du fournisseur de service OAI.</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">L'identifiant permanent utilis&#233; par le fournisseur OAI afin de d&#233;signer la collection cibl&#233;e</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Vous devez fournir un no d'identification de l'ensemble (Set) OAI de la collection cibl&#233;e.</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Contenu devant &#234;tre moissonn&#233;</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Contenu devant &#234;tre moissonn&#233;</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Moissonner uniquement les m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Moissonner les m&#233;tadonn&#233;es et les r&#233;f&#233;rences aux fichiers (requiert le support ORE).</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Moissonner les m&#233;tadonn&#233;es et les fichiers (requiert le support ORE).</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Tester le param&#233;trage</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Format de métadonnées</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">L'URL du dépôt cible du fournisseur de service OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Vous devez fournir un URL du dépôt cible du fournisseur de service OAI.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">L'identifiant permanent utilisé par le fournisseur OAI afin de désigner la collection ciblée</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Vous devez fournir un no d'identification de l'ensemble (Set) OAI de la collection ciblée.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Contenu devant être moissonné</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Moissonner uniquement les métadonnées</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Moissonner les métadonnées et les références aux fichiers (requiert le support ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Moissonner les métadonnées et les fichiers (requiert le support ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Tester le paramétrage</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Emplacement de la collection moissonn&#233;e</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Emplacement de la collection moissonnée</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Fournisseur OAI</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">No d'identification de l'ensemble (Set) OAI</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Format de m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Contenu devant &#234;tre moissonn&#233;</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">R&#233;sultat du dernier moissonnage</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Cette collection n'a pas encore &#233;t&#233; moissonn&#233;e</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Format de métadonnées</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Contenu devant être moissonné</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Résultat du dernier moissonnage</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Cette collection n'a pas encore été moissonnée</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Statut actuel du moissonnage</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">La collection est pr&#234;te pour le moissonnage</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">La collection est pr&#233;sentement en cours de moissonnage</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">La collection est en file d'attente en vue d'&#234;tre moissonn&#233;e</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">La collection est prête pour le moissonnage</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">La collection est présentement en cours de moissonnage</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">La collection est en file d'attente en vue d'être moissonnée</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Une erreur OAI est survenue lors du dernier moissonnage</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Une erreur inattendue est survenue lors du dernier moissonnage</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Moissonner uniquement les m&#233;tadonn&#233;es.</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Moissonner les m&#233;tadonn&#233;es et les r&#233;f&#233;rences aux fichiers.</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Moissonner les m&#233;tadonn&#233;es et les fichiers (r&#233;plication int&#233;grale).</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Modifier le param&#233;trage</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Moissonner uniquement les métadonnées.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Moissonner les métadonnées et les références aux fichiers.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Moissonner les métadonnées et les fichiers (réplication intégrale).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Modifier le paramétrage</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importer maintenant</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">R&#233;initialiser et importer de nouveau la collection</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Réinitialiser et importer de nouveau la collection</message>
 
 	<message key="xmlui.administrative.ControlPanel.option_harvest">Moissonnage</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Programme de planification du moissonnage</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Statut</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Actions</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Initier le moissonnage</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">R&#233;initialiser le statut du moissonnage</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Réinitialiser le statut du moissonnage</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Reprendre</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Faire une pause</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Arr&#234;ter</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Param&#233;trage des collections pour le moissonnage</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Arrêter</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Paramétrage des collections pour le moissonnage</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Moissonnages actifs</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Moissonnages en attente</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Erreurs OAI</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Erreurs internes</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Param&#233;trage du g&#233;n&#233;rateur</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Paramétrage du générateur</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">URL OAI-PMH</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Source ORE</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Param&#233;trage du moissonnage</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Paramétrage du moissonnage</message>
 
 	<!-- General tags for community management -->
-	<message key="xmlui.administrative.community.general.community_trail">Communaut&#233;s</message>
-	<message key="xmlui.administrative.community.general.options_metadata">&#201;diter les m&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.community.general.options_roles">Attribuer des r&#244;les</message>
+	<message key="xmlui.administrative.community.general.community_trail">Communautés</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Éditer les métadonnées</message>
+	<message key="xmlui.administrative.community.general.options_roles">Attribuer des rôles</message>
         <message key="xmlui.administrative.community.general.options_curate">Conservation</message>
         <message key="xmlui.administrative.community.general.options_queue">Mettre en file d'attente</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-	<message key="xmlui.administrative.community.AssignCommunityRoles.title">&#201;diter les r&#244;les de communaut&#233;</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">R&#244;les</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">&#201;diter la communaut&#233;&#160;: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Éditer les rôles de communauté</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Rôles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Éditer la communauté : {0}</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">aucun</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Cr&#233;er&#8230;</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Les administrateurs de communaut&#233;s peuvent cr&#233;er des sous-communaut&#233;s ou des collections, ainsi que g&#233;rer ou assigner des droits de gestion sur ces sous-communaut&#233;s ou collections.  De plus, ils peuvent &#233;galement d&#233;cider de qui peut soumettre des documents &#224; n'importe quelle sous-collection, &#233;diter les m&#233;tadonn&#233;es (suite &#224; la soumission), et qui peut ajouter (associer) des documents existants provenant d'autres collections (sous r&#233;serve des autorisations ad&#233;quates).</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Cette communaut&#233; utilise des param&#232;tres personnalis&#233;s d'acc&#232;s par d&#233;faut.</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Par d&#233;faut, le droit d'acc&#232;s en lecture des documents et fichiers entrants est actuellement attribu&#233; &#224; Anonyme.</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">&#201;diter les politiques d'autorisation directement.</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">R&#244;le</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Groupe associ&#233;</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Créer…</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Les administrateurs de communautés peuvent créer des sous-communautés ou des collections, ainsi que gérer ou assigner des droits de gestion sur ces sous-communautés ou collections.  De plus, ils peuvent également décider de qui peut soumettre des documents à n'importe quelle sous-collection, éditer les métadonnées (suite à la soumission), et qui peut ajouter (associer) des documents existants provenant d'autres collections (sous réserve des autorisations adéquates).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Cette communauté utilise des paramètres personnalisés d'accès par défaut.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Par défaut, le droit d'accès en lecture des documents et fichiers entrants est actuellement attribué à Anonyme.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Éditer les politiques d'autorisation directement.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rôle</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Groupe associé</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administrateurs</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(Administrateurs syst&#232;me uniquement)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Conserver la communaut&#233;&#160;: {0}</message>
-        <message key="xmlui.administrative.community.CurateCommunityForm.title">Conserver la communaut&#233;</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Conserver la communauté : {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Conserver la communauté</message>
         <message key="xmlui.administrative.community.CurateCommunityForm.trail">Conservateur</message>
-        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">T&#226;che</message>
-        	
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Tâche</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmer la suppression</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmer</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmer la suppression de la communaut&#233; {0}</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">&#202;tes-vous certain que la communaut&#233; {0}  devrait &#234;tre supprim&#233;e? Ceci supprimera&#160;:</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Toutes les collections de la communaut&#233; qui ne sont pas contenues dans d'autres communaut&#233;s</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tous les documents et les soumissions incompl&#232;tes dans cette communaut&#233; qui ne figurent pas dans d'autres communaut&#233;s</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirmer la suppression de la communauté {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Êtes-vous certain que la communauté {0}  devrait être supprimée? Ceci supprimera :</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Toutes les collections de la communauté qui ne sont pas contenues dans d'autres communautés</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Tous les documents et les soumissions incomplètes dans cette communauté qui ne figurent pas dans d'autres communautés</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Le contenu de ces documents</message>
-	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Toutes les politiques d'autorisation associ&#233;es</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Toutes les politiques d'autorisation associées</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirmer la suppression du r&#244;le</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirmer la suppression du rôle</message>
 	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirmer</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirmer la suppression du r&#244;le {0}</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">&#202;tes-vous certain de vouloir supprimer ce r&#244;le? Toutes les modifications et les personnalisations apport&#233;es au groupe {0} seront perdues et devront &#234;tre recr&#233;&#233;es de nouveau.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirmer la suppression du rôle {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Êtes-vous certain de vouloir supprimer ce rôle? Toutes les modifications et les personnalisations apportées au groupe {0} seront perdues et devront être recréées de nouveau.</message>
 
-	
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">&#201;diter les m&#233;tadonn&#233;es de la communaut&#233;</message>
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">M&#233;tadonn&#233;es</message>
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">&#201;diter les m&#233;tadonn&#233;es de la communaut&#233; {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Éditer les métadonnées de la communauté</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Métadonnées</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Éditer les métadonnées de la communauté {0}</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Modifier les politiques d'autorisation</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nom</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Description succincte</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texte d'introduction (HTML)</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texte de copyright (texte brut)</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Nouvelles (HTML)</message>
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">T&#233;l&#233;charger un nouveau logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Télécharger un nouveau logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actuel</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Supprimer le logo</message>
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Supprimer la communaut&#233;</message>
-	
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Supprimer la communauté</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-	<message key="xmlui.administrative.community.CreateCommunityForm.title">Cr&#233;er une communaut&#233;</message>
-	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Cr&#233;er une communaut&#233;</message>
-	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Entrer des m&#233;tadonn&#233;es pour une nouvelle sous-communaut&#233; de {0}</message>
-	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Modifier les m&#233;tadonn&#233;es pour une nouvelle communaut&#233; de 1er niveau</message>
-	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Cr&#233;er</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Créer une communauté</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Créer une communauté</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Entrer des métadonnées pour une nouvelle sous-communauté de {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Modifier les métadonnées pour une nouvelle communauté de 1er niveau</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Créer</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
@@ -1890,101 +1957,101 @@
 	<message key="xmlui.administrative.ControlPanel.head">Panneau de configuration</message>
 	<message key="xmlui.administrative.ControlPanel.option_java">Informations Java</message>
 	<message key="xmlui.administrative.ControlPanel.option_dspace">Configuration de DSpace</message>
-	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertes syst&#232;me</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertes système</message>
 	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
 	<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
 	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-	<message key="xmlui.administrative.ControlPanel.java_head">Java et syst&#232;me d'exploitation</message>
-	<message key="xmlui.administrative.ControlPanel.java_version">No de version de l'environnement d'ex&#233;cution de Java</message>
-	<message key="xmlui.administrative.ControlPanel.java_vendor">Fournisseur de l'environnement d'ex&#233;cution de Java</message>
-	<message key="xmlui.administrative.ControlPanel.os_name">Nom du syst&#232;me d'exploitation</message>
-	<message key="xmlui.administrative.ControlPanel.os_arch">Architecture du syst&#232;me d'exploitation</message>
-	<message key="xmlui.administrative.ControlPanel.os_version">Version du syst&#232;me d'exploitation</message>
-	<message key="xmlui.administrative.ControlPanel.runtime_head">Statistiques de l'environnement d'ex&#233;cution</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java et système d'exploitation</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">No de version de l'environnement d'exécution de Java</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Fournisseur de l'environnement d'exécution de Java</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nom du système d'exploitation</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Architecture du système d'exploitation</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Version du système d'exploitation</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Statistiques de l'environnement d'exécution</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_processors">Processeurs disponibles</message>
-	<message key="xmlui.administrative.ControlPanel.runtime_max">M&#233;moire maximum</message>
-	<message key="xmlui.administrative.ControlPanel.runtime_total">M&#233;moire allou&#233;e</message>
-	<message key="xmlui.administrative.ControlPanel.runtime_used">M&#233;moire utilis&#233;e</message>
-	<message key="xmlui.administrative.ControlPanel.runtime_free">M&#233;moire disponible</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Mémoire maximum</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Mémoire allouée</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Mémoire utilisée</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Mémoire disponible</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_head">Informations Cocoon</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_version">Version de Cocoon</message>
-        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">R&#233;pertoire cache de Cocoon</message>
-        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">R&#233;pertoire de travail de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Répertoire cache de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Répertoire de travail de Cocoon</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Taille de la cache principale ({0})</message>
-        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Nettoyer la cache imm&#233;diatement)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Nettoyer la cache immédiatement)</message>
         <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Taille de la cache persistante ({0})</message>
-        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Taille de la cache transitoire ({0})</message>	
-	<message key="xmlui.administrative.ControlPanel.dspace_head">Param&#232;tres de DSpace</message>
-     <message key="xmlui.administrative.ControlPanel.dspace_version">Version de DSpace</message>
-	<message key="xmlui.administrative.ControlPanel.dspace_dir">R&#233;pertoire d'installation de DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Taille de la cache transitoire ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Paramètres de DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Version de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Répertoire d'installation de DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">URL de base de DSpace</message>
-	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom de l'h&#244;te de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nom de l'hôte de DSpace</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_name">Nom du site</message>
-	<message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de donn&#233;es (BD)</message>
-	<message key="xmlui.administrative.ControlPanel.db_url">URL de la base de donn&#233;es (BD)</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nom de la base de données (BD)</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL de la base de données (BD)</message>
 	<message key="xmlui.administrative.ControlPanel.db_driver">Pilote JDBC</message>
-	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre maximal en partage de connexions &#224; la BD</message>
-	<message key="xmlui.administrative.ControlPanel.db_maxwait">Temps d'attente maximal de connexions &#224; la BD</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Nombre maximal en partage de connexions à la BD</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Temps d'attente maximal de connexions à la BD</message>
 	<message key="xmlui.administrative.ControlPanel.db_maxidle">Nombre maximal de connexions inactives</message>
 	<message key="xmlui.administrative.ControlPanel.mail_server">Serveur de messagerie SMTP</message>
-	<message key="xmlui.administrative.ControlPanel.mail_from_address">Courriel de l'&#233;metteur des messages (De: )</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Courriel de l'émetteur des messages (De: )</message>
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Courriel du destinataire des commentaires</message>
-	<message key="xmlui.administrative.ControlPanel.mail_admin">Courriel de l'administration g&#233;n&#233;rale du site</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertes &#224; l'&#233;chelle du syst&#232;me</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Avertissement concernant la charge des syst&#232;mes balanc&#233;s&#160;</strong>: Les alertes &#224; l'&#233;chelle du syst&#232;me ne sont efficaces que pour le n&#339;ud sur lequel ils sont activ&#233;s. Vous devez vous assurer que chaque n&#339;ud de l'ensemble re&#231;oit la commande d'activation de l'alerte.</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Courriel de l'administration générale du site</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertes à l'échelle du système</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Message d'alerte</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Le syst&#232;me sera arr&#234;t&#233; pour permettre l'entretien r&#233;gulier. Pri&#232;re d'enregistrer votre travail et vous d&#233;connecter.</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte &#224; rebours</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Aucun compte &#224; rebours</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Le système sera arrêté pour permettre l'entretien régulier. Prière d'enregistrer votre travail et vous déconnecter.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Compte à rebours</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Aucun compte à rebours</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutes</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutes</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutes</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 heure</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Garder le chronom&#232;tre actuel de compte &#224; rebours</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">G&#233;rer la session</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuer &#224; permettre des sessions authentifi&#233;es</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restreindre l'authentification, mais maintenir les sessions en cours</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restreindre l'authentification et mettre fin aux sessions en cours</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Remarque&#160;:</strong> Les administrateurs du site sont exempt&#233;s de la gestion de session.</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Garder le chronomètre actuel de compte à rebours</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Gérer la session</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuer à permettre des sessions authentifiées</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restreindre l'authentification, mais maintenir les sessions en cours</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restreindre l'authentification et mettre fin aux sessions en cours</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activer</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">D&#233;sactiver</message>
-	<message key="xmlui.administrative.ControlPanel.activity_head">Activit&#233; actuelle ({0} pages maximum)</message>
-	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ARR&#202;TER l'enregistrement de l'activit&#233; anonyme.</message>
-	<message key="xmlui.administrative.ControlPanel.start_anonymous">D&#201;BUTER l'enregistrement de l'activit&#233; anonyme.</message>
-	<message key="xmlui.administrative.ControlPanel.stop_bot">ARR&#202;TER l'enregistrement de l'activit&#233; des robots.</message>
-	<message key="xmlui.administrative.ControlPanel.start_bot">D&#201;BUTER l'enregistrement de l'activit&#233; des robots.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Désactiver</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Activité actuelle ({0} pages maximum)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ARRÊTER l'enregistrement de l'activité anonyme.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">DÉBUTER l'enregistrement de l'activité anonyme.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">ARRÊTER l'enregistrement de l'activité des robots.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">DÉBUTER l'enregistrement de l'activité des robots.</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Estampille temporelle </message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Utilisateur</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adresse IP</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL de la page</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Agent utilisateur </message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonyme {0}</message>	
-	<message key="xmlui.administrative.ControlPanel.activity_none">Aucune page n'a encore &#233;t&#233; visionn&#233;e.</message>
-	
-	<message key="xmlui.administrative.ControlPanel.select_panel">Utiliser les onglets ci-dessus pour s&#233;lectionner les informations &#224; afficher</message>
-	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonyme {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Aucune page n'a encore été visionnée.</message>
+
+	<message key="xmlui.administrative.ControlPanel.select_panel">Utiliser les onglets ci-dessus pour sélectionner les informations à afficher</message>
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Dans {0} minutes</strong>&#160;: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-	<message key="xmlui.administrative.NotAuthorized.title">Non autoris&#233;</message>
-	<message key="xmlui.administrative.NotAuthorized.trail">Non autoris&#233;</message>
-	<message key="xmlui.administrative.NotAuthorized.head">Privil&#232;ges insuffisants</message>
-	<message key="xmlui.administrative.NotAuthorized.para1a">Votre compte a des privil&#232;ges insuffisants pour effectuer l'action demand&#233;e. Si vous pensez qu'il s'agit d'une erreur ou avez des questions concernant vos droits, pri&#232;re de contacter </message>
-	<message key="xmlui.administrative.NotAuthorized.para1b">les administrateurs syst&#232;me du site</message>
+	<message key="xmlui.administrative.NotAuthorized.title">Non autorisé</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">Non autorisé</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Privilèges insuffisants</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">Votre compte a des privilèges insuffisants pour effectuer l'action demandée. Si vous pensez qu'il s'agit d'une erreur ou avez des questions concernant vos droits, prière de contacter </message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">les administrateurs système du site</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Connectez-vous en tant qu'un autre utilisateur</message>
-	
+        
         <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-        <message key="xmlui.administrative.CurateForm.title">T&#226;ches de conservation</message>
-        <message key="xmlui.administrative.CurateForm.trail">T&#226;ches de conservation</message>
-        <message key="xmlui.administrative.CurateForm.object_label_name">Handle de l'&#233;l&#233;ment de DSpace</message>
-        <message key="xmlui.administrative.CurateForm.object_hint">Conseil: Entrer [votre-pr&#233;fixe-de-Handle]/0 pour effectuer une t&#226;che &#224; travers tout le site (cette capacit&#233; peut ne pas &#234;tre support&#233;e par toutes les t&#226;ches).</message>
-        <message key="xmlui.administrative.CurateForm.task_label_name">T&#226;che</message>
+        <message key="xmlui.administrative.CurateForm.title">Tâches de conservation</message>
+        <message key="xmlui.administrative.CurateForm.trail">Tâches de conservation</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle de l'élément de DSpace</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Conseil: Entrer [votre-préfixe-de-Handle]/0 pour effectuer une tâche à travers tout le site (cette capacité peut ne pas être supportée par toutes les tâches).</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Tâche</message>
     <!-- Used by Curate<DSO>Form classes also -->
-        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choisir &#224; partir des groupes suivants</message>	
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choisir à partir des groupes suivants</message>
 
-	
+
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                      Statistics Aspect
@@ -1994,57 +2061,56 @@
     <message key="xmlui.statistics.search.title">Statistiques de recherche</message>
     <message key="xmlui.statistics.search.head">Statistiques de recherche</message>
     <message key="xmlui.statistics.search.head-dso">Statistiques de recherche pour {0}</message>
-    <message key="xmlui.statistics.search.error">Une erreur est survenue tandis que les statistiques de recherche &#233;taient g&#233;n&#233;r&#233;es, essayez encore une fois.</message>
-    <message key="xmlui.statistics.search.no-results">Il n'y a aucunes statistiques de recherche qui sont disponibles pour la p&#233;riode s&#233;lectionn&#233;e. No search statistics available for the selected period.</message>
-    <message key="xmlui.statistics.workflow.title">Statistiques de t&#226;ched de validation</message>
+    <message key="xmlui.statistics.search.error">Une erreur est survenue tandis que les statistiques de recherche étaient générées, essayez encore une fois.</message>
+    <message key="xmlui.statistics.search.no-results">Il n'y a aucunes statistiques de recherche qui sont disponibles pour la période sélectionnée. No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Statistiques de tâched de validation</message>
     <message key="xmlui.statistics.visits.total">Nombre total de visites</message>
     <message key="xmlui.statistics.visits.month">Nombre total de visites par mois</message>
     <message key="xmlui.statistics.visits.views">Consultations</message>
-    <message key="xmlui.statistics.visits.countries">Consultations : palmar&#232;s par pays</message>
-    <message key="xmlui.statistics.visits.cities">Consultations : palmar&#232;s par ville</message>
-    <message key="xmlui.statistics.visits.bitstreams">T&#233;l&#233;chargements de fichiers</message>
+    <message key="xmlui.statistics.visits.countries">Consultations : palmarès par pays</message>
+    <message key="xmlui.statistics.visits.cities">Consultations : palmarès par ville</message>
+    <message key="xmlui.statistics.visits.bitstreams">Téléchargements de fichiers</message>
     <message key="xmlui.statistics.Navigation.title">Statistiques</message>
     <message key="xmlui.statistics.Navigation.usage.view">Statistiques d'usage de visualisation</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Statistiques de recherche de visualisation</message>
-    <message key="xmlui.statistics.Navigation.workflow.view">Statistiques de t&#226;ches de validation de visualisation</message>
-    <message key="xmlui.statistics.Navigation.view">Consulter les statistiques</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">Statistiques de tâches de validation de visualisation</message>
     <message key="xmlui.statistics.trail">Statistiques</message>
     <message key="xmlui.statistics.trail-search">Statistiques de recherche</message>
-    <message key="xmlui.statistics.trail-workflow">Statistiques de t&#226;ched de validation</message>
-    <message key="xmlui.statistics.workflow.no-results">Il n'y a aucunes statistiques de recherche qui sont disponibles pour la p&#233;riode s&#233;lectionn&#233;e.</message>
-    <message key="xmlui.statistics.workflow.error">Une erreur est survenue tandis que les statistiques de recherche &#233;taient g&#233;n&#233;r&#233;es, essayez encore une fois.</message>
-    <message key="xmlui.statistics.workflow.head">Statistiques de t&#226;ched de validation</message>
-    <message key="xmlui.statistics.workflow.head-dso">Statistiques de t&#226;ched de validation pour {0}</message>
+    <message key="xmlui.statistics.trail-workflow">Statistiques de tâched de validation</message>
+    <message key="xmlui.statistics.workflow.no-results">Il n'y a aucunes statistiques de recherche qui sont disponibles pour la période sélectionnée.</message>
+    <message key="xmlui.statistics.workflow.error">Une erreur est survenue tandis que les statistiques de recherche étaient générées, essayez encore une fois.</message>
+    <message key="xmlui.statistics.workflow.head">Statistiques de tâched de validation</message>
+    <message key="xmlui.statistics.workflow.head-dso">Statistiques de tâched de validation pour {0}</message>
 
 
-    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Mots recherch&#233;s les plus populaires</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Mots recherchés les plus populaires</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
-    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Mois pr&#233;c&#233;dent</message>
-    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Semestre pr&#233;c&#233;dent</message>
-    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Année pr&#233;c&#233;dente</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Mois précédent</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Semestre précédent</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Année précédente</message>
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Globale</message>
 
 
-    <message key="xmlui.statistics.display.table.column-label.search-terms">Mot recherch&#233;s</message>
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Mot recherchés</message>
     <message key="xmlui.statistics.display.table.column-label.searches">Commandes de recherche</message>
     <message key="xmlui.statistics.display.table.column-label.percent-total">% du total</message>
     <message key="xmlui.statistics.display.table.column-label.views-search">Pages vues / Commandes de recherche</message>
-    <message key="xmlui.statistics.display.table.column-label.step">&#201;tappe</message>
-    <message key="xmlui.statistics.display.table.column-label.performed">Effectu&#233;</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Étappe</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Effectué</message>
     <message key="xmlui.statistics.display.table.column-label.average">En moyenne</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accepter/R&#233;pudier l'ensemble des &#233;tappes</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accepter/R&#233;pudier l'&#233;tappe</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accepter/R&#233;pudier/Modifier l'ensemble des &#233;tappes</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accepter/R&#233;pudier/Modifier l'&#233;tappe</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Modifier l'ensemble des les &#233;tappes</message>
-    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Modifier les m&#233;tadonn&#233;es des &#233;tappes</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accepter/R&#233;pudier l'ensemble des &#233;tappes</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accepter/R&#233;pudier l'&#233;tappe</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accepter/R&#233;pudier/Modifier l'ensemble des &#233;tappes des m&#233;tadonn&#233;es</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accepter/R&#233;pudier/Modifier les &#233;tappes des m&#233;tadonn&#233;es</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Modifier l'ensemble des &#233;tappes des m&#233;tadonn&#233;es</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Modifier les &#233;tappes des m&#233;tadonn&#233;es</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Modifier les &#233;tappes des m&#233;tadonn&#233;es</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accepter/Répudier l'ensemble des étappes</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accepter/Répudier l'étappe</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accepter/Répudier/Modifier l'ensemble des étappes</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accepter/Répudier/Modifier l'étappe</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Modifier l'ensemble des les étappes</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Modifier les métadonnées des étappes</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accepter/Répudier l'ensemble des étappes</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accepter/Répudier l'étappe</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accepter/Répudier/Modifier l'ensemble des étappes des métadonnées</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accepter/Répudier/Modifier les étappes des métadonnées</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Modifier l'ensemble des étappes des métadonnées</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Modifier les étappes des métadonnées</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
@@ -2052,11 +2118,31 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
-    	
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -2066,59 +2152,60 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Ce site utilise Manakin, un nouveau frontal pour DSpace cr&#233;&#233; par les biblioth&#232;ques de la Texas A &amp; M University.
-			L'interface peut &#234;tre consid&#233;rablement modifi&#233; via les Aspects Manakin et sur la base des th&#232;mes XSL.
-			Pour en savoir plus visiter les sites
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> et
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Contactez-nous</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Faire parvenir un commentaire</message>
-	
-	<message key="xmlui.dri2xhtml.structural.head-subtitle">D&#233;p&#244;t DSpace/Manakin</message>
 
-	<message key="xmlui.dri2xhtml.structural.profile">Profil&#160;: </message>
-	<message key="xmlui.dri2xhtml.structural.logout">D&#233;connexion</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Dépôt DSpace/Manakin</message>
+
+	<message key="xmlui.dri2xhtml.structural.profile">Profil : </message>
+	<message key="xmlui.dri2xhtml.structural.logout">Déconnexion</message>
 	<message key="xmlui.dri2xhtml.structural.login">Ouvrir une session</message>
 
-	<message key="xmlui.dri2xhtml.structural.search">Chercher dans le d&#233;p&#244;t</message>
-	<message key="xmlui.dri2xhtml.structural.search-advanced">Recherche avanc&#233;e</message>
-	<message key="xmlui.dri2xhtml.structural.search-in-community">Cette communaut&#233;</message>
+	<message key="xmlui.dri2xhtml.structural.search">Chercher dans le dépôt</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Recherche avancée</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Cette communauté</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">Cette collection</message>
-	
-	<message key="xmlui.dri2xhtml.structural.pagination-previous">Page Pr&#233;c&#233;dente</message>
-	<message key="xmlui.dri2xhtml.structural.pagination-info">Voici les &#233;l&#233;ments {0}-{1} de {2}</message>
+
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Page Précédente</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Voici les éléments {0}-{1} de {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">Page suivante</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Licence originale</message>
-		
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
-	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Pas d'aper&#231;u disponible</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Pas d'aperçu disponible</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.no-title">[Sans titre]</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Auteur inconnu</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
-		Ceci n'est pas une ressource DSpace conforme au profil METS 1.0 et en tant que tel elle ne peut &#234;tre rendue de mani&#232;re efficace.
-		Vous pouvez remplacer soit le mod&#232;le qui traite le cas g&#233;n&#233;ral dans dri2xhtml pour pouvoir accomplir la fonction n&#233;cessaire,
-		ou encore cr&#233;er votre mod&#232;le pour l'associer &#224; n'importe quel profil utilis&#233;.
-	</message>	
-	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Aper&#231;u</message>
+		Ceci n'est pas une ressource DSpace conforme au profil METS 1.0 et en tant que tel elle ne peut être rendue de manière efficace.
+		Vous pouvez remplacer soit le modèle qui traite le cas général dans dri2xhtml pour pouvoir accomplir la fonction nécessaire,
+		ou encore créer votre modèle pour l'associer à n'importe quel profil utilisé.
+	</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Aperçu</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Titre</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Auteur</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">R&#233;sum&#233;</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Résumé</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Description</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Date</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">&#201;diteur</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Éditeur</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Sujet</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Fichier(s) constituant ce document</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Fichiers</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nom</message>
@@ -2126,45 +2213,44 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Vue</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Voir/<wbr/>Ouvrir</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Il n'y a pas de fichiers associ&#233;s &#224; ce document.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Voir/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Il n'y a pas de fichiers associés à ce document.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">octets</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Ko</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mo</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Go</message>
-	
-	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Les fichiers de licence suivants sont associ&#233;s &#224; ce document&#160;: </message>
-    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except&#233; l&#224; o&#249; sp&#233;cifi&#233; autrement, la license de ce document est d&#233;crite en tant que  </message>
-		
-	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Actuellement, l'aper&#231;u bref d'une collection n'est pas utilis&#233; ni impl&#233;ment&#233;.
-		Cela peut &#234;tre corrig&#233; en rempla&#231;ant le mod&#232;le de la dri2xhtml nomm&#233; collectionSummaryView.</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">Actuelleemnt, l'aper&#231;u bref d'une communaut&#233; n'est pas utilis&#233; ni impl&#233;ment&#233;.
-		Cela peut &#234;tre corrig&#233; en rempla&#231;ant le mod&#232;le de la dri2xhtml nomm&#233; communitySummaryView.</message>
-	
+
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Les fichiers de licence suivants sont associés à ce document : </message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Excepté là où spécifié autrement, la license de ce document est décrite en tant que  </message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">Actuellement, l'aperçu bref d'une collection n'est pas utilisé ni implémenté.
+		Cela peut être corrigé en remplaçant le modèle de la dri2xhtml nommé collectionSummaryView.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">Actuelleemnt, l'aperçu bref d'une communauté n'est pas utilisé ni implémenté.
+		Cela peut être corrigé en remplaçant le modèle de la dri2xhtml nommé communitySummaryView.</message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Le logo de la collection</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Le logo de la communaut&#233;</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Pas de logo</message>		
-	<message key="xmlui.dri2xhtml.METS-1.0.news">Nouvelles</message>	
-	<message key="xmlui.dri2xhtml.METS-1.0.copyright">Copyright et licence</message>			
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Le logo de la communauté</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Pas de logo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Nouvelles</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
-	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Actuellement, le Qualified Dublin Core (QDC) ne peut s'appliquer aux communaut&#233;s et collections de DSpace.
-		Lorsque vous utilisez QDC, vous devez utiliser le tableau de correspondance (crosswalk) QDC pour les documents de DSpace et, soit DIM ou MODS, pour le traitement des communaut&#233;s et des collections.</message>
-	
-	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">&#201;l&#233;ments Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">Actuellement, le Qualified Dublin Core (QDC) ne peut s'appliquer aux communautés et collections de DSpace.
+		Lorsque vous utilisez QDC, vous devez utiliser le tableau de correspondance (crosswalk) QDC pour les documents de DSpace et, soit DIM ou MODS, pour le traitement des communautés et des collections.</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Éléments Dublin Core</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termes Dublin Core</message>
 
-		<message key="xmlui.dri2xhtml.METS-1.0.blocked">Bloqu&#233;</message>
-	
-	
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Bloqué</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
-	<message key="xmlui.dri2xhtml.pioneer.preview">Aper&#231;u</message>
+	<message key="xmlui.dri2xhtml.pioneer.preview">Aperçu</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Date</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Titre</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Auteur</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
@@ -2236,27 +2322,24 @@
   <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
   <!-- Video-based formats -->
-  <message key="xmlui.dri2xhtml.mimetype.video/avi">Vid&#233;o AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">Vidéo AVI</message>
   <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">Vid&#233;o MPEG</message>
-  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Vid&#233;o MPEG-2</message>
-  <message key="xmlui.dri2xhtml.mimetype.video/mp4">Vid&#233;o MPEG-4</message>
-  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Vid&#233;o QuickTime</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">Vidéo MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Vidéo MPEG-2</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">Vidéo MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Vidéo QuickTime</message>
 
-
- <!-- explanatory messages for choice authority confidence values -->
-  <message key="xmlui.authority.confidence.description.cf_unset">Un niveau de confiance n'a jamais &#233;t&#233; enregistr&#233;e pour cette valeur</message>
-  <message key="xmlui.authority.confidence.description.cf_novalue">Aucune valeur avec un niveau de confiance raisonable n'a &#233;t&#233; retourn&#233;e par le contr&#244;le d'autorit&#233;</message>
-  <message key="xmlui.authority.confidence.description.cf_rejected">Le contr&#244;le d'autorit&#233; recommande que cette soumission soit rejet&#233;e</message>
-  <message key="xmlui.authority.confidence.description.cf_failed">Le contr&#244;le d'autorit&#233; a rencontr&#233; une d&#233;faillance interne</message>
-  <message key="xmlui.authority.confidence.description.cf_notfound">Il n'y a pas de r&#233;ponses correspondantes dans le contr&#244;le d'autorit&#233;</message>
-  <message key="xmlui.authority.confidence.description.cf_ambiguous">Il y a plusieurs valeurs correspondantes dont la validit&#233; est &#233;quivalente</message>
-  <message key="xmlui.authority.confidence.description.cf_uncertain">La valeur est unique et valide mais n'a pas &#233;t&#233; r&#233;vis&#233;e et accept&#233;e par un responsable et cons&#233;quememnt demeure donc incertaine</message>
-  <message key="xmlui.authority.confidence.description.cf_accepted">Cette valeur a &#233;t&#233; confirm&#233;e et est reconnue comme exacte par un utilisateur interactif</message>
-
-
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Un niveau de confiance n'a jamais été enregistrée pour cette valeur</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">Aucune valeur avec un niveau de confiance raisonable n'a été retournée par le contrôle d'autorité</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">Le contrôle d'autorité recommande que cette soumission soit rejetée</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">Le contrôle d'autorité a rencontré une défaillance interne</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">Il n'y a pas de réponses correspondantes dans le contrôle d'autorité</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">Il y a plusieurs valeurs correspondantes dont la validité est équivalente</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">La valeur est unique et valide mais n'a pas été révisée et acceptée par un responsable et conséquememnt demeure donc incertaine</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">Cette valeur a été confirmée et est reconnue comme exacte par un utilisateur interactif</message>
   <!-- help message on "unlock" button in EditItemMetadata display -->
-  <message key="xmlui.authority.confidence.unlock.help">D&#233;barrer la cl&#233;e de la valeur sous contr&#244;le d'autorit&#233; pour pouvoir en faire une &#233;dition manuelle, ou basculer-l&#224; de nouveau afin de la rebarr&#233;r.</message>
+  <message key="xmlui.authority.confidence.unlock.help">Débarrer la clée de la valeur sous contrôle d'autorité pour pouvoir en faire une édition manuelle, ou basculer-là de nouveau afin de la rebarrér.</message>
 
   <!-- Choice Lookup popup window -->
   <!-- NOTE: These messages necessarily use a *different* format for
@@ -2264,29 +2347,30 @@
      - JavaScript (AJAX) that completes the lookup popup window.
      - So, positional parameters are @1@, @2@, etc.
     -->
-  <message key="xmlui.ChoiceLookupTransformer.title">V&#233;rifier une valeur dans DSpace</message>
+  <message key="xmlui.ChoiceLookupTransformer.title">Vérifier une valeur dans DSpace</message>
   <message key="xmlui.ChoiceLookupTransformer.accept">Accepter</message>
   <message key="xmlui.ChoiceLookupTransformer.add">Ajouter</message>
   <message key="xmlui.ChoiceLookupTransformer.cancel">Annuler</message>
-  <message key="xmlui.ChoiceLookupTransformer.more">Voir plus de r&#233;sultats</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">Voir plus de résultats</message>
   <!-- params are: start, end, total-count, search-value -->
-  <message key="xmlui.ChoiceLookupTransformer.results">R&#233;sultats @1@ &#224; @2@ de @3@ pour "@4@"</message>
-  <message key="xmlui.ChoiceLookupTransformer.fail">&#201;chec du chargement des donn&#233;es choisies&#160;: </message>
+  <message key="xmlui.ChoiceLookupTransformer.results">Résultats @1@ à @2@ de @3@ pour "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Échec du chargement des données choisies : </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nom de l'&#233;diteur</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">V&#233;rifier l'&#233;diteur</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nom de l'éditeur</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Vérifier l'éditeur</message>
   <!-- Params are: search-value -->
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Valeur sans contr&#244;le d'autorit&#233;: @1@</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Valeur sans contrôle d'autorité: @1@</message>
 
   <!-- Choice Lookup - sample config for dc.contributor.author field -->
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nom complet selon le format "Nom, Pr&#233;nom"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nom complet selon le format "Nom, Prénom"</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Nom de famille, e.g. "Durand"</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Pr&#233;nom(s) e.g. "Jean"</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">V&#233;rifier un nom d'auteur selon le contr&#244;le d'autorit&#233; de LC</message>
-  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valeur locale "@1@" (pas dans les autorit&#233;s de nom)</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Prénom(s) e.g. "Jean"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Vérifier un nom d'auteur selon le contrôle d'autorité de LC</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valeur locale "@1@" (pas dans les autorités de nom)</message>
 
-   <!-- mobile theme -->
+  <!-- mobile theme -->
   <message key="xmlui.mobile.home_mobile">Version mobile de DSpace</message>
   <message key="xmlui.mobile.search_all">Rechercher tout</message>
   <message key="xmlui.mobile.browse_all">Naviguer tout par</message>
@@ -2294,38 +2378,38 @@
   <message key="xmlui.mobile.browse_author">Auteur</message>
   <message key="xmlui.mobile.browse_title">Titre</message>
   <message key="xmlui.mobile.browse_subject">Subjet</message>
-  <message key="xmlui.mobile.related_google_scholar">Li&#233;</message>
+  <message key="xmlui.mobile.related_google_scholar">Lié</message>
   <message key="xmlui.mobile.items_in_google_scholar">Items dans Google Scholar</message>
-  <message key="xmlui.mobile.download">T&#233;l&#233;charger</message>
+  <message key="xmlui.mobile.download">Télécharger</message>
 
 
     <!-- Versioning -->
-    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Cr&#233;er une version de cet item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Créer une version de cet item</message>
     <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Visualise l'historique des versions</message>
 
-    <message key="xmlui.aspect.versioning.VersionItemForm.title">Cr&#233;er une version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Créer une version</message>
     <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
-    <message key="xmlui.aspect.versioning.VersionItemForm.head1">cr&#233;er une version de l'item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">créer une version de l'item: {0}</message>
     <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
-    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Mettre &#224; jour la version</message>
-    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Raison pour cr&#233;er des nouvelles versions</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Mettre à jour la version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Raison pour créer des nouvelles versions</message>
 
-    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Mettre &#224; jour la version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Mettre à jour la version</message>
     <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
-    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Mettre &#224; jour la version de l'item : {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Mettre à jour la version de l'item : {0}</message>
     <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
-    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Mettre &#224; jour la version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Mettre à jour la version</message>
     <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">En bref</message>
 
 
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirmer la suppression</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirmer la suppression</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirmer la/les suppression(s)</message>
-    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">&#202;tes-vous certain que ces versions devraient &#234;tre supprim&#233;es? </message>
-    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">VEUILLEZ NOTER&#160;: En suppressant ces versions, Les items associ&#233;s ne seront plus accessibles.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Êtes-vous certain que ces versions devraient être supprimées? </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">VEUILLEZ NOTER : En suppressant ces versions, Les items associés ne seront plus accessibles.</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
-    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">&#201;diteur</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Éditeur</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
     <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">En bref</message>
 
@@ -2333,9 +2417,9 @@
     <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Remettre la version</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Remettre la version</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Remettre la version</message>
-    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">&#202;tes-vous certain que cette version devraient &#234;tre remise?:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Êtes-vous certain que cette version devraient être remise?:</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
-    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">&#201;diteur</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Éditeur</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">En bref</message>
     <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Remetre</message>
@@ -2343,21 +2427,61 @@
     <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Historique des versions</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
-    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">&#201;diteur</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Éditeur</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">En bref</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Remettre</message>
-    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Mettre &#224; jour</message>
-    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Version s&#233;lectionn&#233;e</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Mettre à jour</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Version sélectionnée</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Supprimer les versions</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Retourner</message>
     <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(Administrateurs de collection uniquement)</message>
 
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Avis</message>
-    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Ceci n'est pas la version la plus r&#233;cente de cet item. On peut trouver la version la plus r&#233;cente &#224;: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Ceci n'est pas la version la plus récente de cet item. On peut trouver la version la plus récente à: </message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Avis</message>
-    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Une version plus r&#233;cente de cet item-ci se trouve dans le Workflow.</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Une version plus récente de cet item-ci se trouve dans le Workflow.</message>
 
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_fr.xml
+++ b/src/main/webapp/i18n/messages_fr.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="fr">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_gl.xml
+++ b/src/main/webapp/i18n/messages_gl.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="gl">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_gl.xml
+++ b/src/main/webapp/i18n/messages_gl.xml
@@ -1,2009 +1,2490 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="gl" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-
-<!--
-The format used by all keys is as follows
-xmlui.<Aspect>.<Java Class>.<name>
-There are a few exceptions to this naming format,
-1) Some general keys are in the xmlui.general namespace
-because they are used very frequently.
-2) Some general keys which are specific to a particular aspect
-may be found at xmlui.<Aspect> without specifying a
-particular java class.
--->
-<!--messages v1.8 Translated at Universidade de Vigo - Vigo University   www.uvigo.es/
-
-http://www.uvigo.es/uvigo_gl/administracion/biblioteca/  )--> 
- 
-
-<!-- General keys -->
-<message key="xmlui.general.dspace_home">DSpace Principal</message>
-<message key="xmlui.general.search">Buscas</message>
-<message key="xmlui.general.go">Ir</message>
-<message key="xmlui.general.go_home">Ir á páxina principal de DSpace</message>
-<message key="xmlui.general.save">Gardar</message>
-<message key="xmlui.general.cancel">Cancelar</message>
-<message key="xmlui.general.return">Volver</message>
-<message key="xmlui.general.update">Modificar</message>
-<message key="xmlui.general.delete">Borrar</message>
-<message key="xmlui.general.next">Seguinte</message>
-<message key="xmlui.general.untitled">Sen título</message>
-<message key="xmlui.general.perform">Realizar</message>
-<message key="xmlui.general.queue">Deixar á espera</message>
-
-<!--
-Page not found keys
-
-This is a special component that is not part of any aspect but is added
-by manakin to all aspect chains.
--->
-<message key="xmlui.PageNotFound.title">Páxina non atopada</message>
-<message key="xmlui.PageNotFound.head">Páxina non atopada</message>
-<message key="xmlui.PageNotFound.para1">A páxina á que tenta acceder non se atopou no servidor</message>
-
-<!--
-The "utils" non-aspect
--->
-<message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Só os administradores poden acceder como outro usuario.</message>
-<message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Só usuarios autenticados que sexan administradores poden acceder como outro usuario.</message>
-<message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Non pode acceder como outro administrador.</message>
-
-<!--
-This section is for feed syndications (RSS, atom, etc)
--->
-<message key="xmlui.feed.general_description">O repositorio dixital DSpace captura, almacena, indexa, preserva e distribúe materiais de investigación en formato dixital.</message>
-<message key="xmlui.feed.header">RSS Feeds</message>
-<message key="xmlui.feed.logo_title">Imaxe</message>
-<message key="xmlui.feed.untitled">Sen título</message>
-
-<!--
-Default notice header
--->
-<message key="xmlui.general.notice.default_head">Aviso</message>
-
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-ArtifactBrowser Aspect
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-
-
-<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultados da busca na comunidade: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultados da busca na colección: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultados da busca</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">A súa solicitude {0} obtivo {1} resultados</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunidades ou coleccións que coinciden coa solicitude</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Ítems que coinciden coa solicitude</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">A busca non obtivo resultados</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Todo DSpace</message>
-
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">título</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data de publicación</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data de envío</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinencia</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordenar ítems por</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en orde</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendente</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendente</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultados/páxina</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Busca avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Busca avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Busca avanzada</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Ámbito da busca</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limite a busca a unha comunidade ou colección.</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conxunción</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipo de busca</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Buscar por</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Título</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Asunto</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resumo</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Serie</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Idioma (ISO)</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Palabra chave</message>
-
-<!-- some common other possibilities for Advanced Search Fields -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contribuidor/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Creador/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descrición</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relación</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Outro/a colaborador/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Asesor/a</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departamento</message>
-
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texto completo</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">E</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">Ou</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NON</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ou introducir as primeiras letras:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Listar ítems que comezan con estas letras</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Saltar a un punto do índice:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Escoller mes)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Escoller ano)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ou introducir un ano:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Listar ítems dun determinado ano.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sentímolo, non hai resultados para esta busca.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordenar por:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Orde:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultados:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autores/ítem:</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Todos</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">título</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data de publicación</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data de envío</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendente</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendente</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nome dos autores</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Listar {0} por autor {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Listar {0} por autor</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Listar{0} por tema {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Listar {0} por tema</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Listar {0} por título {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Listar {0} por título</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Listar {0} por data de publicación {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Listar {0} data de publicación</message>
-
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Listar {0} por data de envío {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Listar {0} por data de envío</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Ámbito da busca</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Busca nesta colección:</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Listar por</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títulos</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autores</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datas</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Busca avanzada</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Envíos recentes</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Listaxe de comunidades</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Listaxe de comunidades</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunidades en DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Escolla unha comunidade para listar as súas coleccións</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Ámbito da busca</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Buscar nesta comunidade e nas súas coleccións:</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Listar por</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títulos</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autores</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Datas</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Busca avanzada</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunidades nesta comunidade</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Coleccións nesta comunidade</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Envíos recentes</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-<message key="xmlui.ArtifactBrowser.Contact.title">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.trail">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.head">Contacto</message>
-<message key="xmlui.ArtifactBrowser.Contact.para1">{0} administración en contacto en:</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulario en liña</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.Contact.email">Enderezo electrónico</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Grazas por compartir as súas suxestións sobre DSpace. Teremos en conta os seus comentarios!</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email">O seu correo electrónico</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Este enderezo será empregado para o seguimento da súa suxestión.</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentarios</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Suxestións</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Suxestións</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Suxestión enviada</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">O seu comentario foi recibido</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Buscar en DSpace</message>
-<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Introduza o texto que quere buscar en DSpace</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Ver ítem</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Este ítem aparece na(s) seguinte(s) colección(s)</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostrar o rexistro simple do ítem</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostrar o rexistro completo do ítem</message>
-
-<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este ítem retirouse e non está dispoñible.</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Listar</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Todo DSpace</message>
-<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunidades e coleccións</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títulos</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autores</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materias</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Por data de publicación</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Por data de envío</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Esta colección</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Esta comunidade</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Buscar</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Ámbito da busca</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Busca de texto completo</message>
-
-<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Este recurso está restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Este recurso está restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Esta comunidade está restrinxida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Esta colección está restrinxida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Este ítem está restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Este arquivo está restrinxido.</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Non ten os permisos necesarios para acceder ao recurso restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Non ten os permisos necesarios para acceder á comunidade restrinxida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Non ten os permisos necesarios para acceder á colección restrinxida</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Non ten os permisos necesarios para acceder ao ítem restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Non ten os permisos necesarios para acceder ao arquivo restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">colección</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">Comunidade</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">arquivo</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">ítem</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurso</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">descoñecido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continúe na pantalla de acceso</message>
-
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem retirouse. </message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">O ítem seleccionado retirouse e non está dispoñible.</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">O ítem seleccionado é de acceso restrinxido e require credenciais para poder visualizalo. </message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">O seu usuario non dispón de permisos para ver o ítem. Para máis información, por favor contacte co administrador</message>
-
-<!-- Authentication messages used at the top of the login page: -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Este ítem está restrinxido</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">O ítem ao que tenta acceder é un ítem restrinxido e require credenciais para poder verse. Por favor, identifíquese arriba para acceder ao ítem.</message>
-
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes mensuais</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resumo estatístico</message>
-
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Sen informes dispoñibles na actualidade</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Actualmente non hai informes dispoñibles para este servizo. Comprobe a súa dispoñibilidade máis adiante.</message>
-
-<!-- Authentication messages used for bitstream authentication -->
-<message key="xmlui.BitstreamReader.auth_header">O arquivo está restrinxido</message>
-<message key="xmlui.BitstreamReader.auth_message">O arquivo ao que tenta acceder é un arquivo restrinxido e require credenciais para poder verse. Por favor, identifíquese arriba para acceder ao arquivo.</message>
-
-<!-- Export Archive download messages -->
-<message key="xmlui.ItemExportDownloadReader.auth_header">Este arquivo de exportación está restrinxido.</message>
-<message key="xmlui.ItemExportDownloadReader.auth_message">O arquivo de exportación ao que tenta acceder é un recurso restrinxido e require permisos para poder visualizarse. Por favor, autentíquese máis baixo para acceder ao arquivo de exportación.</message>
-
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-EPerson Aspect
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-
-
-<!-- General keys used by the EPerson aspect -->
-<message key="xmlui.EPerson.trail_new_registration">Rexistro de novo usuario</message>
-<message key="xmlui.EPerson.trail_forgot_password">Esqueceu o contrasinal?</message>
-
-<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-<message key="xmlui.EPerson.CannotRegister.title">Rexistro non dispoñible</message>
-<message key="xmlui.EPerson.CannotRegister.head">Rexistro non dispoñible</message>
-<message key="xmlui.EPerson.CannotRegister.para1">A configuración deste repositorio DSpace non permite o rexistro neste contexto. Por favor, contacte co</message>
-
-<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-<message key="xmlui.EPerson.EditProfile.title_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.title_create">Crear perfil</message>
-<message key="xmlui.EPerson.EditProfile.trail_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.head_update">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.head_create">Crear perfil</message>
-<message key="xmlui.EPerson.EditProfile.email_address">Enderezo de correo electrónico</message>
-<message key="xmlui.EPerson.EditProfile.first_name">Nome</message>
-<message key="xmlui.EPerson.EditProfile.last_name">Apelido</message>
-<message key="xmlui.EPerson.EditProfile.telephone">Teléfono de contacto</message>
-<message key="xmlui.EPerson.EditProfile.Language">Idioma</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions">Subscricións</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions_help">Pode subscribirse a coleccións para recibir diariamente un correo cos novos ítems engadidos. Pode subscribirse a tantas coleccións como queira. Outra opción é usar o servizo RSS dispoñible para todas as coleccións.</message>
-<message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscrición de correo electrónico</message>
-<message key="xmlui.EPerson.EditProfile.select_collection">(Escolla unha colección)</message>
-<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalmente, pode escoller un contrasinal novo tecleándoo na cela superior e verificalo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
-<message key="xmlui.EPerson.EditProfile.create_password_instructions">Por favor, introduza unha clave na cela superior. Confírmea tecleándoa de novo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
-<message key="xmlui.EPerson.EditProfile.password">Contrasinal</message>
-<message key="xmlui.EPerson.EditProfile.confirm_password">Repita para confirmar</message>
-<message key="xmlui.EPerson.EditProfile.submit_update">Completar o rexistro</message>
-<message key="xmlui.EPerson.EditProfile.submit_create">Modificar perfil</message>
-<message key="xmlui.EPerson.EditProfile.error_required">Este campo é obrigatorio</message>
-<message key="xmlui.EPerson.EditProfile.error_invalid_password">Escolla un contrasinal que conteña, polo menos, 6 caracteres</message>
-<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Por favor, repita o contrasinal para confirmalo</message>
-<message key="xmlui.EPerson.EditProfile.head_auth">Vostede pertence aos seguintes grupos de autorización</message>
-<message key="xmlui.EPerson.EditProfile.head_identify">Identificar</message>
-<message key="xmlui.EPerson.EditProfile.head_security">Seguridade</message>
-
-<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifique o correo electrónico</message>
-<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crear perfil</message>
-<message key="xmlui.EPerson.EPersonUtils.register_finished">Rematado</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifique o correo electrónico</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Rematado</message>
-
-<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-<message key="xmlui.EPerson.ForgotPasswordFinished.title">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.head">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.para1">O seu contrasinal restableceuse</message>
-
-<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-<message key="xmlui.EPerson.InvalidToken.title">Cadea non válida</message>
-<message key="xmlui.EPerson.InvalidToken.trail">Cadea non válida</message>
-<message key="xmlui.EPerson.InvalidToken.head">Cadea non válida</message>
-<message key="xmlui.EPerson.InvalidToken.para1">A URL que indicou non é válida. É posible que o seu correo fragmentase a URL en varias liñas, como:</message>
-<message key="xmlui.EPerson.InvalidToken.para2">De ser o caso, deberá copiar e pegar a URL completa directamente na barra de enderezos do seu navegador, en lugar de simplemente premer na ligazón. A barra de enderezos deberá conter algo similar ao seguinte:</message>
-
-<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-<message key="xmlui.EPerson.Navigation.my_account">A miña conta</message>
-<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
-<message key="xmlui.EPerson.Navigation.logout">Saír</message>
-<message key="xmlui.EPerson.Navigation.login">Acceder</message>
-<message key="xmlui.EPerson.Navigation.register">Rexistro</message>
-
-<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-<message key="xmlui.EPerson.PasswordLogin.title">Entrar</message>
-<message key="xmlui.EPerson.PasswordLogin.trail">Acceder</message>
-<message key="xmlui.EPerson.PasswordLogin.head1">Acceder a DSpace</message>
-<message key="xmlui.EPerson.PasswordLogin.email_address">Enderezo electrónico</message>
-<message key="xmlui.EPerson.PasswordLogin.error_bad_login">O enderezo de correo electrónico introducido e/ou o contrasinal non son válidos.</message>
-<message key="xmlui.EPerson.PasswordLogin.password">Contrasinal</message>
-<message key="xmlui.EPerson.PasswordLogin.forgot_link">Esqueceu o contrasinal?</message>
-<message key="xmlui.EPerson.PasswordLogin.submit">Acceder</message>
-<message key="xmlui.EPerson.PasswordLogin.head2">Rexistrar un novo usuario</message>
-<message key="xmlui.EPerson.PasswordLogin.para1">Rexistrar unha conta para subscribirse ás coleccións, para recibir notificación das modificacións e das novas adquisicións de ítems en DSpace.</message>
-<message key="xmlui.EPerson.PasswordLogin.register_link">Prema aquí para rexistrarse.</message>
-
-<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-<message key="xmlui.EPerson.LDAPLogin.title">Entrar</message>
-<message key="xmlui.EPerson.LDAPLogin.trail">Acceder</message>
-<message key="xmlui.EPerson.LDAPLogin.head1">Acceder a DSpace</message>
-<message key="xmlui.EPerson.LDAPLogin.title">Acceder</message>
-<message key="xmlui.EPerson.LDAPLogin.username">Nome de usuario</message>
-<message key="xmlui.EPerson.LDAPLogin.error_bad_login">O nome de usuario ou o contrasinal non son válidos.</message>
-<message key="xmlui.EPerson.LDAPLogin.password">Contrasinal</message>
-<message key="xmlui.EPerson.LDAPLogin.submit">Acceder</message>
-
-<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-<message key="xmlui.EPerson.LoginChooser.title">Escoller un método de acceso</message>
-<message key="xmlui.EPerson.LoginChooser.trail">Escoller nome de usuario</message>
-<message key="xmlui.EPerson.LoginChooser.head1">Escoller un método de acceso</message>
-<message key="xmlui.EPerson.LoginChooser.para1">Acceso mediante:</message>
-<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticación mediante Shibboleth</message>
-<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticación mediante LDAP</message>
-<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticación mediante contrasinal</message>
-<message key="org.dspace.eperson.X509Authentication.title">Autenticación mediante certificado web</message>
-
-<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-<message key="xmlui.EPerson.FailedAuthentication.BadCreds">As credenciais proporcionadas non son válidas.</message>
-<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Non se puido realizar a autenticación debido a que se recibiron argumentos non válidos.</message>
-<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Non se atopou ningún usuario cos permisos especificados.</message>
-<message key="xmlui.EPerson.FailedAuthentication.title">Erro de autenticación</message>
-<message key="xmlui.EPerson.FailedAuthentication.trail">Erro de autenticación</message>
-<message key="xmlui.EPerson.FailedAuthentication.h1">Erro de autenticación</message>
-
-<!-- Login xml files -->
-<message key="xmlui.eperson.noAuthMethod.head">Non se atopou método de autenticación</message>
-<message key="xmlui.eperson.noAuthMethod.p1">Non se atopou método de autenticación. Por favor, póñase en contacto co administrador.</message>
-<message key="xmlui.eperson.shibbLoginFailure.head">A autenticación mediante Shibboleth fallou.</message>
-<message key="xmlui.eperson.shibbLoginFailure.p1">A autenticación mediante Shibboleth non está dispoñible neste momento. Por favor, póñase en contacto co administrador.</message>
-
-<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-<message key="xmlui.EPerson.ProfileUpdated.title">Perfil modificado</message>
-<message key="xmlui.EPerson.ProfileUpdated.trail">Modificar perfil</message>
-<message key="xmlui.EPerson.ProfileUpdated.head">Perfil modificado</message>
-<message key="xmlui.EPerson.ProfileUpdated.para1">A información do seu perfil foi modificada.</message>
-
-<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-<message key="xmlui.EPerson.RegistrationFinished.title">Rexistro acabado</message>
-<message key="xmlui.EPerson.RegistrationFinished.head">Rexistro acabado</message>
-<message key="xmlui.EPerson.RegistrationFinished.para1">Agora xa está rexistrado no sistema DSpace. Pode subscribirse a coleccións para recibir por correo electrónico as modificacións e as novas incorporacións.</message>
-
-<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-<message key="xmlui.EPerson.ResetPassword.title">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.ResetPassword.head">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.ResetPassword.para1">Por favor, introduza unha nova clave na cela superior. Confírmea tecleándoa de novo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
-<message key="xmlui.EPerson.ResetPassword.email_address">Enderezo de correo electrónico</message>
-<message key="xmlui.EPerson.ResetPassword.new_password">Novo contrasinal</message>
-<message key="xmlui.EPerson.ResetPassword.confirm_password">Repita para confirmar</message>
-<message key="xmlui.EPerson.ResetPassword.submit">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Escolla un contrasinal que conteña, polo menos, 6 caracteres</message>
-<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Por favor, repita o seu contrasinal para confirmalo</message>
-
-<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-<message key="xmlui.EPerson.StartForgotPassword.title">Esqueceu o contrasinal?</message>
-<message key="xmlui.EPerson.StartForgotPassword.head">Esqueceu o contrasinal?</message>
-<message key="xmlui.EPerson.StartForgotPassword.para1">Introduza o enderezo de correo electrónico que proporcionou ao rexistrarse en DSpace. Enviarémoslle unha mensaxe a ese enderezo coas instrucións pertinentes.</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address">Enderezo de correo electrónico</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduza o mesmo enderezo co que se rexistrou.</message>
-<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Enderezo de correo electrónico non atopado</message>
-<message key="xmlui.EPerson.StartForgotPassword.submit">Enviar información</message>
-
-<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-<message key="xmlui.EPerson.StartRegistration.title">Rexistro de novo usuario</message>
-<message key="xmlui.EPerson.StartRegistration.head1">Enderezo de correo electrónico en uso</message>
-<message key="xmlui.EPerson.StartRegistration.para1">Este enderezo de correo está a ser utilizado por outra persoa. Se quere restablecer o contrasinal para esta conta, prema no botón "Restablecer contrasinal."</message>
-<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restablecer contrasinal para:</message>
-<message key="xmlui.EPerson.StartRegistration.submit_reset">Restablecer contrasinal</message>
-<message key="xmlui.EPerson.StartRegistration.head2">Rexistro de novo usuario</message>
-<message key="xmlui.EPerson.StartRegistration.para2">Rexistrar unha conta para subscribirse a coleccións para recibir por correo electrónico as modificacións e as novas incorporacións.</message>
-<message key="xmlui.EPerson.StartRegistration.email_address">Enderezo de correo electrónico</message>
-<message key="xmlui.EPerson.StartRegistration.email_address_help">Este enderezo será verificado e corresponderá co seu nome de acceso.</message>
-<message key="xmlui.EPerson.StartRegistration.error_bad_email">É imposible enviar un correo electrónico a este enderezo.</message>
-<message key="xmlui.EPerson.StartRegistration.submit_register">Rexistro</message>
-
-<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-<message key="xmlui.EPerson.VerifyEmail.title">Correo de verificación enviado</message>
-<message key="xmlui.EPerson.VerifyEmail.head">Correo de verificación enviado</message>
-<message key="xmlui.EPerson.VerifyEmail.para">Enviouse un correo a {0} que contén unha URL especial e instrucións de rexistro.</message>
-
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Submission Aspect
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-
-
-<!-- general submission aspect messages -->
-<message key="xmlui.Submission.general.mydspace_home">DSpace Principal</message>
-<message key="xmlui.Submission.general.go_mydspace">O meu DSpace</message>
-<message key="xmlui.Submission.general.submission.title">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.trail">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.head">Envío de ítems</message>
-<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
-<message key="xmlui.Submission.general.submission.save">Gardar/saír</message>
-<message key="xmlui.Submission.general.submission.next">Seguinte &gt;</message>
-<message key="xmlui.Submission.general.submission.complete">Completar o envío</message>
-<message key="xmlui.Submission.general.workflow.title">Envío de ítems</message>
-<message key="xmlui.Submission.general.workflow.trail">Envío de ítems</message>
-<message key="xmlui.Submission.general.workflow.head">Envío de ítems</message>
-<message key="xmlui.Submission.general.showfull">Mostrar o rexistro completo do ítem</message>
-<message key="xmlui.Submission.general.showsimple">Mostrar o rexistro simple do ítem</message>
-<message key="xmlui.Submission.general.default.title">Envío</message>
-<message key="xmlui.Submission.general.default.trail">Envío</message>
-
-<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-<message key="xmlui.Submission.CollectionViewer.link1">Enviar un ítem a esta colección</message>
-
-<!-- org.dspace.app.xmlui.submission.Navigation -->
-<message key="xmlui.Submission.Navigation.submissions">Envíos</message>
-
-<!-- org.dspace.app.xmlui.Submission.submissions -->
-<message key="xmlui.Submission.Submissions.title">Envíos &amp; fluxos de traballo</message>
-<message key="xmlui.Submission.Submissions.trail">Envíos</message>
-<message key="xmlui.Submission.Submissions.head">Envíos &amp; tarefas do fluxo de traballo</message>
-<message key="xmlui.Submission.Submissions.untitled"><i>Sen título</i></message>
-<message key="xmlui.Submission.Submissions.email">enderezo electrónico:</message>
-
-<message key="xmlui.Submission.Submissions.workflow_head1">Tarefas do fluxo de traballo</message>
-<message key="xmlui.Submission.Submissions.workflow_info1">Estas tarefas son ítems que están á espera de aprobación antes de seren engadidas ao repositorio. Hai dous tipos de elementos en espera, as tarefas aceptadas e as tarefas que aínda non asumiu ninguén.</message>
-<message key="xmlui.Submission.Submissions.workflow_head2">As súas tarefas</message>
-<message key="xmlui.Submission.Submissions.workflow_column1"></message>
-<message key="xmlui.Submission.Submissions.workflow_column2">Tarefa</message>
-<message key="xmlui.Submission.Submissions.workflow_column3">Ítem</message>
-<message key="xmlui.Submission.Submissions.workflow_column4">Colección</message>
-<message key="xmlui.Submission.Submissions.workflow_column5">Remitente</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_return">Deixar as tarefas seleccionadas de novo en espera</message>
-<message key="xmlui.Submission.Submissions.workflow_info2">Non ten asignada ningunha tarefa</message>
-<message key="xmlui.Submission.Submissions.workflow_head3">Tarefas en espera</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_take">Asumir as tarefas seleccionadas</message>
-<message key="xmlui.Submission.Submissions.workflow_info3">Non hai tarefas en espera</message>
-<!-- Same transformer, submissions section -->
-<message key="xmlui.Submission.Submissions.submit_head1">Envíos</message>
-<message key="xmlui.Submission.Submissions.submit_info1a">Debería </message>
-<message key="xmlui.Submission.Submissions.submit_info1b">comezar un envío</message>
-<message key="xmlui.Submission.Submissions.submit_info1c">O proceso de envío consiste en cubrir o formulario de metadatos e depositar o(s) ficheiro(s) que compón(compoñen) o ítem dixital. Cada comunidade ou colección pode ter a súa propia política de envíos.</message>
-<message key="xmlui.Submission.Submissions.submit_head2">Envíos non rematados</message>
-<message key="xmlui.Submission.Submissions.submit_info2a">Estes son os envíos parciais de ítems que non se completaron. Podería</message>
-<message key="xmlui.Submission.Submissions.submit_info2b">comezar outro envío</message>
-<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-<message key="xmlui.Submission.Submissions.submit_column1"></message>
-<message key="xmlui.Submission.Submissions.submit_column2">Título</message>
-<message key="xmlui.Submission.Submissions.submit_column3">Colección</message>
-<message key="xmlui.Submission.Submissions.submit_column4">Remitente</message>
-<message key="xmlui.Submission.Submissions.submit_head3">Autoría</message>
-<message key="xmlui.Submission.Submissions.submit_info3">Non hai envíos incompletos.</message>
-<message key="xmlui.Submission.Submissions.submit_head4">Supervisando:</message>
-<message key="xmlui.Submission.Submissions.submit_submit_remove">Eliminar os envíos seleccionados</message>
-
-<!-- Same transformer, inprogress section -->
-<message key="xmlui.Submission.Submissions.progress_head1">Envíos en revisión</message>
-<message key="xmlui.Submission.Submissions.progress_info1">Estes son os envíos que se completaron e que están a ser revisados polos responsables da colección.</message>
-<message key="xmlui.Submission.Submissions.progress_column1">Título</message>
-<message key="xmlui.Submission.Submissions.progress_column2">Colección</message>
-<message key="xmlui.Submission.Submissions.progress_column3">Estado</message>
-
-<!-- Same transformer, workflow status -->
-<message key="xmlui.Submission.Submissions.status_0">Enviados</message>
-<message key="xmlui.Submission.Submissions.status_1">Á espera da revisión</message>
-<message key="xmlui.Submission.Submissions.status_2">En revisión</message>
-<message key="xmlui.Submission.Submissions.status_3">Á espera da revisión do editor</message>
-<message key="xmlui.Submission.Submissions.status_4">En edición</message>
-<message key="xmlui.Submission.Submissions.status_5">Á espera da revisión final do editor</message>
-<message key="xmlui.Submission.Submissions.status_6">En edición</message>
-<message key="xmlui.Submission.Submissions.status_7">Arquivados</message>
-<message key="xmlui.Submission.Submissions.status_unknown">Estado descoñecido</message>
-
-<!-- Same transformer, completed submissions section -->
-<message key="xmlui.Submission.Submissions.completed.head">Envíos arquivados</message>
-<message key="xmlui.Submission.Submissions.completed.info">Estes son os seus envíos aceptados en DSpace</message>
-<message key="xmlui.Submission.Submissions.completed.column1">Data de aceptación</message>
-<message key="xmlui.Submission.Submissions.completed.column2">Título</message>
-<message key="xmlui.Submission.Submissions.completed.column3">Colección</message>
-<message key="xmlui.Submission.Submissions.completed.limit">Só se mostran 50 dos seus envíos arquivados</message>
-<message key="xmlui.Submission.Submissions.completed.displayall">Mostrar todos os meus envíos arquivados.</message>
-
-<!-- submission progress bar messages -->
-<message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntas iniciais</message>
-<message key="xmlui.Submission.submit.progressbar.describe">Describir</message>
-<message key="xmlui.Submission.submit.progressbar.upload">Subir</message>
-<message key="xmlui.Submission.submit.progressbar.verify">Revisar</message>
-<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-<message key="xmlui.Submission.submit.progressbar.CClicense">Licenza CC</message>
-<message key="xmlui.Submission.submit.progressbar.license">Licenza</message>
-<message key="xmlui.Submission.submit.progressbar.complete">Finalizar</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Retomar</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-<message key="xmlui.Submission.submit.SelectCollection.head">Seleccione unha colección...</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection">Colección</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccione a colección á que quere enviar un ítem.</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccione unha colección...</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Quere gardar ou cancelar o envío?</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Quere eliminar o envío ou prefire gardalo para continuar traballando nel máis tarde? Tamén pode retomar o proceso de envío onde o deixou se premeu "Cancelar" por erro.</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continuar co envío</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Gardar para continuar máis tarde</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Eliminar o envío</message>
-
-<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntas iniciais</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota importante:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.and">e</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Múltiples títulos</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">O ítem ten máis dun título, </message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Se a cela anexa está desmarcada, daquela o título(s) eliminarase do ítem:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicado</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">O ítem publicouse ou distribuíuse publicamente antes</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Se a cela anexa está desmarcada, daquela o elemento eliminarase do ítem:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data de publicación</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-<message key="xmlui.Submission.submit.DescribeStep.head">Describir o ítem</message>
-<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Erro: tipo de campo descoñecido</message>
-<message key="xmlui.Submission.submit.DescribeStep.required_field">Este campo é obrigatorio</message>
-<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Apelido, </message>
-<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nome(s) + "", <i>p. ex. Manuel </i></message>
-<message key="xmlui.Submission.submit.DescribeStep.year">Ano</message>
-<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
-<message key="xmlui.Submission.submit.DescribeStep.day">Día</message>
-<message key="xmlui.Submission.submit.DescribeStep.series_name">Nome da serie</message>
-<message key="xmlui.Submission.submit.DescribeStep.report_no">Informe n.º</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-<message key="xmlui.Submission.submit.UploadStep.head">Subir ficheiro(s)</message>
-<message key="xmlui.Submission.submit.UploadStep.file">Ficheiro</message>
-<message key="xmlui.Submission.submit.UploadStep.file_help">Por favor, introduza o camiño completo do ficheiro que corresponda co ítem no seu ordenador. Se preme en "Examinar...", abrirase unha xanela que lle permitirá seleccionar un ficheiro do seu ordenador.</message>
-<message key="xmlui.Submission.submit.UploadStep.file_error">O ítem debe conter polo menos un ficheiro.</message>
-<message key="xmlui.Submission.submit.UploadStep.upload_error">Houbo un problema ao anexar o seu ficheiro. Puido deberse a que o nome do ficheiro era incorrecto, houbo un problema na rede que impediu que o ficheiro nos chegase correctamente ou que anexou un ficheiro cuxo formato só se permite para usos internos do sistema. Por favor, ténteo de novo.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_error">O ficheiro non se puido cargar, xa que parece conter un virus. Por favor, contacte co administrador.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Houbo un problema técnico mentres se comprobaba a ausencia de virus no ficheiro. Por favor, contacte co administrador.</message>
-<message key="xmlui.Submission.submit.UploadStep.description">Descrición do ficheiro</message>
-<message key="xmlui.Submission.submit.UploadStep.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_upload">Subir ficheiro e engadir outro máis</message>
-<message key="xmlui.Submission.submit.UploadStep.head2">Ficheiros subidos</message>
-<message key="xmlui.Submission.submit.UploadStep.column0">Primario</message>
-<message key="xmlui.Submission.submit.UploadStep.column1"></message>
-<message key="xmlui.Submission.submit.UploadStep.column2">Ficheiro</message>
-<message key="xmlui.Submission.submit.UploadStep.column3">Tamaño</message>
-<message key="xmlui.Submission.submit.UploadStep.column4">Descrición</message>
-<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
-<message key="xmlui.Submission.submit.UploadStep.column6"></message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_name">descoñecido</message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_format">formato descoñecido</message>
-<message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
-<message key="xmlui.Submission.submit.UploadStep.known">(Soportado)</message>
-<message key="xmlui.Submission.submit.UploadStep.unsupported">(Incompatible)</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editar</message>
-<message key="xmlui.Submission.submit.UploadStep.checksum">Verificación do ficheiro</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_remove">Eliminar os ficheiros seleccionados</message>
-
-
-<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-<message key="xmlui.Submission.submit.EditFileStep.head">Editar ficheiro</message>
-<message key="xmlui.Submission.submit.EditFileStep.file">Ficheiro</message>
-<message key="xmlui.Submission.submit.EditFileStep.description">Descrición do ficheiro</message>
-<message key="xmlui.Submission.submit.EditFileStep.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "</message>
-<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccione na listaxe o formato do arquivo, por exemplo "</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato detectado</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_selected">Formato escollido</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_default">O formato non está na listaxe.</message>
-<message key="xmlui.Submission.submit.EditFileStep.info2">Se o formato non está na listaxe, </message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user">Outro formato</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user_help">O nome e versión da aplicación que empregou para crear o ficheiro (por exemplo, "</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-<message key="xmlui.Submission.submit.ReviewStep.head">Revisar envío</message>
-<message key="xmlui.Submission.submit.ReviewStep.yes">Si</message>
-<message key="xmlui.Submission.submit.ReviewStep.no">Non</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corrixir algún destes</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Engadir ou eliminar un ficheiro</message>
-<message key="xmlui.Submission.submit.ReviewStep.head1">Preguntas iniciais</message>
-<message key="xmlui.Submission.submit.ReviewStep.head2">Describir a páxina {0}</message>
-<message key="xmlui.Submission.submit.ReviewStep.head3">Ficheiros subidos</message>
-<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Múltiples títulos</message>
-<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicado antes de</message>
-<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-<message key="xmlui.Submission.submit.ReviewStep.unknown">descoñecido</message>
-<message key="xmlui.Submission.submit.ReviewStep.known">coñecido</message>
-<message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Produciuse un erro... {0}</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.head">Licencie o seu traballo</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.info1">Opcionalmente pode asignar ao seu ítem unha licenza </message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Escolla licenza</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Acceder a Creative Commons para escoller unha licenza</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.license">Tipo de licenza</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Seleccione ou modifique a licenza...</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Sen licenza Creative Commons</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Prema Seguinte para gardar os seus cambios.</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-<message key="xmlui.Submission.submit.LicenseStep.head">Licenza de distribución</message>
-<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Só queda un último paso:</strong> para permitir que DSpace reproduza, traduza e distribúa o seu envío a través do mundo, necesitamos a súa conformidade nos seguintes termos.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info2">Conceda a licenza de distribución estándar seleccionando "Conceder licenza" e premendo en "Completar envío".</message>
-<message key="xmlui.Submission.submit.LicenseStep.info3">Se tiver algunha dúbida sobre a licenza, por favor, contacte co administrador do sistema.</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licenza de distribución</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concedo a licenza</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_error">Debe conceder a licenza para completar o envío. Se neste momento non a pode conceder, deberá gardar o seu traballo e retomalo máis tarde, ou ben eliminar inmediatamente o envío premendo en "Borrar o envío".</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-<message key="xmlui.Submission.submit.RemovedStep.head">Envío eliminado</message>
-<message key="xmlui.Submission.submit.RemovedStep.info1">O seu envío cancelouse e o ítem incompleto borrouse do sistema.</message>
-<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ir á páxina de envíos</message>
-
-<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-<message key="xmlui.Submission.submit.CompletedStep.head">Envío completado</message>
-<message key="xmlui.Submission.submit.CompletedStep.info1">O seu envío pasará polo fluxo de traballo designado para a colección á que o está a enviar. Recibirá unha notificación vía correo electrónico logo de que o seu envío forme parte da colección, ou, se por algunha razón, houbese algún problema co envío. Tamén pode verificar o estado do seu envío a través da páxina "O meu DSpace".</message>
-<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ir á páxina de envíos</message>
-<message key="xmlui.Submission.submit.CompletedStep.submit_again">Enviar outro ítem</message>
-
-<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accións posibles para esta tarefa:</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Asígnese esta tarefa.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Asumir tarefa</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixar esta tarefa en espera para que a asuma outra persoa.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Deixar tarefa</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Se revisou o ítem e o considera axeitado para a colección, seleccione "Aprobar".</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprobar</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Unha vez editado o ítem, use esta opción para actualizalo.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Actualizar no arquivo</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se revisou o ítem e comprobou que </message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rexeitar ítem</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Escolla esta opción para corrixir ou editar os metadatos do ítem.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editar metadatos</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Use esta opción para volver poñer a tarefa en espera e que outra persoa poida rematar a tarefa de revisión.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Deixar de novo en espera</message>
-
-<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Por favor, indique a razón pola que rexeita o envío. Indique na súa mensaxe o que deberá cambiar o remitente para poder reenvialo.</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motivo</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">O campo "Motivo" é obrigatorio</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rexeitar ítem</message>
-
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Administrative Aspect
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-
-<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
-<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">A tarefa completouse con éxito.</message>
-<message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">A tarefa finalizou ou fallou inesperadamente. Por favor, contacte co administrador ou revise os arquivos de erros</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">A tarefa colocouse correctamente en espera.</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Debido a un erro non se puido deixar a tarefa en espera. Para máis información, por favor contacte co administrador ou revise os arquivos de erros.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">O usuario engadiuse correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">O usuario editouse correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Enviouse unha mensaxe ao usuario que contén un testemuño que lle permitirá obter unha nova clave.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">O usuario(s) borrouse correctamente.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Os usuarios da listaxe non se eliminaron porque existen restricións para realizar esta acción. Para máis información, consulte a páxina dos datos do usuario.</message>
-<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">O grupo modificouse correctamente.</message>
-<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Os grupos seleccionados borráronse con éxito.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Novo esquema creado correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">O esquema(s) borrouse con éxito.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Campo de metadato engadido correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">O campo(s) moveuse correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">O campo(s) borrouse correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">O formato gardouse correctamente.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">O formato(s) borrouse correctamente.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Os metadatos do ítem modificáronse correctamente.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_added">Novo metadato engadido.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">O ítem retirouse.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_reinstated">O ítem reintegrouse.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_moved">O ítem moveuse.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_move_failed">A colección destino seleccionada non se atopou.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_added">O novo arquivo cargouse con éxito.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Erro ao cargar o arquivo.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">O arquivo modificouse.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Os arquivos seleccionados borráronse.</message>
-<message key="xmlui.administrative.FlowMapperUtils.map_items">Os ítems relacionáronse correctamente.</message>
-<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">A relación entre os ítems eliminouse correctamente.</message>
-
-<!-- general items for all of the eperson classes -->
-<message key="xmlui.administrative.eperson.general.epeople_trail">Administrar usuarios</message>
-
-<!-- org.dspace.app.xmlui.administrative.Navigation -->
-<!-- contextual menu items -->
-<message key="xmlui.administrative.Navigation.context_head">Contexto</message>
-<message key="xmlui.administrative.Navigation.context_edit_item">Editar este ítem</message>
-<message key="xmlui.administrative.Navigation.context_edit_collection">Editar colección</message>
-<message key="xmlui.administrative.Navigation.context_item_mapper">Relacionador de ítems</message>
-<message key="xmlui.administrative.Navigation.context_edit_community">Editar comunidade</message>
-<message key="xmlui.administrative.Navigation.context_create_collection">Crear colección</message>
-<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crear subcomunidade</message>
-<message key="xmlui.administrative.Navigation.context_create_community">Crear comunidade</message>
-<message key="xmlui.administrative.Navigation.context_export_item">Exportar ítem</message>
-<message key="xmlui.administrative.Navigation.context_export_collection">Exportar colección</message>
-<message key="xmlui.administrative.Navigation.context_export_community">Exportar comunidade</message>
-<message key="xmlui.administrative.Navigation.context_export_metadata">Exportar metadatos</message>
-
-<!-- Site administrator options -->
-<message key="xmlui.administrative.Navigation.administrative_head">Administrativo</message>
-<message key="xmlui.administrative.Navigation.administrative_access_control">Control de acceso</message>
-<message key="xmlui.administrative.Navigation.administrative_people">Persoas</message>
-<message key="xmlui.administrative.Navigation.administrative_groups">Grupos</message>
-<message key="xmlui.administrative.Navigation.administrative_authorizations">Autorizacións</message>
-<message key="xmlui.administrative.Navigation.administrative_registries">Rexistros</message>
-<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatos</message>
-<message key="xmlui.administrative.Navigation.administrative_format">Formato</message>
-<message key="xmlui.administrative.Navigation.administrative_items">Ítems</message>
-<message key="xmlui.administrative.Navigation.administrative_withdrawn">Ítems eliminados</message>
-<message key="xmlui.administrative.Navigation.administrative_control_panel">Panel de control</message>
-<message key="xmlui.administrative.Navigation.statistics">Estatísticas</message>
-<message key="xmlui.administrative.Navigation.administrative_import_metadata">Importar metadatos</message>
-<message key="xmlui.administrative.Navigation.administrative_curation">Tarefas de curación</message>
-
-<!-- my account items -->
-<message key="xmlui.administrative.Navigation.account_export">As miñas exportacións</message>
-
-<!-- export item -->
-<message key="xmlui.administrative.ItemExport.head">Exportar arquivo </message>
-<message key="xmlui.administrative.ItemExport.item.id.error">O código do ítem que introduciu non é válido.</message>
-<message key="xmlui.administrative.ItemExport.collection.id.error">O identificador da colección que introduciu non é válido.</message>
-<message key="xmlui.administrative.ItemExport.community.id.error">O código da comunidade que introduciu non é válido.</message>
-<message key="xmlui.administrative.ItemExport.item.not.found">Non se atopou o ítem solicitado.</message>
-<message key="xmlui.administrative.ItemExport.collection.not.found">Non se atopou a colección solicitada.</message>
-<message key="xmlui.administrative.ItemExport.community.not.found">Non se atopou a comunidade solicitada.</message>
-<message key="xmlui.administrative.ItemExport.item.success">O ítem exportouse correctamente. Cando o arquivo estea listo para descargar, recibirá un correo electrónico. Tamén pode usar a ligazón "As miñas exportacións" para ver os arquivos dispoñibles.</message>
-<message key="xmlui.administrative.ItemExport.collection.success">A colección exportouse con éxito. Cando o arquivo estea listo para descargar, recibirá unha mensaxe de correo electrónico. Tamén pode empregar a ligazón "A miñas exportacións" para ver unha listaxe dos arquivos que están ao seu dispor.</message>
-<message key="xmlui.administrative.ItemExport.community.success">A comunidade exportouse con éxito. Cando o arquivo estea listo para descargar, recibirá unha mensaxe de correo electrónico. Tamén pode empregar a ligazón "A miñas exportacións" para ver unha listaxe dos arquivos que están ao seu dispor.</message>
-<message key="xmlui.administrative.ItemExport.available.head">Arquivos de exportación dispoñibles para descargar:</message>
-
-<!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Administrar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Xestión de usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accións</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crear un novo usuario</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Prema aquí para engadir un novo usuario.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Listar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Prema aquí para listar todos os usuarios.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Buscar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Os usuarios búscanse por coincidencia parcial de correo electrónico ou nome</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A seguir figura a listaxe de usuarios que coincide co seu padrón de busca. Escolla a que quere borrar e prema o botón "Borrar" para continuar, ou prema sobre o enderezo de correo electrónico ou sobre o nome dun usuario para editalos.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultados da busca</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nome</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Enderezo electrónico</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Borrar usuarios</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">A súa busca non obtivo ningún resultado...</message>
-
-<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-<message key="xmlui.administrative.eperson.AddEPersonForm.title">Engadir usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Engadir usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crear un novo usuario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Este enderezo de correo electrónico está a ser usado por outra persoa. O enderezo de correo electrónico debe ser único.</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Información do novo usuario:</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">O enderezo de correo electrónico debe ser único.</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Requírese un enderezo de correo electrónico</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">O nome é un dato necesario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">O apelido é un dato necesario</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Precisa certificado</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Pode acceder</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crear usuario</message>
-
-<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Editar un usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Este enderezo de correo electrónico está a ser usado por outra persoa. O enderezo de correo electrónico debe ser único.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Información de {0}:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">O correo electrónico debe ser único</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Requírese un enderezo de correo electrónico</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">O nome é un dato necesario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">O apelido é un dato necesario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Precisa certificado</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Pode acceder</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restablecer contrasinal</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Tamén pode borrar permanentemente este usuario do sistema ou restablecer o seu contrasinal. Cando rexenera un contrasinal, o usuario recibe unha mensaxe que contén unha ligazón especial que pode seguir para asignar un novo contrasinal.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Borrar usuario</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Acceder como usuario</message>
-
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Este usuario non se pode borrar debido ás seguintes restricións:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">e</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">O usuario enviou un ou máis ítems</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">O usuario ten un envío de fluxo de traballo activo</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">O usuario ten unha tarefa de fluxo de traballo por atender</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">O usuario ten unha restrición sen identificar no sistema</message>
-
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Este usuario pertence aos grupos:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(polo grupo: {0})</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">ningún</message>
-
-<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirme que quere borrar o usuario</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmar o borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmar o borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Borraranse os seguintes usuarios:</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmar o borrado</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nome</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Enderezo electrónico</message>
-
-<!-- general items for all of the group classes -->
-<message key="xmlui.administrative.group.general.group_trail">Administrar grupos</message>
-
-<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-<message key="xmlui.administrative.group.ManageGroupsMain.title">Administrar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Xestión de grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accións</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crear un novo grupo</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Prema aquí para engadir un novo grupo.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Listar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Prema aquí para listar todos os grupos.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Buscar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Os grupos búscanse por coincidencia parcial no nome</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultados da busca</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nome</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membros</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Comunidade/colección</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ver</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Borrar grupos</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.no_results">A súa busca non obtivo ningún resultado...</message>
-
-<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-<message key="xmlui.administrative.group.EditGroupForm.title">Editor de grupos</message>
-<message key="xmlui.administrative.group.EditGroupForm.trail">Editar grupo</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grupos: {0} (ID: {1})</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grupos: novo grupo</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Limpar a busca</message>
-<message key="xmlui.administrative.group.EditGroupForm.member">Membro</message>
-<message key="xmlui.administrative.group.EditGroupForm.cycle">Ciclo</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending">Pendente</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: os cambios pendentes non se gardan ata que preme o botón "Gardar".</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_add">Engadir</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Eliminar </message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_para">Este grupo está asociado coa colección:</message>
-<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado coa comunidade: </message>
-<message key="xmlui.administrative.group.EditGroupForm.label_name">Cambiar o nome do grupo:</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Este grupo está asociado cunha colección específica e non se pode modificar o seu nome.</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_search">Buscar membros para engadir:</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuarios...</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupos...</message>
-<message key="xmlui.administrative.group.EditGroupForm.no_results">A súa busca non obtivo ningún resultado...</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nome</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Enderezo electrónico</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nome</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membros</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Colección</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ver</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_head">Membros</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nome</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column3">Enderezo electrónico</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupo: {0}</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_none">Este grupo non ten ningún membro.</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendente]</message>
-<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Eliminar membros</message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Eliminar membros</message>
-
-<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirme que quere borrar o grupo</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmar o borrado</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmar o borrado</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Borraranse os seguintes grupos:</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nome</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuarios</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupos</message>
-
-<!-- general items for all of the registries classes -->
-<message key="xmlui.administrative.registries.general.format_registry_trail">Rexistro de formatos</message>
-<message key="xmlui.administrative.registries.general.metadata_registry_trail">Rexistro de metadatos</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Borrar formatos de arquivo</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Borrar formatos do arquivo</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmar o borrado</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Está seguro/a de querer borrar este formato? Calquera arquivo existente con este formato asociarase a un formato descoñecido.</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipo MIME</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nome</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Borrar campos</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Borrar campos</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar o borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Está <b>absolutamente</b> seguro/a de querer borrar estes campos? Se algún ítem contén metadatos nestes campos, producirase un erro e advertiráselle que non se pode borrar. Debe asegurarse de que non hai ítems no sistema que empreguen estes campos.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVISO:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Esta acción producirá un erro se algún ítem contén metadatos nestes campos.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nome</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota de alcance</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Esquema borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Esquema borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmar o borrado</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Está <b>absolutamente</b> seguro/a de querer borrar este esquema? Se algún ítem contén metadatos nos campos contidos neste esquema, producirase un erro e advertiráselle que non se pode borrar. Debe asegurarse de que non hai ítems no sistema que empreguen campos contidos neste esquema.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVISO:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Esta acción producirá un erro se algún ítem contén metadatos en calquera dos campos do esquema.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espazo de nomes</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nome</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Formato do arquivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Formato do arquivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Novo formato de arquivo</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Formato do arquivo: {0}</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Proporcione metadatos descritivos sobre o formato do arquivo indicado abaixo. Mentres que os nomes dos formatos deben ser únicos, os MIME-types non teñen por que selo. Debe manter distintas entradas de formato para diferentes versións de Microsoft Word, mesmo aínda que o MIME-type sexa o mesmo para eles.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nome</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nome único para este formato (p. ex. Microsoft Word XP ou Microsoft Word 2000)</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">O nome do campo é necesario.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipo MIME</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">O MIME-type asociado a este formato non debe ser único.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descrición</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivel de soporte</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">O nivel de soporte que a súa institución concede a este formato.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Descoñecido</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Coñecido</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Compatible</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Interno</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Os formatos marcados como "internos" están ocultos para os usuarios e úsanse para fins administrativos.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensións do ficheiro</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">As extensións son extensións dos arquivos que se empregan automaticamente para identificar os formatos dos arquivos cargados. Pode indicar varias extensións para cada formato.</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadatos: {0}</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Este é o esquema de {0}. Pode engadir ou modificar campos de metadatos existentes deste esquema. Os campos tamén poden marcarse para borralos ou movelos a outro esquema.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Campos de metadatos do esquema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota de alcance</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Sen campos de metadatos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Borrar campos</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mover campos a outro esquema</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Engadir un novo campo de metadato</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nome do campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota de alcance</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notas adicionais sobre este campo de metadato.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Engadir un novo campo de metadato</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Modificar campo: {0}</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Modificar campo</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error">Erro</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">O nome do campo xa está en uso. Todos os elementos e cualificadores deben ser únicos.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">O elemento do campo é necesario.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">O elemento do campo contén un carácter estraño. O elemento NON pode conter: puntos, texto subliñado ou espazos.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">O elemento do campo é demasiado longo, debe conter menos de 32 caracteres.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">O cualificador do campo é demasiado longo, debe conter menos de 32 caracteres.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">O cualificador do campo contén un carácter estraño. O cualificador NON pode conter: puntos, texto subliñado ou espazos.</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
-<message key="xmlui.administrative.registries.FormatRegistryMain.title">Rexistro de formatos</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.head">Rexistro de formatos de arquivos</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Esta listaxe de arquivos proporciona información sobre formatos de arquivos coñecidos e o seu nivel de soporte. Pode editar ou engadir novos formatos de arquivo con esta ferramenta. Os formatos marcados como "internos" están ocultos para os usuarios e úsanse para fins administrativos.</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Engadir un formato de arquivo novo</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nome</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipo MIME</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivel de soporte</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>interno</i>)</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Descoñecido</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Coñecido</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Soporte</message>
-<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Borrar formatos</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Rexistro de metadatos</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Rexistro de metadatos</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">O rexistro de metadatos mantén unha listaxe de todos os campos dispoñibles no repositorio. Estes campos poden distribuírse entre múltiples esquemas; porén, DSpace necesita o esquema de clasificación de Dublin Core. Pode estender o esquema Dublin Core con campos adicionais ou engadir novos esquemas ao rexistro.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espazo de nomes</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nome</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Esquema borrado</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Engadir novo esquema</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espazo de nomes</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">O "Espazo de nomes" debe establecer un enderezo URI para o novo esquema.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Este campo é obrigatorio</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nome</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Nome resumido do esquema. Empregarase como prefixo dos nomes de campo (p. ex. dc.element.qualifier). O nome debe conter menos de 32 caracteres e non pode incluír espazos, puntos ou texto subliñado.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Este campo é obrigatorio e debe conter polo menos 32 caracteres sen espazos, puntos, nin texto subliñado.</message>
-<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Engadir un novo esquema</message>
-
-<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-<message key="xmlui.administrative.registries.MoveMetadataField.title">Mover campos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mover campos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mover campos de metadatos</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para1">Escolla un esquema destino a onde se moverán estes campos. Se o esquema destino contén campos con nomes idénticos, estes campos non se moverán.</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nome</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota de alcance</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mover ao esquema:</message>
-<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mover campos</message>
-
-<!-- general authorization keywords -->
-<message key="xmlui.administrative.authorization.general.authorize_trail">Autorización</message>
-<message key="xmlui.administrative.authorization.general.policyList_trail">Listaxe de privilexios</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administrar privilexios de autorización</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administrar privilexios de autorización</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autorizacións de ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">O ID que indicou non se pode relacionar con ningún ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Buscar un ítem</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Os ítems búscanse por handle ou por ID interno</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Atopar</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Ferramentas para autorizacións avanzadas</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Prema aquí para acceder á ferramenta de administración de privilexios</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorizacións de comunidades/coleccións</message>
-<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Prema nunha comunidade ou colección para editar os seus privilexios.</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
-<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Editar privilexios</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Listaxe de privilexios</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilexios para a colección {0} ({1}, ID: {2})</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilexios para a comunidade {0} ({1}, ID: {2})</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Prema aquí para engadir un novo privilexio.</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Engadir</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acción</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupo</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Borrar a selección</message>
-<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editar</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
-<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editar privilexios do ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Listaxe de privilexios</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilexios para o ítem {0} (ID={1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Con este editor pode ver e modificar os privilexios dun ítem, ademais de editar os privilexios de cada compoñente individual dun ítem: bloques e arquivos. De xeito breve, un ítem é un contedor de bloques, e os bloques son contedores de arquivos. Habitualmente, os contedores teñen privilexios para ENGADIR/BORRAR/LER/ESCRIBIR, mentres que os arquivos só teñen privilexios para LER/BORRAR.</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Nótese que hai un bloque extra para cada ítem, que é o que contén o texto da licenza para o ítem.</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilexios do ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilexios do bloque {0} ({1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Arquivo {0} ({1})</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Engadir un novo privilexio para o ítem</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Engadir un novo privilexio para o bloque</message>
-<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Engadir un novo privilexio para o arquivo</message>
-
-<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Non se atoparon privilexios asociados a este obxecto</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
-<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editar privilexio</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editar privilexio</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crear novo privilexio para {0} {1}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editar privilexio {0} para {1} {2}</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Non se seleccionou ningún grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Non se seleccionou ningunha acción</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nome</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accións para este recurso</message>
-
-<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conxunto</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultados da busca</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Escolla un grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Buscar un grupo</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Buscar</message>
-<message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Escolla a acción</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Xestor avanzado de privilexios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizacións avanzadas</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Xestor avanzado de privilexios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permite engadir e quitar privilexios a tipos de contidos dunha colección. Ollo, é perigoso: borrar o permiso para LER dalgún ítem pode ocultalos!</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Para todos os grupos marcados...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">... concede a capacidade de levar a cabo a seguinte acción...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">... para todos os seguintes tipos de obxectos...</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">... en todas as coleccións seguintes.</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupo</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acción</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipo de contido</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Colección</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Engadir privilexios</message>
-<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilexios</message>
-
-<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirme que quere borrar os privilexios</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmar o borrado</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmar o borrado</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Eliminaranse os seguintes privilexios:</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acción</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupo</message>
-
-<!-- general edit item messages -->
-<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
-<message key="xmlui.administrative.item.general.template_head">Editar modelo de ítem para a colección: {0}</message>
-<message key="xmlui.administrative.item.general.option_head">Editar ítem</message>
-<message key="xmlui.administrative.item.general.option_status">Estado do ítem</message>
-<message key="xmlui.administrative.item.general.option_bitstreams">Arquivos do ítem</message>
-<message key="xmlui.administrative.item.general.option_metadata">Metadatos do ítem</message>
-<message key="xmlui.administrative.item.general.option_view">Ver ítem</message>
-<message key="xmlui.administrative.item.general.option_curate">Curar</message>
-<message key="xmlui.administrative.item.general.option_queue">Deixar á espera</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-<message key="xmlui.administrative.item.AddBitstreamForm.title">Subir arquivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.trail">Subir arquivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.head1">Subir un novo arquivo</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bloque</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Ficheiros de contido (por defecto)</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Ficheiros de metadatos</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturas</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licenzas</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licenzas Creative Commons</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Ficheiro</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Por favor, introduza o camiño completo do ficheiro que corresponda co ítem no seu ordenador. Se preme en "Examinar...", abrirase unha xanela que lle permitirá seleccionar un ficheiro do seu ordenador.</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descrición</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Subir</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Precisa os privilexios ENGADIR e ESCRIBIR polo menos nun bloque para poder cargar novos arquivos.</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmar o borrado</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmar o borrado</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmar a acción de borrar</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Está seguro/a de querer borrar estes ficheiros?:</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nome</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descrición</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formato</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirmar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirmar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modificar o ítem: {0}</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Está seguro/a de querer borrar por completo este ítem? Coidado: non quedará ningún rastro del.</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Está seguro/a de querer retirar este ítem do repositorio?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Está seguro/a de querer reintegrar este ítem na base de datos?</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column1">Campo</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column3">Idioma</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retirar</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Reintegrar</message>
-
-<!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-<message key="xmlui.administrative.item.MoveItemForm.title">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.trail">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.head1">Mover ítem: {0}</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection">Colección</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_help">Seleccione a colección á que quere mover o ítem.</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_default">Seleccione unha colección...</message>
-<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Herdar privilexios</message>
-<message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Herdar os privilexios por defecto da colección destino</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-<message key="xmlui.administrative.item.EditBitstreamForm.title">Editar arquivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editar arquivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editar arquivo</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Ficheiro</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Arquivo principal</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Si</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Non</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descrición</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccione na listaxe o formato do arquivo, por exemplo "</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Formato escollido</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.format_default">O formato non está na listaxe.</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se o formato non está na listaxe, </message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Outro formato</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.user_help">O nome e versión da aplicación que empregou para crear o ficheiro (por exemplo, "</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nome do ficheiro</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renomear este ficheiro. Nótese que a URL que se mostra cambiará, pero as ligazóns antigas seguiranse resolvendo mentres non cambie o ID.</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Arquivos do ítem</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Arquivos do ítem</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Arquivos</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nome</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descrición</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ver</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Orde</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bloque: {0}</strong></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ver</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un novo arquivo</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Borrar arquivos</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Actualizar a orde dos bitstreams</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Precisa os privilexios ENGADIR e ESCRIBIR sobre o ítem e os bloques para poder cargar novos arquivos.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Só os administradores de DSpace poden borrar ficheiros.</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Anterior:</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Subir</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Descargar</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadatos do ítem</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadatos do ítem</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Engadir novo metadato</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nome</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Idioma</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Engadir novo metadato</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.para1">AVISO: estes cambios non se validan de ningún modo. É a súa responsabilidade introducir os datos no formato correcto. De non estar seguro, por favor, NON faga cambios.</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatos</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Eliminar </message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nome</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Idioma</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
-<message key="xmlui.administrative.item.EditItemStatusForm.title">Estado do ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estado do ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvido/a á páxina de xestión de ítems. Desde aquí poderá retirar, reintegrar ou borrar o ítem. Tamén poderá modificalo ou engadir novos metadatos/arquivos nos outros separadores.</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_id">ID interno do ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Última modificación</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_in">Nas coleccións</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Páxina do ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editar autorizacións do ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirar o ítem do repositorio</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Reintegrar o ítem no repositorio</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mover o ítem a outra colección</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Borrar completamente o ítem</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorizacións...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirar...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Reintegrar...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mover...</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Borrar permanentemente</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(só administradores do sistema)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(só administradores de colección)</message>
-<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(non ten permisos para realizar esta acción)</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
-<message key="xmlui.administrative.item.ViewItem.title">Ver ítem</message>
-<message key="xmlui.administrative.item.ViewItem.trail">Ver ítem</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-<message key="xmlui.administrative.item.CurateItemForm.main_head">Curar o ítem: {0}</message>
-<message key="xmlui.administrative.item.CurateItemForm.title">Curar o ítem</message>
-<message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
-<message key="xmlui.administrative.item.CurateItemForm.label_name">Tarefa</message>
-
-<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
-<message key="xmlui.administrative.item.FindItemForm.title">Atopar ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.head1">Atopar ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_label">ID interno do ítem/handle do ítem</message>
-<message key="xmlui.administrative.item.FindItemForm.identifier_error">Imposible resolver o identificador.</message>
-<message key="xmlui.administrative.item.FindItemForm.find">Atopar</message>
-
-<!-- org.dspace.app.xmlui.administrative.metadataimport -->
-<message key="xmlui.administrative.metadataimport.general.title">Importar metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.head1">Importar metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.trail">Importar metadatos</message>
-<message key="xmlui.administrative.metadataimport.general.changes">cambios</message>
-<message key="xmlui.administrative.metadataimport.general.no_changes">Non se detectaron cambios</message>
-<message key="xmlui.administrative.metadataimport.general.new_item">Novo ítem</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_successful">O ficheiro subiuse con éxito</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_failed">Erro ao subir o ficheiro</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badschema">Esquema de metadatos descoñecido no encabezamento</message>
-<message key="xmlui.administrative.metadataimport.flow.upload_badelement">Elemento de metadatos descoñecido no encabezamento</message>
-<message key="xmlui.administrative.metadataimport.flow.import_successful">Importación realizada con éxito</message>
-<message key="xmlui.administrative.metadataimport.flow.import_failed">Erro na importación</message>
-<message key="xmlui.administrative.metadataimport.flow.over_limit">Excedeuse o número máximo de cambios permitidos. Limíteos ou cambie o parámetro bulkedit.gui-item-limit en dspace.cfg</message>
-
-<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Subir CSV</message>
-
-<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Procesado con éxito</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Cambios aplicados ao ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Engadido: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Eliminado: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Engadido á colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado da colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Relacionado coa colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Desligado da colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ítem borrado</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ítem retirado</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ítem reintegrado</message>
-
-<!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Engadir: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Eliminar:</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Engadir á colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Eliminar da colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Relacionar coa colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Desligar da colección</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Cambios pendentes do ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Aplicar cambios</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Os cambios pendentes móstranse a continuación para seren revisados</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Borrar ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Retirar ítem</message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reintegrar ítem</message>
-
-<!-- general mapper messages -->
-<message key="xmlui.administrative.mapper.general.mapper_trail">Relacionador de ítems</message>
-
-<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
-<message key="xmlui.administrative.mapper.MapperMain.title">Relacionador de ítems</message>
-<message key="xmlui.administrative.mapper.MapperMain.head1">Relacionador de ítems (relaciona ítems doutras coleccións)</message>
-<message key="xmlui.administrative.mapper.MapperMain.para1">Colección: "<strong>{0}</strong>"</message>
-<message key="xmlui.administrative.mapper.MapperMain.para2">Esta é a ferramenta de ligazón de ítems que permite aos administradores de colección relacionar ítems doutras colección nesta. Pode buscar ítems doutra colección e relacionalos ou ver a listaxe de ítems relacionados.</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estatísticas</message>
-<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} de {1}</strong> ítems nesta colección están relacionados con outras coleccións</message>
-<message key="xmlui.administrative.mapper.MapperMain.search_label">Buscar</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_search">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.MapperMain.no_add">(Precisa o privilexio ADD na colección)</message>
-
-<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
-<message key="xmlui.administrative.mapper.SearchItemForm.title">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.trail">Buscar ítems</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.head1">Buscar ítems que coincidan: "{0}"</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Relacionar os ítems marcados</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column2">Colección</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column4">Título</message>
-
-<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-<message key="xmlui.administrative.mapper.BrowseItemForm.title">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Listar ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Listaxe de ítems relacionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desligar os ítems seleccionados</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Colección</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Título</message>
-<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Precisa o privilexio BORRAR nesta colección para desligar os ítems.</message>
-
-<!-- General tags for collection management -->
-<message key="xmlui.administrative.collection.general.collection_trail">Coleccións</message>
-<message key="xmlui.administrative.collection.general.options_metadata">Editar metadatos</message>
-<message key="xmlui.administrative.collection.general.options_roles">Asignar roles</message>
-<message key="xmlui.administrative.collection.general.options_curate">Curar</message>
-<message key="xmlui.administrative.collection.general.options_queue">Deixar á espera</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editar roles da colección</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Roles</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editar colección: {0}</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">ningún</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crear...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restrinxir...</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Os administradores da colección deciden quen pode enviar ítems á colección, retiralos, editar os metadatos (despois do envío) e engadir (relacionar) ítems existentes noutras coleccións a esta colección (dependendo da autorización desta colección).</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">As persoas responsables deste paso poderán aceptar ou rexeitar envíos pendentes. Porén, non poderán editar os metadatos do envío.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">As persoas responsables deste paso poderán editar os metadatos dos envíos pendentes e aceptar ou rexeitar os envíos.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">As persoas responsables deste paso poderán editar os metadatos dos envíos pendentes, pero non poderán rexeitar os envíos.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Usuarios e grupos que teñen permiso para enviar novos ítems a esta colección.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuarios e grupos que poden ler os novos ítems enviados a esta colección. Os cambios neste rol son retroactivos e os antigos ítems permanecerán visibles para aqueles que tiveran acceso no momento da súa incorporación.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Esta colección usa unha configuración de acceso personalizada.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">O permiso por defecto de lectura dos ítems e dos arquivos está actualmente asignado a Anónimo.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editar directamente os privilexios de autorización.</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grupo asociado</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradores</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Pasos de fluxo de traballo</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa aceptar/rexeitar</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa aceptar/rexeitar/editar metadatos</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editar metadatos</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Publicadores</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Acceso por defecto de lectura</message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(só administradores do sistema)</nobr></message>
-<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(Non ten permisos para configurar isto)</nobr></message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar a colección: {0}</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar a colección</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Tarefa</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmar o borrado</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirme que quere borrar a colección {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Está seguro/a de querer borrar a colección {0}? Isto borrará:</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Ítems e envíos pendentes desta colección que non estean contidos noutras coleccións</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">O contido destes ítems</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Todos os privilexios asociados</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirme que quere borrar o rol</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirme que quere borrar o rol {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Está seguro/a de querer borrar este rol? Ao borrar este grupo, dará permiso para LER a todos os ítems enviados a esta colección de agora en diante. Por favor, teña en conta que este cambio non é retroactivo, polo que os ítems enviados con anteriores privilexios restrinxiranse aos membros definidos no grupo que vai borrar.</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Está seguro/a de querer borrar este rol? Perderanse todos os cambios e personalizacións realizados no grupo {0} e terá que crealos de novo.</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editar metadatos da colección</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatos</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar colección: {0}</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nome</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descrición breve:</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introdutorio (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novidades (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licenza</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Orixe</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Subir novo logo</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Modelo de ítem</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crear...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editar...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Eliminar logo</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Borrar colección</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Gardar cambios</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(só administradores do sistema)</nobr></message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crear colección</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crear colección</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduza metadatos para unha nova colección de {0}</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crear</message>
-
-<!-- General to the harvesting options under collection -->
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Parámetros de recolección de colección</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Recollendo</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Orixe do contido</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Orixe do contido</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Esta é unha colección DSpace estándar</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Esta colección recolle os seus contidos dunha fonte externa</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Gardar</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Localización da colección recollida</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opcións de recolección</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Provedor OAI</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set ID</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">A URL do provedor do servizo OAI do repositorio obxecto</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Debe fornecer un set ID da colección obxecto.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">O identificador persistente empregado polo provedor OAI para designar a colección obxecto</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Debe fornecer o set ID da colección obxecto.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">O contido está a ser recollido</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Recoller só metadatos.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Recoller metadatos e referencias aos ficheiros (require soporte ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Recoller metadatos e ficheiros (require soporte ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Probar parámetros</message>
-
-<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Localización da colección recollida</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Provedor OAI</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set ID</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">O contido está a ser recollido</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Último resultado da recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Esta colección aínda non se recolleu.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Estado actual da recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Colección lista para recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Colección en proceso de recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Colección en espera de recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Produciuse un erro OAI na última recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Produciuse un erro na última recolección</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Recoller só metadatos.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Recoller metadatos e referencias aos ficheiros.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Recoller metadatos e ficheiros (replicación completa).</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Cambiar parámetros</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importar agora</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Restaurar e reimportar a colección</message>
-
-<message key="xmlui.administrative.ControlPanel.option_harvest">Recollendo</message>
-<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controis do planificador da Recolección</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_status">Estado</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Accións</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Arrancar Recolección</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado do recolector</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Retomar</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Deter</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Deter</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Coleccións listas para recoller</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_active">Recoleccións activas</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Recoleccións en espera</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Erros OAI</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Erros internos</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Parámetros do xerador</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Orixe ORE</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Parámetros do recolector</message>
-
-<!-- General tags for community management -->
-<message key="xmlui.administrative.community.general.community_trail">Comunidades</message>
-<message key="xmlui.administrative.community.general.options_metadata">Editar metadatos</message>
-<message key="xmlui.administrative.community.general.options_roles">Asignar roles</message>
-<message key="xmlui.administrative.community.general.options_curate">Curar</message>
-<message key="xmlui.administrative.community.general.options_queue">Deixar á espera</message>
-
-<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editar roles da comunidade</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editar comunidade: {0}</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">ningún</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.create">Crear...</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Os administradores de comunidade poden crear subcomunidades ou coleccións, así como xestionar ou conceder permisos a esas comunidades ou coleccións. Ademais, deciden quen pode enviar ítems ás coleccións, editar metadatos e engadir (mapear) ítems existentes noutras coleccións (suxeitos a autorización).</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Esta comunidade usa unha configuración de acceso personalizada. </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">O permiso por defecto de lectura dos ítems e dos arquivos está actualmente asignado a Anónimo.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editar directamente os privilexios de autorización.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Grupo asociado</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons"> </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administradores</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(só administradores do sistema)</nobr></message>
-
-<!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-<message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar a comunidade: {0}</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.title">Curar a comunidade</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.label_name">Tarefa</message>
-
-<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmar o borrado</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirme que quere borrar a comunidade {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Está seguro/a de querer borrar a comunidade {0}? Isto borrará:</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Coleccións da comunidade non contidas noutras comunidades.</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Ítems e envíos pendentes desta comunidade que non estean contidos noutras comunidades</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">O contido destes ítems</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Todos os privilexios asociados</message>
-
-<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirme que quere borrar o rol</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirmar</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirme que quere borrar o rol {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Está seguro/a de querer borrar este rol? Perderanse todos os cambios e personalizacións realizados no grupo {0} e podería ter que recrealo.</message>
-
-<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editar metadatos da comunidade</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatos</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editar metadatos da comunidade {0}</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editar privilexios</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nome</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descrición breve</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introdutorio (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Novidades (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Subir novo logo</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Eliminar logo</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Borrar comunidade</message>
-
-<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-<message key="xmlui.administrative.community.CreateCommunityForm.title">Crear comunidade</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crear comunidade</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introducir metadatos para unha nova subcomunidade de {0}</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editar metadatos dunha nova comunidade de primeiro nivel</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crear</message>
-
-<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-<message key="xmlui.administrative.ControlPanel.title">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.trail">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.head">Panel de control</message>
-<message key="xmlui.administrative.ControlPanel.option_java">Información Java</message>
-<message key="xmlui.administrative.ControlPanel.option_dspace">Configuración de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.option_alerts">Alertas do sistema</message>
-<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
-<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-<message key="xmlui.administrative.ControlPanel.java_head">Java e sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.java_version">Versión de Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.java_vendor">Provedor de Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.os_name">Nome do sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura do sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.os_version">Versión do sistema operativo</message>
-<message key="xmlui.administrative.ControlPanel.runtime_head">Estatísticas de execución</message>
-<message key="xmlui.administrative.ControlPanel.runtime_processors">Procesadores dispoñibles</message>
-<message key="xmlui.administrative.ControlPanel.runtime_max">Memoria máxima</message>
-<message key="xmlui.administrative.ControlPanel.runtime_total">Memoria asignada</message>
-<message key="xmlui.administrative.ControlPanel.runtime_used">Memoria empregada</message>
-<message key="xmlui.administrative.ControlPanel.runtime_free">Memoria libre</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_version">Versión de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Directorio caché de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Directorio de traballo de Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Tamaño da caché principal ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Borrar inmediatamente a caché)</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Tamaño da caché de persistencia ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Tamaño da caché transitoria ({0})</message>
-<message key="xmlui.administrative.ControlPanel.dspace_head">Parámetros de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_version">Versión de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_dir">Directorio de instalación de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_url">URL base de DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nome do host DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_name">Nome do sitio</message>
-<message key="xmlui.administrative.ControlPanel.db_name">Nome da base de datos</message>
-<message key="xmlui.administrative.ControlPanel.db_url">URL da base de datos</message>
-<message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
-<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexións á base de datos no Pool</message>
-<message key="xmlui.administrative.ControlPanel.db_maxwait">Tempo máximo de espera DB</message>
-<message key="xmlui.administrative.ControlPanel.db_maxidle">Número máximo de conexións sen usar</message>
-<message key="xmlui.administrative.ControlPanel.mail_server">Servidor SMTP</message>
-<message key="xmlui.administrative.ControlPanel.mail_from_address">Correo remitente</message>
-<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatario de suxestións</message>
-<message key="xmlui.administrative.ControlPanel.mail_admin">Correo do administrador principal</message>
-<message key="xmlui.administrative.ControlPanel.alerts_head">Alertas do sistema</message>
-<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Advertencia para sistemas de balanceamento de carga</strong>: as alertas globais son só efectivas para o nodo no que se activaron. Precisa asegurarse de que cada nodo no grupo recibe o comando de alerta de activación.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaxe de alerta</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_default">O sistema apagarase debido a tarefas habituais de mantemento. Por favor, garde o seu traballo e desconéctese.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Conta atrás</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Sen conta atrás</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutos</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Manter a conta atrás actual</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_label">Xestionar sesión</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuar a permitir sesións autenticadas</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Deter a autenticación pero sen que afecte ás sesións actuais</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Deter a autenticación e rematar as sesións actuais</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Nota:</strong> os administradores exceptúanse na xestión de sesións.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activar</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactivar</message>
-<message key="xmlui.administrative.ControlPanel.activity_head">Actividade actual (máximo {0} páxinas)</message>
-<message key="xmlui.administrative.ControlPanel.stop_anonymous">PARAR a gravación da actividade anónima.</message>
-<message key="xmlui.administrative.ControlPanel.start_anonymous">COMEZAR a gravación da actividade anónima.</message>
-<message key="xmlui.administrative.ControlPanel.stop_bot">PARAR a gravación automática da actividade.</message>
-<message key="xmlui.administrative.ControlPanel.start_bot">COMEZAR a gravación automática da actividade.</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horaria</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuario</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Enderezo IP</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_url">Páxina URL</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
-<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anónimo {0}</message>
-<message key="xmlui.administrative.ControlPanel.activity_none">Sen rexistrar visualizacións de páxinas</message>
-
-<message key="xmlui.administrative.ControlPanel.select_panel">Empregue os separadores de arriba para seleccionar a información que se vai mostrar</message>
-
-<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>En {0} minutos</strong>:</message>
-
-<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-<message key="xmlui.administrative.NotAuthorized.title">Non autorizado</message>
-<message key="xmlui.administrative.NotAuthorized.trail">Non autorizado</message>
-<message key="xmlui.administrative.NotAuthorized.head">Privilexios insuficientes</message>
-<message key="xmlui.administrative.NotAuthorized.para1a">A súa conta non ten os privilexios suficientes para realizar a acción solicitada. Se cre que se pode tratar dun erro ou se precisa realizar a acción, por favor contacte cos</message>
-<message key="xmlui.administrative.NotAuthorized.para1b">Administradores de sistema</message>
-<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-<message key="xmlui.administrative.NotAuthorized.para2">Acceder como outro usuario</message>
-
-<!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-<message key="xmlui.administrative.CurateForm.title">Tarefas de curación do sistema</message>
-<message key="xmlui.administrative.CurateForm.trail">Tarefas de curación</message>
-<message key="xmlui.administrative.CurateForm.object_label_name">Handle do obxecto DSpace</message>
-<message key="xmlui.administrative.CurateForm.object_hint">Truco: introduza [prefixo-handle]/0 para executar unha tarefa en toda a súa instalación (non todas as tarefas permiten esta opción)</message>
-<message key="xmlui.administrative.CurateForm.task_label_name">Tarefa</message>
-<!-- Used by Curate<DSO>Form classes also -->
-<message key="xmlui.administrative.CurateForm.taskgroup_label_name">Escoller de entre os seguintes grupos</message>
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Statistics Aspect
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-<message key="xmlui.statistics.title">Estatísticas</message>
-<message key="xmlui.statistics.visits.total">Número total de visitas</message>
-<message key="xmlui.statistics.visits.month">Visitas ao mes</message>
-<message key="xmlui.statistics.visits.views">Visualizacións</message>
-<message key="xmlui.statistics.visits.countries">Países con máis visualizacións</message>
-<message key="xmlui.statistics.visits.cities">Cidades con máis visualizacións</message>
-<message key="xmlui.statistics.visits.bitstreams">Visitas ao ficheiro</message>
-<message key="xmlui.statistics.Navigation.title">Estatísticas</message>
-<message key="xmlui.statistics.Navigation.view">Ver estatísticas</message>
-<message key="xmlui.statistics.trail">Estatísticas</message>
-
-
-
-<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-dri2xhtml
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-
-
-
-<!-- structural.xsl -->
-<message key="xmlui.dri2xhtml.structural.footer-promotional"> 
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+
+	<!--
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
+		   because they are used very frequently.
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
+	<!-- General keys -->
+	<message key="xmlui.general.dspace_home">DSpace Principal</message>
+	<message key="xmlui.general.search">Buscas</message>
+	<message key="xmlui.general.go">Ir</message>
+	<message key="xmlui.general.go_home">Ir á páxina principal de DSpace</message>
+	<message key="xmlui.general.save">Gardar</message>
+	<message key="xmlui.general.cancel">Cancelar</message>
+	<message key="xmlui.general.return">Volver</message>
+	<message key="xmlui.general.update">Modificar</message>
+	<message key="xmlui.general.delete">Borrar</message>
+	<message key="xmlui.general.next">Seguinte</message>
+	<message key="xmlui.general.untitled">Sen título</message>
+        <message key="xmlui.general.perform">Realizar</message>
+        <message key="xmlui.general.queue">Deixar á espera</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
+		This is a special component that is not part of any aspect but is added
+		by manakin to all aspect chains.
+		-->
+	<message key="xmlui.PageNotFound.title">Páxina non atopada</message>
+	<message key="xmlui.PageNotFound.head">Páxina non atopada</message>
+	<message key="xmlui.PageNotFound.para1">A páxina á que tenta acceder non se atopou no servidor</message>
+
+
+	<!--
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Só os administradores poden acceder como outro usuario.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Só usuarios autenticados que sexan administradores poden acceder como outro usuario.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Non pode acceder como outro administrador.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
+	-->
+	<message key="xmlui.feed.general_description">O repositorio dixital DSpace captura, almacena, indexa, preserva e distribúe materiais de investigación en formato dixital.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
+	<message key="xmlui.feed.logo_title">Imaxe</message>
+	<message key="xmlui.feed.untitled">Sen título</message>
+
+	<!--
+		Default notice header
+	 	-->
+	<message key="xmlui.general.notice.default_head">Aviso</message>
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             ArtifactBrowser Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Resultados da busca na comunidade: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Resultados da busca na colección: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Resultados da busca</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">A súa solicitude {0} obtivo {1} resultados</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Comunidades ou coleccións que coinciden coa solicitude</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Ítems que coinciden coa solicitude</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">A busca non obtivo resultados</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Todo DSpace</message>
+
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">título</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data de publicación</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data de envío</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">pertinencia</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordenar ítems por</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">en orde</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">ascendente</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">descendente</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Resultados/páxina</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Busca avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Busca avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Busca avanzada</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Ámbito da busca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Limite a busca a unha comunidade ou colección.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Conxunción</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Tipo de busca</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Buscar por</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Título</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Materia</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Resumo</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Serie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Patrocinador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identificador</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Idioma (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Palabra chave</message>
+
+   <!--  some common other possibilities for Advanced Search Fields -->
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Contribuidor/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Creador/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descrición</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Relación</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Tipo MIME</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Outro/a colaborador/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Asesor/a</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Departamento</message>
+
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texto completo</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">E</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">Ou</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NON</message>
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ou introducir as primeiras letras:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Listar ítems que comezan con estas letras</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Saltar a un punto do índice:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Escoller mes)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Escoller ano)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ou introducir un ano:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Listar ítems dun determinado ano.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sentímolo, non hai resultados para esta busca.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Ordenar por:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Orde:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Resultados:</message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Autores/ítem:</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Todos</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">título</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data de publicación</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data de envío</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">ascendente</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">descendente</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Nome dos autores</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Materia</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Listar {0} por autor {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Listar {0} por autor</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Listar{0} por tema {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Listar {0} por tema</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Listar {0} por título {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Listar {0} por título</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Listar {0} por data de publicación {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Listar {0} data de publicación</message>
+
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Listar {0} por data de envío {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Listar {0} por data de envío</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Ámbito da busca</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Busca nesta colección:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Listar por</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autores</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Datas</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Busca avanzada</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Envíos recentes</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Listaxe de comunidades</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Listaxe de comunidades</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Comunidades en DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Escolla unha comunidade para listar as súas coleccións</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Ámbito da busca</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Buscar nesta comunidade e nas súas coleccións:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Listar por</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autores</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Datas</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Busca avanzada</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Subcomunidades nesta comunidade</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Coleccións nesta comunidade</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Envíos recentes</message>
+
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
+	<message key="xmlui.ArtifactBrowser.Contact.title">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Contacto</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">{0} administración en contacto en:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formulario en liña</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Enderezo electrónico</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Grazas por compartir as súas suxestións sobre DSpace. Teremos en conta os seus comentarios!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">O seu correo electrónico</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Este enderezo será empregado para o seguimento da súa suxestión.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Comentarios</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Suxestións</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Suxestións</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Suxestión enviada</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">O seu comentario foi recibido</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Ver ítem</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Este ítem aparece na(s) seguinte(s) colección(s)</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostrar o rexistro simple do ítem</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostrar o rexistro completo do ítem</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este ítem retirouse e non está dispoñible.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Listar</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Todo DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Comunidades e coleccións</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Títulos</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autores</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Materias</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Por data de publicación</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Por data de envío</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Esta colección</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Esta comunidade</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Buscar</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Ámbito da busca</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Busca de texto completo</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Este recurso está restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Este recurso está restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Esta comunidade está restrinxida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Esta colección está restrinxida</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Este ítem está restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Este arquivo está restrinxido.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Non ten os permisos necesarios para acceder ao recurso restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Non ten os permisos necesarios para acceder á comunidade restrinxida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Non ten os permisos necesarios para acceder á colección restrinxida<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Non ten os permisos necesarios para acceder ao ítem restrinxido<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Non ten os permisos necesarios para acceder ao arquivo restrinxido<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">colección</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">Comunidade</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">arquivo</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">ítem</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurso</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">descoñecido</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Continúe na pantalla de acceso</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este ítem retirouse. </message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">O ítem seleccionado retirouse e non está dispoñible.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">O ítem seleccionado é de acceso restrinxido e require credenciais para poder visualizalo. </message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">O seu usuario non dispón de permisos para ver o ítem. Para máis información, por favor contacte co administrador</message>
+        
+	<!-- Authentication messages used at the top of the login page:  -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Este ítem está restrinxido</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">O ítem ao que tenta acceder é un ítem restrinxido e require credenciais para poder verse. Por favor, identifíquese arriba para acceder ao ítem.</message>
+
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Informes mensuais</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Resumo estatístico</message>
+
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Sen informes dispoñibles na actualidade</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Actualmente non hai informes dispoñibles para este servizo. Comprobe a súa dispoñibilidade máis adiante.</message>
+
+    <!-- Authentication messages used for bitstream authentication -->
+	<message key="xmlui.BitstreamReader.auth_header">O arquivo está restrinxido</message>
+	<message key="xmlui.BitstreamReader.auth_message">O arquivo ao que tenta acceder é un arquivo restrinxido e require credenciais para poder verse. Por favor, identifíquese arriba para acceder ao arquivo.</message>
+
+	<!-- Export Archive download messages -->
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Este arquivo de exportación está restrinxido.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">O arquivo de exportación ao que tenta acceder é un recurso restrinxido e require permisos para poder visualizarse. Por favor, autentíquese máis baixo para acceder ao arquivo de exportación.</message>
+
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                EPerson Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- General keys used by the EPerson aspect -->
+	<message key="xmlui.EPerson.trail_new_registration">Rexistro de novo usuario</message>
+	<message key="xmlui.EPerson.trail_forgot_password">Esqueceu o contrasinal?</message>
+
+	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
+	<message key="xmlui.EPerson.CannotRegister.title">Rexistro non dispoñible</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Rexistro non dispoñible</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">A configuración deste repositorio DSpace non permite o rexistro neste contexto. Por favor, contacte co<a href="../contact">site administrator</a> with questions or comments.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
+	<message key="xmlui.EPerson.EditProfile.title_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Crear perfil</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Crear perfil</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Enderezo de correo electrónico</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Nome</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Apelido</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Teléfono de contacto</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Idioma</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Subscricións</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Pode subscribirse a coleccións para recibir diariamente un correo cos novos ítems engadidos. Pode subscribirse a tantas coleccións como queira. Outra opción é usar o servizo RSS dispoñible para todas as coleccións.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Subscrición de correo electrónico</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">(Escolla unha colección)</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcionalmente, pode escoller un contrasinal novo tecleándoo na cela superior e verificalo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Por favor, introduza unha clave na cela superior. Confírmea tecleándoa de novo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Contrasinal</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Repita para confirmar</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Completar o rexistro</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Modificar perfil</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Este campo é obrigatorio</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Escolla un contrasinal que conteña, polo menos, 6 caracteres</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Por favor, repita o contrasinal para confirmalo</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Vostede pertence aos seguintes grupos de autorización</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identificar</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Seguridade</message>
+
+	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifique o correo electrónico</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crear perfil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Rematado</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Verifique o correo electrónico</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Rematado</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">O seu contrasinal restableceuse</message>
+
+	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
+	<message key="xmlui.EPerson.InvalidToken.title">Cadea non válida</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Cadea non válida</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Cadea non válida</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">A URL que indicou non é válida. É posible que o seu correo fragmentase a URL en varias liñas, como:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">De ser o caso, deberá copiar e pegar a URL completa directamente na barra de enderezos do seu navegador, en lugar de simplemente premer na ligazón. A barra de enderezos deberá conter algo similar ao seguinte:</message>
+
+	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
+	<message key="xmlui.EPerson.Navigation.my_account">A miña conta</message>
+	<message key="xmlui.EPerson.Navigation.profile">Perfil</message>
+	<message key="xmlui.EPerson.Navigation.logout">Saír</message>
+	<message key="xmlui.EPerson.Navigation.login">Acceder</message>
+	<message key="xmlui.EPerson.Navigation.register">Rexistro</message>
+
+	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
+	<message key="xmlui.EPerson.PasswordLogin.title">Entrar</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Acceder</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Acceder a DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Enderezo electrónico</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">O enderezo de correo electrónico introducido e/ou o contrasinal non son válidos.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Contrasinal</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">Esqueceu o contrasinal?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Acceder</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Rexistrar un novo usuario</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Rexistrar unha conta para subscribirse ás coleccións, para recibir notificación das modificacións e das novas adquisicións de ítems en DSpace.</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Prema aquí para rexistrarse.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
+	<message key="xmlui.EPerson.LDAPLogin.title">Acceder</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Acceder</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Acceder a DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Nome de usuario</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">O nome de usuario ou o contrasinal non son válidos.</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Contrasinal</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Acceder</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
+	<message key="xmlui.EPerson.LoginChooser.title">Escoller un método de acceso</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Escoller nome de usuario</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Escoller un método de acceso</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Acceso mediante:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Autenticación mediante Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Autenticación mediante LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Autenticación mediante contrasinal</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Autenticación mediante certificado web</message>
+
+	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">As credenciais proporcionadas non son válidas.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Non se puido realizar a autenticación debido a que se recibiron argumentos non válidos.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Non se atopou ningún usuario cos permisos especificados.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Erro de autenticación</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Erro de autenticación</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Erro de autenticación</message>
+
+	<!-- Login xml files -->
+	<message key="xmlui.eperson.noAuthMethod.head">Non se atopou método de autenticación</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">Non se atopou método de autenticación. Por favor, póñase en contacto co administrador.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">A autenticación mediante Shibboleth fallou.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">A autenticación mediante Shibboleth non está dispoñible neste momento. Por favor, póñase en contacto co administrador.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
+	<message key="xmlui.EPerson.ProfileUpdated.title">Perfil modificado</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Modificar perfil</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Perfil modificado</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">A información do seu perfil foi modificada.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
+	<message key="xmlui.EPerson.RegistrationFinished.title">Rexistro acabado</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Rexistro acabado</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Agora xa está rexistrado no sistema DSpace. Pode subscribirse a coleccións para recibir por correo electrónico as modificacións e as novas incorporacións.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
+	<message key="xmlui.EPerson.ResetPassword.title">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Por favor, introduza unha nova clave na cela superior. Confírmea tecleándoa de novo na segunda cela. Debería conter, polo menos, 6 caracteres.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Enderezo de correo electrónico</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Novo contrasinal</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Repita para confirmar</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Escolla un contrasinal que conteña, polo menos, 6 caracteres</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Por favor, repita o seu contrasinal para confirmalo</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
+	<message key="xmlui.EPerson.StartForgotPassword.title">Esqueceu o contrasinal?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Esqueceu o contrasinal?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Introduza o enderezo de correo electrónico que proporcionou ao rexistrarse en DSpace. Enviarémoslle unha mensaxe a ese enderezo coas instrucións pertinentes.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Enderezo de correo electrónico</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Introduza o mesmo enderezo co que se rexistrou.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Enderezo de correo electrónico non atopado</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Enviar información</message>
+
+	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
+	<message key="xmlui.EPerson.StartRegistration.title">Rexistro de novo usuario</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Enderezo de correo electrónico en uso</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Este enderezo de correo está a ser utilizado por outra persoa. Se quere restablecer o contrasinal para esta conta, prema no botón "Restablecer contrasinal."</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Restablecer contrasinal para:</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Restablecer contrasinal</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Rexistro de novo usuario</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Rexistrar unha conta para subscribirse a coleccións para recibir por correo electrónico as modificacións e as novas incorporacións.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Enderezo de correo electrónico</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Este enderezo será verificado e corresponderá co seu nome de acceso.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">É imposible enviar un correo electrónico a este enderezo.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Rexistro</message>
+
+	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
+	<message key="xmlui.EPerson.VerifyEmail.title">Correo de verificación enviado</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Correo de verificación enviado</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">Enviouse un correo a {0} que contén unha URL especial e instrucións de rexistro.</message>
+
+
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		               Submission Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+
+
+	<!-- general submission aspect messages -->
+	<message key="xmlui.Submission.general.mydspace_home">DSpace Principal</message>
+	<message key="xmlui.Submission.general.go_mydspace">O meu DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.trail">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.head">Envío de ítems</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Anterior</message>
+	<message key="xmlui.Submission.general.submission.save">Gardar/saír</message>
+	<message key="xmlui.Submission.general.submission.next">Seguinte &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Completar o envío</message>
+	<message key="xmlui.Submission.general.workflow.title">Envío de ítems</message>
+	<message key="xmlui.Submission.general.workflow.trail">Envío de ítems</message>
+	<message key="xmlui.Submission.general.workflow.head">Envío de ítems</message>
+	<message key="xmlui.Submission.general.showfull">Mostrar o rexistro completo do ítem</message>
+	<message key="xmlui.Submission.general.showsimple">Mostrar o rexistro simple do ítem</message>
+	<message key="xmlui.Submission.general.default.title">Envío</message>
+	<message key="xmlui.Submission.general.default.trail">Envío</message>
+
+	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
+	<message key="xmlui.Submission.CollectionViewer.link1">Enviar un ítem a esta colección</message>
+
+	<!-- org.dspace.app.xmlui.submission.Navigation -->
+	<message key="xmlui.Submission.Navigation.submissions">Envíos</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Envíos &amp; fluxos de traballo</message>
+	<message key="xmlui.Submission.Submissions.trail">Envíos</message>
+	<message key="xmlui.Submission.Submissions.head">Envíos &amp; tarefas do fluxo de traballo</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">enderezo electrónico:</message>
+	<!-- Same transformer, workflow section -->
+	<message key="xmlui.Submission.Submissions.workflow_head1">Tarefas do fluxo de traballo</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Estas tarefas son ítems que están á espera de aprobación antes de seren engadidas ao repositorio. Hai dous tipos de elementos en espera, as tarefas aceptadas e as tarefas que aínda non asumiu ninguén.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">As súas tarefas</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Tarefa</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Ítem</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Colección</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Remitente</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Deixar as tarefas seleccionadas de novo en espera</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">Non ten asignada ningunha tarefa</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Tarefas en espera</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Asumir as tarefas seleccionadas</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">Non hai tarefas en espera</message>
+	<!-- Same transformer, submissions section -->
+	<message key="xmlui.Submission.Submissions.submit_head1">Envíos</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Debería </message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">comezar un envío</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">O proceso de envío consiste en cubrir o formulario de metadatos e depositar o(s) ficheiro(s) que compón(compoñen) o ítem dixital. Cada comunidade ou colección pode ter a súa propia política de envíos.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Envíos non rematados</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Estes son os envíos parciais de ítems que non se completaron. Podería</message>
+	<message key="xmlui.Submission.Submissions.submit_info2b">comezar outro envío</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Título</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Colección</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Remitente</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Autoría</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">Non hai envíos incompletos.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Supervisando:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Eliminar os envíos seleccionados</message>
+	<!-- Same transformer, inprogress section -->
+	<message key="xmlui.Submission.Submissions.progress_head1">Envíos en revisión</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Estes son os envíos que se completaron e que están a ser revisados polos responsables da colección.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Título</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Colección</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Estado</message>
+	<!-- Same transformer, workflow status -->
+	<message key="xmlui.Submission.Submissions.status_0">Enviados</message>
+	<message key="xmlui.Submission.Submissions.status_1">Á espera da revisión</message>
+	<message key="xmlui.Submission.Submissions.status_2">En revisión</message>
+	<message key="xmlui.Submission.Submissions.status_3">Á espera da revisión do editor</message>
+	<message key="xmlui.Submission.Submissions.status_4">En edición</message>
+	<message key="xmlui.Submission.Submissions.status_5">Á espera da revisión final do editor</message>
+	<message key="xmlui.Submission.Submissions.status_6">En edición</message>
+	<message key="xmlui.Submission.Submissions.status_7">Arquivados</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Estado descoñecido</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Envíos arquivados</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Estes son os seus envíos aceptados en DSpace</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Data de aceptación</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Título</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Colección</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Só se mostran 50 dos seus envíos arquivados</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Mostrar todos os meus envíos arquivados.</message>
+
+	<!-- submission progress bar messages -->
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Preguntas iniciais</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Describir</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Subir</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Revisar</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">Licenza CC</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Licenza</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Finalizar</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Retomar</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
+	<message key="xmlui.Submission.submit.SelectCollection.head">Seleccione unha colección...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Colección</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Seleccione a colección á que quere enviar un ítem.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Seleccione unha colección...</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Quere gardar ou cancelar o envío?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Quere eliminar o envío ou prefire gardalo para continuar traballando nel máis tarde? Tamén pode retomar o proceso de envío onde o deixou se premeu "Cancelar" por erro.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Continuar co envío</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Gardar para continuar máis tarde</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Eliminar o envío</message>
+
+
+	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Preguntas iniciais</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota importante:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and">e</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Múltiples títulos</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">O ítem ten máis dun título, <i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Se a cela anexa está desmarcada, daquela o título(s) eliminarase do ítem:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicado</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">O ítem publicouse ou distribuíuse publicamente antes</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Se a cela anexa está desmarcada, daquela o elemento eliminarase do ítem:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data de publicación</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cita</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editor</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
+	<message key="xmlui.Submission.submit.DescribeStep.head">Describir o ítem</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Erro: tipo de campo descoñecido</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Este campo é obrigatorio</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Apelido, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nome(s) + "", <i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Ano</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Mes</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Día</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nome da serie</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Informe n.º</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+	<message key="xmlui.Submission.submit.UploadStep.head">Subir ficheiro(s)</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Ficheiro</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Por favor, introduza o camiño completo do ficheiro que corresponda co ítem no seu ordenador. Se preme en "Examinar...", abrirase unha xanela que lle permitirá seleccionar un ficheiro do seu ordenador.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">O ítem debe conter polo menos un ficheiro.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Houbo un problema ao anexar o seu ficheiro. Puido deberse a que o nome do ficheiro era incorrecto, houbo un problema na rede que impediu que o ficheiro nos chegase correctamente ou que anexou un ficheiro cuxo formato só se permite para usos internos do sistema. Por favor, ténteo de novo.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">O ficheiro non se puido cargar, xa que parece conter un virus. Por favor, contacte co administrador.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Houbo un problema técnico mentres se comprobaba a ausencia de virus no ficheiro. Por favor, contacte co administrador.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Descrición do ficheiro</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Subir ficheiro e engadir outro máis</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Ficheiros subidos</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Primario</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Ficheiro</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Tamaño</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Descrición</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">descoñecido</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">formato descoñecido</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Compatible)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Soportado)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Incompatible)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Editar</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Verificación do ficheiro</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Eliminar os ficheiros seleccionados</message>
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
+	<message key="xmlui.Submission.submit.EditFileStep.head">Editar ficheiro</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Ficheiro</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Descrición do ficheiro</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Seleccione na listaxe o formato do arquivo, por exemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato detectado</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Formato escollido</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">O formato non está na listaxe.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Se o formato non está na listaxe, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Outro formato</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">O nome e versión da aplicación que empregou para crear o ficheiro (por exemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">Revisar envío</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Si</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">Non</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Corrixir algún destes</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Engadir ou eliminar un ficheiro</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Preguntas iniciais</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Describir a páxina {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Ficheiros subidos</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Múltiples títulos</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Publicado antes de</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">descoñecido</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">coñecido</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">compatible</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Produciuse un erro... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Licencie o seu traballo</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Opcionalmente pode asignar ao seu ítem unha licenza <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Escolla licenza</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Acceder a Creative Commons para escoller unha licenza</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Tipo de licenza</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Seleccione ou modifique a licenza...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Sen licenza Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Prema Seguinte para gardar os seus cambios.</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
+	<message key="xmlui.Submission.submit.LicenseStep.head">Licenza de distribución</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Conceda a licenza de distribución estándar seleccionando "Conceder licenza" e premendo en "Completar envío".</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Se tiver algunha dúbida sobre a licenza, por favor, contacte co administrador do sistema.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licenza de distribución</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Concedo a licenza</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Debe conceder a licenza para completar o envío. Se neste momento non a pode conceder, deberá gardar o seu traballo e retomalo máis tarde, ou ben eliminar inmediatamente o envío premendo en "Borrar o envío".</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
+	<message key="xmlui.Submission.submit.RemovedStep.head">Envío eliminado</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">O seu envío cancelouse e o ítem incompleto borrouse do sistema.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ir á páxina de envíos</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
+	<message key="xmlui.Submission.submit.CompletedStep.head">Envío completado</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">O seu envío pasará polo fluxo de traballo designado para a colección á que o está a enviar. Recibirá unha notificación vía correo electrónico logo de que o seu envío forme parte da colección, ou, se por algunha razón, houbese algún problema co envío. Tamén pode verificar o estado do seu envío a través da páxina "O meu DSpace".</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ir á páxina de envíos</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Enviar outro ítem</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Accións posibles para esta tarefa:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Asígnese esta tarefa.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Asumir tarefa</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Deixar esta tarefa en espera para que a asuma outra persoa.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Deixar tarefa</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Se revisou o ítem e o considera axeitado para a colección, seleccione "Aprobar".</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprobar</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Unha vez editado o ítem, use esta opción para actualizalo.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Actualizar no arquivo</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se revisou o ítem e comprobou que <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rexeitar ítem</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Escolla esta opción para corrixir ou editar os metadatos do ítem.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editar metadatos</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Use esta opción para volver poñer a tarefa en espera e que outra persoa poida rematar a tarefa de revisión.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Deixar de novo en espera</message>
+
+	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Por favor, indique a razón pola que rexeita o envío. Indique na súa mensaxe o que deberá cambiar o remitente para poder reenvialo.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motivo</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">O campo "Motivo" é obrigatorio</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rexeitar ítem</message>
+
+
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             Administrative Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">A tarefa completouse con éxito.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">A tarefa finalizou ou fallou inesperadamente. Por favor, contacte co administrador ou revise os arquivos de erros</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">A tarefa colocouse correctamente en espera.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Debido a un erro non se puido deixar a tarefa en espera. Para máis información, por favor contacte co administrador ou revise os arquivos de erros.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">O usuario engadiuse correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">O usuario editouse correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Enviouse unha mensaxe ao usuario que contén un testemuño que lle permitirá obter unha nova clave.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">O usuario(s) borrouse correctamente.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Os usuarios da listaxe non se eliminaron porque existen restricións para realizar esta acción. Para máis información, consulte a páxina dos datos do usuario.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">O grupo modificouse correctamente.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Os grupos seleccionados borráronse con éxito.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Novo esquema creado correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">O esquema(s) borrouse con éxito.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Campo de metadato engadido correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Campo de metadato modificado correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">O campo(s) moveuse correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">O campo(s) borrouse correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">O formato gardouse correctamente.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">O formato(s) borrouse correctamente.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Os metadatos do ítem modificáronse correctamente.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Novo metadato engadido.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">O ítem retirouse.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">O ítem reintegrouse.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">O ítem moveuse.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">A colección destino seleccionada non se atopou.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">O novo arquivo cargouse con éxito.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Erro ao cargar o arquivo.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">O arquivo modificouse.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Os arquivos seleccionados borráronse.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Os ítems relacionáronse correctamente.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">A relación entre os ítems eliminouse correctamente.</message>
+
+	<!-- general items for all of the eperson classes -->
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Administrar usuarios</message>
+
+	<!-- org.dspace.app.xmlui.administrative.Navigation -->
+	<!-- contextual menu items -->
+	<message key="xmlui.administrative.Navigation.context_head">Contexto</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Editar este ítem</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Editar colección</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Relacionador de ítems</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Editar comunidade</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Crear colección</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crear subcomunidade</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Crear comunidade</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Exportar ítem</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Exportar colección</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Exportar comunidade</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Exportar metadatos</message>
+
+	<!-- Site administrator options -->
+	<message key="xmlui.administrative.Navigation.administrative_head">Administrativo</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Control de acceso</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Persoas</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Grupos</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Autorizacións</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Rexistros</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadatos</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Formato</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Ítems</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Ítems eliminados</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Panel de control</message>
+    <message key="xmlui.administrative.Navigation.statistics">Estatísticas</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importar metadatos</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Tarefas de curación</message>
+
+    <!-- my account items -->
+	<message key="xmlui.administrative.Navigation.account_export">As miñas exportacións</message>
+
+
+	<!-- export item -->
+	<message key="xmlui.administrative.ItemExport.head">Exportar arquivo </message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">O código do ítem que introduciu non é válido.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">O identificador da colección que introduciu non é válido.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">O código da comunidade que introduciu non é válido.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">Non se atopou o ítem solicitado.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">Non se atopou a colección solicitada.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">Non se atopou a comunidade solicitada.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">O ítem exportouse correctamente. Cando o arquivo estea listo para descargar, recibirá un correo electrónico. Tamén pode usar a ligazón "As miñas exportacións" para ver os arquivos dispoñibles.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">A colección exportouse con éxito. Cando o arquivo estea listo para descargar, recibirá unha mensaxe de correo electrónico. Tamén pode empregar a ligazón "A miñas exportacións" para ver unha listaxe dos arquivos que están ao seu dispor.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">A comunidade exportouse con éxito. Cando o arquivo estea listo para descargar, recibirá unha mensaxe de correo electrónico. Tamén pode empregar a ligazón "A miñas exportacións" para ver unha listaxe dos arquivos que están ao seu dispor.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Arquivos de exportación dispoñibles para descargar:</message>
+
+
+
+    <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Administrar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Xestión de usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Accións</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Crear un novo usuario</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Prema aquí para engadir un novo usuario.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Listar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Prema aquí para listar todos os usuarios.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Buscar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Os usuarios búscanse por coincidencia parcial de correo electrónico ou nome</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">A seguir figura a listaxe de usuarios que coincide co seu padrón de busca. Escolla a que quere borrar e prema o botón "Borrar" para continuar, ou prema sobre o enderezo de correo electrónico ou sobre o nome dun usuario para editalos.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultados da busca</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nome</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Enderezo electrónico</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Borrar usuarios</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">A súa busca non obtivo ningún resultado...</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Engadir usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Engadir usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Crear un novo usuario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Este enderezo de correo electrónico está a ser usado por outra persoa. O enderezo de correo electrónico debe ser único.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Información do novo usuario:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">O enderezo de correo electrónico debe ser único.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Requírese un enderezo de correo electrónico</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">O nome é un dato necesario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">O apelido é un dato necesario</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Precisa certificado</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Pode acceder</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crear usuario</message>
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Editar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Editar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Editar un usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Este enderezo de correo electrónico está a ser usado por outra persoa. O enderezo de correo electrónico debe ser único.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Información de {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">O correo electrónico debe ser único</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Requírese un enderezo de correo electrónico</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">O nome é un dato necesario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">O apelido é un dato necesario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Precisa certificado</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Pode acceder</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Restablecer contrasinal</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Tamén pode borrar permanentemente este usuario do sistema ou restablecer o seu contrasinal. Cando rexenera un contrasinal, o usuario recibe unha mensaxe que contén unha ligazón especial que pode seguir para asignar un novo contrasinal.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Borrar usuario</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Acceder como usuario</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Este usuario non se pode borrar debido ás seguintes restricións:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">e</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">O usuario enviou un ou máis ítems</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">O usuario ten un envío de fluxo de traballo activo</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">O usuario ten unha tarefa de fluxo de traballo por atender</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">O usuario ten unha restrición sen identificar no sistema</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Este usuario pertence aos grupos:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(polo grupo: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">ningún</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Confirme que quere borrar o usuario</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Confirmar o borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Borraranse os seguintes usuarios:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Confirmar o borrado</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nome</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Enderezo electrónico</message>
+
+	<!-- general items for all of the group classes -->
+	<message key="xmlui.administrative.group.general.group_trail">Administrar grupos</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Administrar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Xestión de grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Accións</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Crear un novo grupo</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Prema aquí para engadir un novo grupo.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Listar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Prema aquí para listar todos os grupos.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Buscar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Os grupos búscanse por coincidencia parcial no nome</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultados da busca</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nome</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membros</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Comunidade/colección</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Ver</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Borrar grupos</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">A súa busca non obtivo ningún resultado...</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
+	<message key="xmlui.administrative.group.EditGroupForm.title">Editor de grupos</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Editar grupo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Editor de grupos: {0} (ID: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Editor de grupos: novo grupo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Limpar a busca</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Membro</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Ciclo</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Pendente</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Nota: os cambios pendentes non se gardan ata que preme o botón "Gardar".</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Engadir</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Eliminar </message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Este grupo está asociado coa colección:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Este grupo está asociado coa comunidade: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Cambiar o nome do grupo:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Este grupo está asociado cunha colección específica e non se pode modificar o seu nome.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Buscar membros para engadir:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Usuarios...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupos...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">A súa busca non obtivo ningún resultado...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nome</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Enderezo electrónico</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nome</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Colección</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ver</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nome</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Enderezo electrónico</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupo: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Este grupo non ten ningún membro.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendente]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Eliminar membros</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Eliminar membros</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Confirme que quere borrar o grupo</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Confirmar o borrado</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Borraranse os seguintes grupos:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nome</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Usuarios</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupos</message>
+
+	<!-- general items for all of the registries classes -->
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Rexistro de formatos</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Rexistro de metadatos</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Borrar formatos de arquivo</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Borrar formatos do arquivo</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Está seguro/a de querer borrar este formato? Calquera arquivo existente con este formato asociarase a un formato descoñecido.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nome</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Borrar campos</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Borrar campos</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Está <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">AVISO:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Esta acción producirá un erro se algún ítem contén metadatos nestes campos.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nome</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Nota de alcance</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Esquema borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Esquema borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Está <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">AVISO:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Esta acción producirá un erro se algún ítem contén metadatos en calquera dos campos do esquema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Espazo de nomes</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nome</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Formato do arquivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Formato do arquivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Novo formato de arquivo</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Formato do arquivo: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Proporcione metadatos descritivos sobre o formato do arquivo indicado abaixo. Mentres que os nomes dos formatos deben ser únicos, os MIME-types non teñen por que selo. Debe manter distintas entradas de formato para diferentes versións de Microsoft Word, mesmo aínda que o MIME-type sexa o mesmo para eles.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nome</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Un nome único para este formato (p. ex. Microsoft Word XP ou Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">O nome do campo é necesario.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">O MIME-type asociado a este formato non debe ser único.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Descrición</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Nivel de soporte</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">O nivel de soporte que a súa institución concede a este formato.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Descoñecido</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Coñecido</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Compatible</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Interno</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Os formatos marcados como "internos" están ocultos para os usuarios e úsanse para fins administrativos.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Extensións do ficheiro</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">As extensións son extensións dos arquivos que se empregan automaticamente para identificar os formatos dos arquivos cargados. Pode indicar varias extensións para cada formato.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Esquema de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Esquema de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadatos: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Este é o esquema de {0}. Pode engadir ou modificar campos de metadatos existentes deste esquema. Os campos tamén poden marcarse para borralos ou movelos a outro esquema.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Campos de metadatos do esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Sen campos de metadatos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Borrar campos</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Mover campos a outro esquema</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Engadir un novo campo de metadato</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nome do campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Notas adicionais sobre este campo de metadato.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Engadir un novo campo de metadato</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Modificar campo: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Modificar campo</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Erro</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">O nome do campo xa está en uso. Todos os elementos e cualificadores deben ser únicos.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">O elemento do campo é necesario.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">O elemento do campo contén un carácter estraño. O elemento NON pode conter: puntos, texto subliñado ou espazos.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">O elemento do campo é demasiado longo, debe conter menos de 32 caracteres.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">O cualificador do campo é demasiado longo, debe conter menos de 32 caracteres.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">O cualificador do campo contén un carácter estraño. O cualificador NON pode conter: puntos, texto subliñado ou espazos.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Rexistro de formatos</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Rexistro de formatos de arquivos</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Esta listaxe de arquivos proporciona información sobre formatos de arquivos coñecidos e o seu nivel de soporte. Pode editar ou engadir novos formatos de arquivo con esta ferramenta. Os formatos marcados como "internos" están ocultos para os usuarios e úsanse para fins administrativos.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Engadir un formato de arquivo novo</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nome</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipo MIME</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nivel de soporte</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Descoñecido</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Coñecido</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Soporte</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Borrar formatos</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Rexistro de metadatos</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Rexistro de metadatos</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">O rexistro de metadatos mantén unha listaxe de todos os campos dispoñibles no repositorio. Estes campos poden distribuírse entre múltiples esquemas; porén, DSpace necesita o esquema de clasificación de Dublin Core. Pode estender o esquema Dublin Core con campos adicionais ou engadir novos esquemas ao rexistro.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Espazo de nomes</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nome</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Esquema borrado</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Engadir novo esquema</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Espazo de nomes</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">O "Espazo de nomes" debe establecer un enderezo URI para o novo esquema.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">Este campo é obrigatorio</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nome</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Nome resumido do esquema. Empregarase como prefixo dos nomes de campo (p. ex. dc.element.qualifier). O nome debe conter menos de 32 caracteres e non pode incluír espazos, puntos ou texto subliñado.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">Este campo é obrigatorio e debe conter polo menos 32 caracteres sen espazos, puntos, nin texto subliñado.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Engadir un novo esquema</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Mover campos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Mover campos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Mover campos de metadatos</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Escolla un esquema destino a onde se moverán estes campos. Se o esquema destino contén campos con nomes idénticos, estes campos non se moverán.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nome</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota de alcance</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Mover ao esquema:</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Mover campos</message>
+
+
+
+
+	<!-- general authorization keywords -->
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorización</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Listaxe de privilexios</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administrar privilexios de autorización</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Administrar privilexios de autorización</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autorizacións de ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">O ID que indicou non se pode relacionar con ningún ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Buscar un ítem</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Os ítems búscanse por handle ou por ID interno</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Atopar</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Ferramentas para autorizacións avanzadas</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Prema aquí para acceder á ferramenta de administración de privilexios</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorizacións de comunidades/coleccións</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Prema nunha comunidade ou colección para editar os seus privilexios.</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Editar privilexios</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Listaxe de privilexios</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Privilexios para a colección {0} ({1}, ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Privilexios para a comunidade {0} ({1}, ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Prema aquí para engadir un novo privilexio.</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Engadir</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Acción</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupo</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Borrar a selección</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Editar</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Editar privilexios do ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Listaxe de privilexios</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Privilexios para o ítem {0} (ID={1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Con este editor pode ver e modificar os privilexios dun ítem, ademais de editar os privilexios de cada compoñente individual dun ítem: bloques e arquivos. De xeito breve, un ítem é un contedor de bloques, e os bloques son contedores de arquivos. Habitualmente, os contedores teñen privilexios para ENGADIR/BORRAR/LER/ESCRIBIR, mentres que os arquivos só teñen privilexios para LER/BORRAR.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Nótese que hai un bloque extra para cada ítem, que é o que contén o texto da licenza para o ítem.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Privilexios do ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Privilexios do bloque {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Arquivo {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Engadir un novo privilexio para o ítem</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Engadir un novo privilexio para o bloque</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Engadir un novo privilexio para o arquivo</message>
+
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Non se atoparon privilexios asociados a este obxecto</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Editar privilexio</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Editar privilexio</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Crear novo privilexio para {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editar privilexio {0} para {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Non se seleccionou ningún grupo</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Non se seleccionou ningunha acción</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nome</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Accións para este recurso</message>
+
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Conxunto</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">actual</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Resultados da busca</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Escolla un grupo</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Buscar un grupo</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Buscar</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Escolla a acción</message>
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Xestor avanzado de privilexios</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizacións avanzadas</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Xestor avanzado de privilexios</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Permite engadir e quitar privilexios a tipos de contidos dunha colección. Ollo, é perigoso: borrar o permiso para LER dalgún ítem pode ocultalos!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Para todos os grupos marcados...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">... concede a capacidade de levar a cabo a seguinte acción...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">... para todos os seguintes tipos de obxectos...</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">... en todas as coleccións seguintes.</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupo</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Acción</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Tipo de contido</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Colección</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Engadir privilexios</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Limpiar privilexios</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirme que quere borrar os privilexios</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmar o borrado</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Confirmar o borrado</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Eliminaranse os seguintes privilexios:</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Acción</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupo</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
+	<!-- general edit item messages -->
+	<message key="xmlui.administrative.item.general.item_trail">Ítems</message>
+	<message key="xmlui.administrative.item.general.template_head">Editar modelo de ítem para a colección: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Editar ítem</message>
+	<message key="xmlui.administrative.item.general.option_status">Estado do ítem</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Arquivos do ítem</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Metadatos do ítem</message>
+	<message key="xmlui.administrative.item.general.option_view">Ver ítem</message>
+        <message key="xmlui.administrative.item.general.option_curate">Curar</message>
+        <message key="xmlui.administrative.item.general.option_queue">Deixar á espera</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Subir arquivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Subir arquivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Subir un novo arquivo</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bloque</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Ficheiros de contido (por defecto)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Ficheiros de metadatos</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturas</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licenzas</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licenzas Creative Commons</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Ficheiro</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Por favor, introduza o camiño completo do ficheiro que corresponda co ítem no seu ordenador. Se preme en "Examinar...", abrirase unha xanela que lle permitirá seleccionar un ficheiro do seu ordenador.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descrición</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Subir</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Precisa os privilexios ENGADIR e ESCRIBIR polo menos nun bloque para poder cargar novos arquivos.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Confirmar o borrado</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirmar o borrado</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirmar a acción de borrar</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Está seguro/a de querer borrar estes ficheiros?:</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nome</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descrición</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formato</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Confirmar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Confirmar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modificar o ítem: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Está seguro/a de querer borrar por completo este ítem? Coidado: non quedará ningún rastro del.</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Está seguro/a de querer retirar este ítem do repositorio?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Está seguro/a de querer reintegrar este ítem na base de datos?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Campo</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valor</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Idioma</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Retirar</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Reintegrar</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">Mover</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Mover</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Mover ítem: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Colección</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Seleccione a colección á que quere mover o ítem.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Seleccione unha colección...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Mover</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Herdar privilexios</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Herdar os privilexios por defecto da colección destino</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Editar arquivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Editar arquivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Editar arquivo</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Ficheiro</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Arquivo principal</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Si</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Non</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descrición</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Se quere, pode describir brevemente o contido deste ficheiro, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Seleccione na listaxe o formato do arquivo, por exemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Formato escollido</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">O formato non está na listaxe.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se o formato non está na listaxe, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Outro formato</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">O nome e versión da aplicación que empregou para crear o ficheiro (por exemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nome do ficheiro</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Renomear este ficheiro. Nótese que a URL que se mostra cambiará, pero as ligazóns antigas seguiranse resolvendo mentres non cambie o ID.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Arquivos do ítem</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Arquivos do ítem</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Arquivos</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nome</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descrición</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Ver</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Orde</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">(principal)</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Ver</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Subir un novo arquivo</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Borrar arquivos</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Actualizar a orde dos bitstreams</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Precisa os privilexios ENGADIR e ESCRIBIR sobre o ítem e os bloques para poder cargar novos arquivos.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Só os administradores de DSpace poden borrar ficheiros.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Anterior:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Subir</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Descargar</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadatos do ítem</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadatos do ítem</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Engadir novo metadato</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nome</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Idioma</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Engadir novo metadato</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">AVISO: estes cambios non se validan de ningún modo. É a súa responsabilidade introducir os datos no formato correcto. De non estar seguro, por favor, NON faga cambios.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadatos</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Eliminar </message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nome</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Valor</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Idioma</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Estado do ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Estado do ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Benvido/a á páxina de xestión de ítems. Desde aquí poderá retirar, reintegrar ou borrar o ítem. Tamén poderá modificalo ou engadir novos metadatos/arquivos nos outros separadores.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">ID interno do ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Handle</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Última modificación</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">Nas coleccións</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Páxina do ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Editar autorizacións do ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Retirar o ítem do repositorio</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Reintegrar o ítem no repositorio</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Mover o ítem a outra colección</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Borrar completamente o ítem</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autorizacións...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Retirar...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Reintegrar...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Mover...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Borrar permanentemente</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(só administradores do sistema)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(só administradores de colección)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(non ten permisos para realizar esta acción)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
+	<message key="xmlui.administrative.item.ViewItem.title">Ver ítem</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Ver ítem</message>
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curar o ítem: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curar o ítem</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curador</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Tarefa</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
+	<message key="xmlui.administrative.item.FindItemForm.title">Atopar ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Atopar ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">ID interno do ítem/handle do ítem</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Imposible resolver o identificador.</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Atopar</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Importar metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Importar metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Importar metadatos</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">cambios</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Non se detectaron cambios</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Novo ítem</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">O ficheiro subiuse con éxito</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Erro ao subir o ficheiro</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Esquema de metadatos descoñecido no encabezamento</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Elemento de metadatos descoñecido no encabezamento</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Importación realizada con éxito</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Erro na importación</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Excedeuse o número máximo de cambios permitidos. Limíteos ou cambie o parámetro bulkedit.gui-item-limit en dspace.cfg</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Subir CSV</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Procesado con éxito</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Cambios aplicados ao ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Engadido: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Eliminado: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Engadido á colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Eliminado da colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Relacionado coa colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Desligado da colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Ítem borrado</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Ítem retirado</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Ítem reintegrado</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Engadir: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Eliminar:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Engadir á colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Eliminar da colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Relacionar coa colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Desligar da colección</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Cambios pendentes do ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Aplicar cambios</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Os cambios pendentes móstranse a continuación para seren revisados</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Borrar ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Retirar ítem</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reintegrar ítem</message>
+
+	<!-- general mapper messages -->
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Relacionador de ítems</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
+	<message key="xmlui.administrative.mapper.MapperMain.title">Relacionador de ítems</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Relacionador de ítems (relaciona ítems doutras coleccións)</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Colección: "<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">Esta é a ferramenta de ligazón de ítems que permite aos administradores de colección relacionar ítems doutras colección nesta. Pode buscar ítems doutra colección e relacionalos ou ver a listaxe de ítems relacionados.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estatísticas</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Buscar</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Precisa o privilexio ADD na colección)</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Buscar ítems</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Buscar ítems que coincidan: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Relacionar os ítems marcados</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Colección</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Título</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Listar ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Listaxe de ítems relacionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Desligar os ítems seleccionados</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Colección</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Título</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Precisa o privilexio BORRAR nesta colección para desligar os ítems.</message>
+
+	<!-- General tags for collection management -->
+	<message key="xmlui.administrative.collection.general.collection_trail">Coleccións</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Editar metadatos</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Asignar roles</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Deixar á espera</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Editar roles da colección</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Roles</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Editar colección: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">ningún</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crear...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Restrinxir...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Os administradores da colección deciden quen pode enviar ítems á colección, retiralos, editar os metadatos (despois do envío) e engadir (relacionar) ítems existentes noutras coleccións a esta colección (dependendo da autorización desta colección).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">As persoas responsables deste paso poderán aceptar ou rexeitar envíos pendentes. Porén, non poderán editar os metadatos do envío.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">As persoas responsables deste paso poderán editar os metadatos dos envíos pendentes e aceptar ou rexeitar os envíos.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">As persoas responsables deste paso poderán editar os metadatos dos envíos pendentes, pero non poderán rexeitar os envíos.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">Usuarios e grupos que teñen permiso para enviar novos ítems a esta colección.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">Usuarios e grupos que poden ler os novos ítems enviados a esta colección. Os cambios neste rol son retroactivos e os antigos ítems permanecerán visibles para aqueles que tiveran acceso no momento da súa incorporación.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Esta colección usa unha configuración de acceso personalizada.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">O permiso por defecto de lectura dos ítems e dos arquivos está actualmente asignado a Anónimo.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Editar directamente os privilexios de autorización.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Grupo asociado</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons"/>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administradores</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Pasos de fluxo de traballo</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Etapa aceptar/rexeitar</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Etapa aceptar/rexeitar/editar metadatos</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa editar metadatos</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Publicadores</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Acceso por defecto de lectura</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curar a colección: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curar a colección</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curador</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Tarefa</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Confirmar o borrado</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Confirme que quere borrar a colección {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Está seguro/a de querer borrar a colección {0}? Isto borrará:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Ítems e envíos pendentes desta colección que non estean contidos noutras coleccións</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">O contido destes ítems</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Todos os privilexios asociados</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Confirme que quere borrar o rol</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Confirme que quere borrar o rol {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Está seguro/a de querer borrar este rol? Ao borrar este grupo, dará permiso para LER a todos os ítems enviados a esta colección de agora en diante. Por favor, teña en conta que este cambio non é retroactivo, polo que os ítems enviados con anteriores privilexios restrinxiranse aos membros definidos no grupo que vai borrar.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Está seguro/a de querer borrar este rol? Perderanse todos os cambios e personalizacións realizados no grupo {0} e terá que crealos de novo.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Editar metadatos da colección</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadatos</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Editar colección: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nome</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Descrición breve:</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Texto introdutorio (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Novidades (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licenza</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Orixe</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Subir novo logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Modelo de ítem</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crear...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Editar...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Eliminar logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Borrar colección</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Gardar cambios</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crear colección</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crear colección</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Introduza metadatos para unha nova colección de {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crear</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Parámetros de recolección de colección</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Recollendo</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Orixe do contido</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Orixe do contido</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Esta é unha colección DSpace estándar</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Esta colección recolle os seus contidos dunha fonte externa</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Gardar</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Localización da colección recollida</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opcións de recolección</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Provedor OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set ID</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">A URL do provedor do servizo OAI do repositorio obxecto</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Debe fornecer un set ID da colección obxecto.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">O identificador persistente empregado polo provedor OAI para designar a colección obxecto</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Debe fornecer o set ID da colección obxecto.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">O contido está a ser recollido</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Recoller só metadatos.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Recoller metadatos e referencias aos ficheiros (require soporte ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Recoller metadatos e ficheiros (require soporte ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Probar parámetros</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Localización da colección recollida</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Provedor OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set ID</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Formato de metadatos</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">O contido está a ser recollido</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Último resultado da recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Esta colección aínda non se recolleu.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Estado actual da recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Colección lista para recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Colección en proceso de recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Colección en espera de recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Produciuse un erro OAI na última recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Produciuse un erro na última recolección</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Recoller só metadatos.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Recoller metadatos e referencias aos ficheiros.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Recoller metadatos e ficheiros (replicación completa).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Cambiar parámetros</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importar agora</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Restaurar e reimportar a colección</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Recollendo</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Controis do planificador da Recolección</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Estado</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Accións</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Arrancar Recolección</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Restaurar estado do recolector</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Retomar</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Deter</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Deter</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Coleccións listas para recoller</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Recoleccións activas</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Recoleccións en espera</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Erros OAI</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Erros internos</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Parámetros do xerador</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Orixe ORE</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Parámetros do recolector</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Comunidades</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Editar metadatos</message>
+	<message key="xmlui.administrative.community.general.options_roles">Asignar roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.community.general.options_queue">Deixar á espera</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Editar roles da comunidade</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Editar comunidade: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">ningún</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Crear...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Os administradores de comunidade poden crear subcomunidades ou coleccións, así como xestionar ou conceder permisos a esas comunidades ou coleccións. Ademais, deciden quen pode enviar ítems ás coleccións, editar metadatos e engadir (mapear) ítems existentes noutras coleccións (suxeitos a autorización).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Esta comunidade usa unha configuración de acceso personalizada. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">O permiso por defecto de lectura dos ítems e dos arquivos está actualmente asignado a Anónimo.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Editar directamente os privilexios de autorización.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Rol</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Grupo asociado</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons"> </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administradores</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curar a comunidade: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curar a comunidade</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curador</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Tarefa</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Confirmar o borrado</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Confirme que quere borrar a comunidade {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Está seguro/a de querer borrar a comunidade {0}? Isto borrará:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Coleccións da comunidade non contidas noutras comunidades.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Ítems e envíos pendentes desta comunidade que non estean contidos noutras comunidades</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">O contido destes ítems</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Todos os privilexios asociados</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirme que quere borrar o rol</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirmar</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirme que quere borrar o rol {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Está seguro/a de querer borrar este rol? Perderanse todos os cambios e personalizacións realizados no grupo {0} e podería ter que recrealo.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Editar metadatos da comunidade</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadatos</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Editar metadatos da comunidade {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Editar privilexios</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nome</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Descrición breve</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Texto introdutorio (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Texto de copyright (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Novidades (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Subir novo logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo actual</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Eliminar logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Borrar comunidade</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Crear comunidade</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crear comunidade</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Introducir metadatos para unha nova subcomunidade de {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Editar metadatos dunha nova comunidade de primeiro nivel</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crear</message>
+
+
+	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
+	<message key="xmlui.administrative.ControlPanel.title">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.head">Panel de control</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Información Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Configuración de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alertas do sistema</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} min</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java e sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Versión de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Provedor de Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nome do sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Arquitectura do sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Versión do sistema operativo</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Estatísticas de execución</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Procesadores dispoñibles</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Memoria máxima</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Memoria asignada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Memoria empregada</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Memoria libre</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Información de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Versión de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Directorio caché de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Directorio de traballo de Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Tamaño da caché principal ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Borrar inmediatamente a caché)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Tamaño da caché de persistencia ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Tamaño da caché transitoria ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Parámetros de DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Versión de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Directorio de instalación de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">URL base de DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nome do host DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Nome do sitio</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nome da base de datos</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL da base de datos</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Controlador JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Número máximo de conexións á base de datos no Pool</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Tempo máximo de espera DB</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Número máximo de conexións sen usar</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Servidor SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Correo remitente</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Destinatario de suxestións</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Correo do administrador principal</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alertas do sistema</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensaxe de alerta</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">O sistema apagarase debido a tarefas habituais de mantemento. Por favor, garde o seu traballo e desconéctese.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Conta atrás</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Sen conta atrás</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minutos</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 hora</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Manter a conta atrás actual</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Xestionar sesión</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuar a permitir sesións autenticadas</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Deter a autenticación pero sen que afecte ás sesións actuais</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Deter a autenticación e rematar as sesións actuais</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Activar</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desactivar</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Actividade actual (máximo {0} páxinas)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">PARAR a gravación da actividade anónima.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">COMEZAR a gravación da actividade anónima.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">PARAR a gravación automática da actividade.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">COMEZAR a gravación automática da actividade.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Marca horaria</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Usuario</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Enderezo IP</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">Páxina URL</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Navegador</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anónimo {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Sen rexistrar visualizacións de páxinas</message>
+
+	<message key="xmlui.administrative.ControlPanel.select_panel">Empregue os separadores de arriba para seleccionar a información que se vai mostrar</message>
+
+	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
+	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
+	<message key="xmlui.administrative.NotAuthorized.title">Non autorizado</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">Non autorizado</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Privilexios insuficientes</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">A súa conta non ten os privilexios suficientes para realizar a acción solicitada. Se cre que se pode tratar dun erro ou se precisa realizar a acción, por favor contacte cos</message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">Administradores de sistema</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Acceder como outro usuario</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">Tarefas de curación do sistema</message>
+        <message key="xmlui.administrative.CurateForm.trail">Tarefas de curación</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle do obxecto DSpace</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Truco: introduza [prefixo-handle]/0 para executar unha tarefa en toda a súa instalación (non todas as tarefas permiten esta opción)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Tarefa</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Escoller de entre os seguintes grupos</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Estatísticas</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">Número total de visitas</message>
+    <message key="xmlui.statistics.visits.month">Visitas ao mes</message>
+    <message key="xmlui.statistics.visits.views">Visualizacións</message>
+    <message key="xmlui.statistics.visits.countries">Países con máis visualizacións</message>
+    <message key="xmlui.statistics.visits.cities">Cidades con máis visualizacións</message>
+    <message key="xmlui.statistics.visits.bitstreams">Visitas ao ficheiro</message>
+    <message key="xmlui.statistics.Navigation.title">Estatísticas</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">Estatísticas</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
+
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                  dri2xhtml
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
+
+
+
+	<!-- structural.xsl -->
+	<message key="xmlui.dri2xhtml.structural.footer-promotional"> 
 <a href="http://di.tamu.edu" id="ds-logo-link">
-<span id="ds-footer-logo"> </span>
-</a>
-<p>
-XMLUI, unha interface para DSpace creada por Texas A&amp; M University Libraries. 
-Para máis información, visite 
-<a href="http://di.tamu.edu">http://di.tamu.edu</a> e
-<a href="http://dspace.org">http://dspace.org</a>
-</p>
-</message>
-<message key="xmlui.dri2xhtml.structural.contact-link">Contacto</message>
-<message key="xmlui.dri2xhtml.structural.feedback-link">Suxestións</message>
+			<span id="ds-footer-logo"> </span>
+		</a>
+		<p>
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
+		</p>
+	</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Contacto</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Suxestións</message>
 
-<message key="xmlui.dri2xhtml.structural.head-subtitle">Repositorio DSpace/Manakin</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Repositorio DSpace/Manakin</message>
 
-<message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
-<message key="xmlui.dri2xhtml.structural.logout">Saír</message>
-<message key="xmlui.dri2xhtml.structural.login">O meu DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.profile">Perfil:</message>
+	<message key="xmlui.dri2xhtml.structural.logout">Saír</message>
+	<message key="xmlui.dri2xhtml.structural.login">O meu DSpace</message>
 
-<message key="xmlui.dri2xhtml.structural.search">Buscar en DSpace</message>
-<message key="xmlui.dri2xhtml.structural.search-advanced">Busca avanzada</message>
-<message key="xmlui.dri2xhtml.structural.search-in-community">Esta comunidade</message>
-<message key="xmlui.dri2xhtml.structural.search-in-collection">Esta colección</message>
+	<message key="xmlui.dri2xhtml.structural.search">Buscar en DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Busca avanzada</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Esta comunidade</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">Esta colección</message>
 
-<message key="xmlui.dri2xhtml.structural.pagination-previous">Páxina anterior</message>
-<message key="xmlui.dri2xhtml.structural.pagination-info">Mostrando ítems {0}-{1} de {2}</message>
-<message key="xmlui.dri2xhtml.structural.pagination-next">Páxina seguinte</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Páxina anterior</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Mostrando ítems {0}-{1} de {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Páxina seguinte</message>
 
-<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-<message key="xmlui.dri2xhtml.structural.link_original_license">Licenza orixinal</message>
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Licenza orixinal</message>
 
-<!-- DS-METS-1.0-MODS.xsl -->
-<!-- DS-METS-1.0-DIM.xsl -->
-<!-- DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Vista previa non dispoñible</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sen título</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor descoñecido</message>
-<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Este non é un obxecto DSpace conforme co perfil METS1.0, polo que non pode ser interpretado correctamente. Pode substituír o modelo que xestiona o caso xeral dri2xhtml para mellorar a función necesaria ou ben crear un modelo que se axuste ao perfil que está a usar.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Vista previa</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-title">Título</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resumo</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descrición</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
+	<!-- DS-METS-1.0-MODS.xsl -->
+	<!-- DS-METS-1.0-DIM.xsl -->
+	<!-- DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Vista previa non dispoñible</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Sen título</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Autor descoñecido</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">Este non é un obxecto DSpace conforme co perfil METS1.0, polo que non pode ser interpretado correctamente. Pode substituír o modelo que xestiona o caso xeral dri2xhtml para mellorar a función necesaria ou ben crear un modelo que se axuste ao perfil que está a usar.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Ficheiros no ítem</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Ficheiros</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nome</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaño</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ver</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Descrición</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ver/<wbr></wbr>abrir</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Non hai ficheiros asociados a este ítem.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Vista previa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Título</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Resumo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Descrición</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Materia</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Ficheiros no ítem</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Ficheiros</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nome</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Tamaño</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Ver</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Descrición</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Ver/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Non hai ficheiros asociados a este ítem.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.license-text">O ítem ten asociados os seguintes ficheiros de licenza:</message>
-<message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">A non ser que se indique outra cousa, a licenza do ítem descríbese como</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">O ítem ten asociados os seguintes ficheiros de licenza:</message>
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">A non ser que se indique outra cousa, a licenza do ítem descríbese como</message>
+
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 A vista resumo da colección non está en uso ou implementada actualmente. 
 Isto pode solucionarse sobrescribindo o modelo dri2xhtml denominado collectionSummaryView.
 </message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
 A vista resumo da comunidade non está en uso ou implementada actualmente. 
 Isto pode solucionarse sobrescribindo o modelo dri2xhtml denominado communitySummaryView.
 </message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo da colección</message>
-<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo da comunidade</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Sen logo</message>
-<message key="xmlui.dri2xhtml.METS-1.0.news">Novidades</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo da colección</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo da comunidade</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Sen logo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Novidades</message>
 
-<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
-DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
+	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
+		DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
 Qualified Dublin Core (QDC) non se pode aplicar ás comunidades e coleccións de DSpace neste momento.
 Ao usar QDC para os elementos de DSpace, recoméndase o uso de crosswalks QDC
 ou ben DIM ou MODS para o procesamento das comunidades e coleccións. 
 </message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementos Dublin Core</message>
-<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termos Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementos Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termos Dublin Core</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
 
 
-<!-- Special pioneer model related text, wherever it might end up -->
-<message key="xmlui.dri2xhtml.pioneer.preview">Vista previa</message>
-<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
-<message key="xmlui.dri2xhtml.pioneer.title">Título</message>
-<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
+	<!-- Special pioneer model related text, wherever it might end up -->
+	<message key="xmlui.dri2xhtml.pioneer.preview">Vista previa</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Título</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
 
-<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
-<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
-<!--###### File Format MIME Type Mappings ######-->
+  <!--###### File Format MIME Type Mappings ######-->
 
-<!-- Application-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.application/marc">rexistro MARC</message>
-<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-<message key="xmlui.dri2xhtml.mimetype.application/octet-stream">descoñecido</message>
-<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java Applet</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">rexistro MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">descoñecido</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java Applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
-<!-- Audio-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
 
-<!-- Image-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.image/gif">imaxe GIF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jp2">imaxe JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jpeg">imaxe JPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/png">imaxe PNG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/tiff">imaxe TIFF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">imaxe BMP </message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">imaxe GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">imaxe JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">imaxe JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">imaxe PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">imaxe TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">imaxe BMP </message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
 
-<!-- Text-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.text/css">Ficheiro CSS</message>
-<message key="xmlui.dri2xhtml.mimetype.text/csv">Ficheiro CSV</message>
-<message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-<message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-<message key="xmlui.dri2xhtml.mimetype.text/plain">Ficheiro de texto</message>
-<message key="xmlui.dri2xhtml.mimetype.text/richtext">Ficheiro RTF</message>
-<message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">Ficheiro CSS</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">Ficheiro CSV</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Ficheiro de texto</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">Ficheiro RTF</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
-<!-- Video-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.video/avi">vídeo AVI</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg">vídeo MPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 vídeo</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mp4">vídeo MPEG-4</message>
-<message key="xmlui.dri2xhtml.mimetype.video/quicktime">Vídeo QuickTime</message>
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">vídeo AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">vídeo MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 vídeo</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">vídeo MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Vídeo QuickTime</message>
 
-<!-- explanatory messages for choice authority confidence values -->
-<message key="xmlui.authority.confidence.description.cf_unset">Confianza non establecida para este valor</message>
-<message key="xmlui.authority.confidence.description.cf_novalue">A autoridade non devolveu un valor de confianza razoable</message>
-<message key="xmlui.authority.confidence.description.cf_rejected">A autoridade recomenda que este envío se rexeite</message>
-<message key="xmlui.authority.confidence.description.cf_failed">A autoridade atopou un erro interno</message>
-<message key="xmlui.authority.confidence.description.cf_notfound">Non hai respostas que coincidan na autoridade</message>
-<message key="xmlui.authority.confidence.description.cf_ambiguous">Hai múltiples valores de autoridade conformes coa mesma validez</message>
-<message key="xmlui.authority.confidence.description.cf_uncertain">O valor é único e válido, pero non foi aceptado por ningún usuario, polo que aínda non é certo</message>
-<message key="xmlui.authority.confidence.description.cf_accepted">Un usuario confirmou a validez deste valor de autoridade</message>
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Confianza non establecida para este valor</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">A autoridade non devolveu un valor de confianza razoable</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">A autoridade recomenda que este envío se rexeite</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">A autoridade atopou un erro interno</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">Non hai respostas que coincidan na autoridade</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">Hai múltiples valores de autoridade conformes coa mesma validez</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">O valor é único e válido, pero non foi aceptado por ningún usuario, polo que aínda non é certo</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">Un usuario confirmou a validez deste valor de autoridade</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Desbloquear o valor da clave de autoridade para a edición manual ou cambialo para bloquealo de novo</message>
 
-<!-- help message on "unlock" button in EditItemMetadata display -->
-<message key="xmlui.authority.confidence.unlock.help">Desbloquear o valor da clave de autoridade para a edición manual ou cambialo para bloquealo de novo</message>
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">Valor da busca DSpace</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Aceptar</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Engadir</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancelar</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">Ver máis resultados</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Resultados @1@ a @2@ de @3@ para @4@</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Os datos escollidos non se puideron cargar: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
-<!-- Choice Lookup popup window -->
-<!-- NOTE: These messages necessarily use a *different* format for
-- parameters, unfortunately, since substitution happens in the
-- JavaScript (AJAX) that completes the lookup popup window.
-- So, positional parameters are @1@, @2@, etc.
--->
-<message key="xmlui.ChoiceLookupTransformer.title">Valor da busca DSpace</message>
-<message key="xmlui.ChoiceLookupTransformer.accept">Aceptar</message>
-<message key="xmlui.ChoiceLookupTransformer.add">Engadir</message>
-<message key="xmlui.ChoiceLookupTransformer.cancel">Cancelar</message>
-<message key="xmlui.ChoiceLookupTransformer.more">Ver máis resultados</message>
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nome do editor</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Buscar Editor</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non é valor de autoridade: @1@</message>
 
-<!-- params are: start, end, total-count, search-value -->
-<message key="xmlui.ChoiceLookupTransformer.results">Resultados @1@ a @2@ de @3@ para @4@</message>
-<message key="xmlui.ChoiceLookupTransformer.fail">Os datos escollidos non se puideron cargar: </message>
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nome en formato "Apelido, Nome"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Apelido, p. ex. "López"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Nome(s), p. ex. "Alfredo"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Busca de autores na LC Name Authorithy</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local @1@ (non se atopa na Autoridade)</message>
 
-<!-- Choice Lookup - sample config for dc.publisher field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nome do editor</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Buscar Editor</message>
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
 
-<!-- Params are: search-value -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non é valor de autoridade: @1@</message>
 
-<!-- Choice Lookup - sample config for dc.contributor.author field -->
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Nome en formato "Apelido, Nome"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Apelido, p. ex. "López"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Nome(s), p. ex. "Alfredo"</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Busca de autores na LC Name Authorithy</message>
-<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Valor local @1@ (non se atopa na Autoridade)</message>
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
 
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_id.xml
+++ b/src/main/webapp/i18n/messages_id.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="id">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_id.xml
+++ b/src/main/webapp/i18n/messages_id.xml
@@ -1,14 +1,4 @@
-<?xml version="1.0"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="id" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -374,7 +364,7 @@
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Permintaan Menyalin Dokumen</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Permintaan Menyalin Dokumen</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">>Permintaan Menyalin Dokumen</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">&gt;Permintaan Menyalin Dokumen</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">Ini teks yang dikirim ke pemohon.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Pesan</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subjek</message>
@@ -458,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Pendaftaran tidak tersedia</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Pendaftaran tidak tersedia</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Konfigurasi di repositori ini tidak mengijinkan untuk mendaftar di konteks ini. Tolong hubungi <a href="../contact">administrator situs</a> dengan pertanyaan atau komentar.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Konfigurasi di repositori ini tidak mengijinkan untuk mendaftar di konteks ini. Tolong hubungi <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Perbaharui Profil</message>
@@ -656,13 +646,13 @@
 	<message key="xmlui.Submission.Submissions.title">Pengunggahan &amp; Alurkerja</message>
 	<message key="xmlui.Submission.Submissions.trail">Alurkerja</message>
 	<message key="xmlui.Submission.Submissions.head">Tugas Pengunggahan &amp; Alurkerja</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Tidak Berjudul</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">surel: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Tugas Alurkerja</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Tugas ini adalah publikasi yang menunggu persetujuan sebelum ditambahkan ke repositori. Terdapat dua antrian tugas, satu tugas untuk yang kamu terima dan lainnya tugas untuk yang belum diterima oleh lainya.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Tugas yang anda miliki</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Tugas</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Publikasi</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Koleksi</message>
@@ -681,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Berikut adalah pengunggahan yang belum selesai. Anda juga boleh </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">memulai pengunggahan lain</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Judul</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Koleksi</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Pengunggah</message>
@@ -750,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Judul Banyak</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Judul lebih dari satu, <i>cnth. judul terjemahan</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Judul lebih dari satu, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Jika kotak pilihan diatas tidak terpilih maka judul berikut akan dihapus dari publikasi ini: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Dipublikasikan</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Publikasi harus sudah dipublikasikan atau didistribusikan secara publik sebelumnya</message>
@@ -763,8 +753,8 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Deskripsikan Item</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Galat: Tipe kolom tidak diketahui</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Kolom ini wajib di isi</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nama belakang, <i>cnth. Ariyanto</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nama Depan + "Jr", <i>cnth. Gunawan Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nama belakang, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nama Depan + "Jr", <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Tahun</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Bulan</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Hari</message>
@@ -827,7 +817,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Berkas belum jadi diunggah karena nampaknya terdapat virus. Silahkan hubungi administrator.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Terdapat masalah teknis ketika memindai berkas dari virus. Silahkan hubungi administrator anda.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Deskripsi Berkas</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Sebagai tambahan, sediakan deskripsi singkat untuk berkasnya, contoh "<i>Artikel Utama</i>", atau "<i>Bacaan data eksperimen</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Sebagai tambahan, sediakan deskripsi singkat untuk berkasnya, contoh "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Unggah berkas &amp; tambahkan lainnya</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Berkas Diunggah</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Primer</message>
@@ -836,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Ukuran</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Deskripsi</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Tidak Diketahui</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">Format tidak diketahui</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Didukung)</message>
@@ -856,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Berkas belum jadi diunggah karena nampaknya terdapat virus. Silahkan hubungi administrator.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Terdapat masalah teknis ketika memindai berkas dari virus. Silahkan hubungi administrator anda.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Deskripsi Berkas</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Sebagai Tambahan, sediakan deskripsi singkat dari berkas, sebagai contoh "<i>Artikel Utama</i>", atau "<i>Bacaan data eksperimen</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Sebagai Tambahan, sediakan deskripsi singkat dari berkas, sebagai contoh "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Unggah berkas &amp; tambah lainnya</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Berkas terunggah</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primer</message>
@@ -865,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Ukuran</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Deskripsi</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Tidak Diketahui</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">format tidak diketahui</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Didukung)</message>
@@ -1075,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-Pengguna dicari berdasar kecocokan parsial surel atau nama</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Dibawah ini daftar E-Pengguna yang cocok. Pilih E-Pengguna yang ingin anda hapus dan klik tombol hapus untuk melanjutkan atau klik nama atau surel E-Pengguna untuk merubahnya.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Hasil Pencarian</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nama</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Surel</message>
@@ -1150,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Mencari grup</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Grup dicari berdasar kecocokan parsial namanya</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Hasil Pencarian</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nama</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Anggota</message>
@@ -1182,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nama</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Surel</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nama</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Anggota</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Koleksi</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">lihat</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Anggota</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nama</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Surel</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grup: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Grup ini tidak beranggota.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[tertunda]</message>
@@ -1273,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadata Schema: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">This is the metadata schema for "{0}". You may add new or update existing metadata fields to this schema. Fields may also be selected for deletion or be moved to another schema. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Schema metadata fields</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Field</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Scope Note</message>
@@ -1300,7 +1290,7 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Bitstream format registry</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">This list of bitstream formats provides information about known formats and their support level. You can edit or add new bitstream formats with this tool. Formats marked as 'internal' are hidden from the user, and are used for administrative purposes.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Add a new bitstream format</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Name</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Type</message>
@@ -1315,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadata Registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadata registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas.  However, DSpace requires the qualified Dublin Core schema. You may extend the Dublin Core schema with additional fields or add new schemas to the registry.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namespace</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Name</message>
@@ -1403,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edit policy {0} for {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No group selected</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No action selected</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Name</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Actions for this resource</message>
@@ -1581,7 +1571,7 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Name</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Description</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
@@ -1726,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Search items</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Search items matching: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Map selected items</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Author</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Title</message>
@@ -1736,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Browse mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Browsing mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Unmap selected items</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Author</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Title</message>
@@ -2162,7 +2152,7 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
 			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
@@ -2225,7 +2215,6 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">View</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">View/<wbr/>Open</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Read access available for</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">There are no files associated with this item.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
@@ -2472,6 +2461,7 @@
     <message key="xmlui.aspect.sherpa.submission.blue">biru</message>
     <message key="xmlui.aspect.sherpa.submission.white">putih</message>
     <message key="xmlui.aspect.sherpa.submission.yellow">kuning</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
 

--- a/src/main/webapp/i18n/messages_it.xml
+++ b/src/main/webapp/i18n/messages_it.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="it">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_it.xml
+++ b/src/main/webapp/i18n/messages_it.xml
@@ -1,28 +1,18 @@
-<?xml version="1.0"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="it" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">DSpace Home</message>
 	<message key="xmlui.general.search">Ricerca</message>
@@ -35,44 +25,60 @@
 	<message key="xmlui.general.delete">Cancella</message>
 	<message key="xmlui.general.next">Prossimo</message>
 	<message key="xmlui.general.untitled">Senza Titolo</message>
-	
-	<!-- 
-		Page not found keys 
-		
+        <message key="xmlui.general.perform">Perform</message>
+        <message key="xmlui.general.queue">Queue</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">Pagina non trovata</message>
 	<message key="xmlui.PageNotFound.head">Pagina non trovata</message>
 	<message key="xmlui.PageNotFound.para1">Impossibile trovare la pagina richiesta.</message>
-	
-	
+
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Only site administrators may assume login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description"> DSpace digital repository cattura, immagazzina, indicizza, preserva, e distribuisce i materiali di ricerca digitali.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">The Channel Image</message>
 	<message key="xmlui.feed.untitled">Senza titolo</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">Notifica</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Risultati della ricerca nella comunità: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Risultati della ricerca nella Collezione: {0}</message>
@@ -83,9 +89,9 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">La ricerca non ha prodotto risultati.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tutto DSpace</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Titolo</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">Data di pubblicazione</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Data di inserimento</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Titolo</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">Data di pubblicazione</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">Data di inserimento</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">Rilevanza</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordina per </message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">in ordine </message>
@@ -93,7 +99,7 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">discendente</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Risultati/pagina </message>
 
- 	<!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
+    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Ricerca Avanzata</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Ricerca Avanzata</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Ricerca Avanzata</message>
@@ -112,31 +118,31 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Linguaggio (ISO)</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Parole chiave</message>
 
-    <!--  some common other possibilities for Advanced Search Fields -->
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Autore</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Ideatore</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descrizione</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Correlato</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Mime-Type</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">altro autore</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Relatore</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Dipartimento</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Full Text</message>
-	
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
-	<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
+   <!--  some common other possibilities for Advanced Search Fields -->
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Autore</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Ideatore</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Descrizione</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Correlato</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Mime-Type</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">altro autore</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Relatore</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Dipartimento</message>
 
-	
-	
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Full Text</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Oppure inserite le prime lettere del nome:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Cerca tra gli item che iniziano con queste lettere</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Vai ad una sezione nell'indice:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Scegli mese)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Scegli anno)</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Vai ad una sezione nell'indice:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Scegli mese)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Scegli anno)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Oppure inserici un anno: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Sfoglia gli item dell'anno specificato.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Sorry, there are no results for this browse.</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Ordina per: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordine: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Risultati: </message><!-- /Page -->
@@ -159,17 +165,37 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Sfoglia {0} per Soggetto {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Sfoglia {0} per Soggetto</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Sfoglia {0} per Titolo {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Sfoglia {0} per Titolo</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Sfoglia {0} per Data di Pubblicazione {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Sfoglia {0} per Data di Pubblicazione</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Sfoglia {0} per Data di Immissione {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Sfoglia {0} per Data di Immissione</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Ambito della Ricerca</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Tutto DSpace</message>
@@ -180,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Date</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Ricerca avanzata</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Immissioni Recenti</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Lista degli Archivi</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Lista degli Archivi</message>
@@ -199,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">sotto-comunità all'interno di questa comunità</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Collezioni in questa sotto-comunità</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Immissioni Recenti</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Contattaci</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Contattaci</message>
@@ -209,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Modulo On-line</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Feedback</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Esprimi la tua opinione</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Esprimi la tua opinione</message>
@@ -219,23 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Questo indirizzo sara' utilizzato per inoltrare la tua opinione.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Commenti</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Invia la tua opinione</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Esprimi la tua opinione</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Esprimi la tua opinione</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">La tua opinione e' stata inviata</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">I tuoi suggerimenti sono stati ricevuti.</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Ricerca in DSpace</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Inserisci un testo nel box sottostante per effettuare ricerche in DSpace.</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Mostra Item</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Questo item appare nelle seguenti collezioni</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostra i principali dati dell'item</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostra tutti i dati dell'item</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Ricerca</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Tutto DSpace</message>
@@ -247,74 +271,185 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Data di immissione</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Questa Collezione</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Questa comunità</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Cerca</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Cerca</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Cerca</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Ambito della ricerca</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Cerca l'intero testo</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Questa risorsa e' riservata</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Riservata</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Questa risorsa e' riservata</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Questa comunita' e' riservata</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Questa collezione e' riservata</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Questo item e' riservato</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Questo bitstream e' riservato</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Questa comunita' e' riservata</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Questa collezione e' riservata</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Questo item e' riservato</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Questo bitstream e' riservato</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Spiacenti ma non possedete i permessi necessari per accedere a questa risorsa riservata.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Spiacenti ma non possedete i permessi necessari per accedere alla community <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Spiacenti ma non possedete i permessi necessari per accedere alla collezione <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Spiacenti ma non possedete i permessi necessari per accedere all' item <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Spiacenti ma non possedete i permessi necessari per accedere al bitstream <b>{0}</b>.</message>
-  <message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">Collezione</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">Collezione</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">comunità</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">bitstream</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">item</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">risorsa</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">sconosciuto</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'accesso al file e' riservato</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">L'accesso al file e' riservato</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Il file per cui hai richiesto l'accesso necessita dei permessi per essere visualizzato. Si richiede il login per accedere al file.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Reports mensili</message>
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Statistiche complessive</message>
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Nessun report disponibile</message>
-	<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Nessun report è al momento disponibile per questo servizio. Effettua una nuova verifica tra qualche tempo.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Statistiche complessive</message>
 
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Nessun report disponibile</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Nessun report è al momento disponibile per questo servizio. Effettua una nuova verifica tra qualche tempo.</message>
 
-	<!-- Authentication messages used for bitstream authentication -->	
-	<message key="xmlui.BitstreamReader.auth_header">L'accesso al file e' riservato</message>	
+    <!-- Authentication messages used for bitstream authentication -->
+	<message key="xmlui.BitstreamReader.auth_header">L'accesso al file e' riservato</message>
 	<message key="xmlui.BitstreamReader.auth_message">Il file per cui hai richiesto l'accesso richiede dei permessi per essere visualizzato. Si richiede il login per accedere al file.</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Questo file di export è riservato.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Il file di export a cui vuoi accedere è riservato e richiede l'autenticazione. Effettua il login per accedervi.</message>
-	
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Nuova registrazione</message>
 	<message key="xmlui.EPerson.trail_forgot_password">Password dimenticata</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Registrazione non valida</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Registrazione non valida</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">La configurazione di questa comunità digitale non permette la registrazione in questo contesto. Contattare<a href="../contact">l'amministratore</a> per domande o commenti.</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">La configurazione di questa comunità digitale non permette la registrazione in questo contesto. Contattare<a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Aggiorna Profilo</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">Crea Profilo</message>
@@ -325,6 +460,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">Nome</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">Cognome</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">Telefono</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Language</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">Iscrizione</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">E' possibile iscriversi ad una collezione per ricevere email aggiornate sui nuovi items immessi. E' possibile iscriversi a tutte le collezioni. Un'altra alternativa per ricevere eventuali aggiornamenti e' utilizzare l'RSS disponibile per ogni collezione.</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Iscrizione Email</message>
@@ -341,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">Gruppi di appartenenza autorizzati</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Identify</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">Security</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Verifica Email</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Crea Profilo</message>
@@ -354,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Password cancellata</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Password cancellata</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">La password e'stata cancellata.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Inserimento non valido</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Inserimento non valido</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Inserimento non valido</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">L'URL inserita non e' valida. L'indirizzo potrebbe essere stato diviso su piu' righe dal vostro client di posta, in questo modo:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">Se cosi' fosse, copiate ed incollate l'intera URL nella barra degli indirizzi del vostro browser, invece che semplicemente cliccare sul collegamento. La barra degli indirizzi dovrebbe dunque contenere qualcosa come:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">My Account</message>
 	<message key="xmlui.EPerson.Navigation.profile">Profilo</message>
@@ -381,7 +517,7 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">Registra nuovo utente</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">Registra un account per sottoscriverti ad una collezione, ricevere email sugli aggiornamenti, ed inserire nuovi elementi in DSpace.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Clicca qui per registrarti.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Registrati</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Registrati</message>
@@ -390,7 +526,7 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Il nome utente e/o la password non sono validi.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Password</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Registrati</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Scegli la modalita' di registrazione</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">Scegli il login</message>
@@ -408,24 +544,24 @@
 	<message key="xmlui.EPerson.FailedAuthentication.title">Autenticazione fallita</message>
     <message key="xmlui.EPerson.FailedAuthentication.trail">Autenticazione fallita</message>
     <message key="xmlui.EPerson.FailedAuthentication.h1">Autenticazione fallita</message>
-	
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">Modalita' di autenticazione non trovata</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">Modalita' di autenticazione non trovata.Contattare l'amministratore.</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">Fallito Login Shibboleth </message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">Autenticazione Shibboleth  non disponibile al momento. Contattare l'amministratore di sistema.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">Profilo aggiornato</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">Profilo aggiornato</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">Profilo aggiornato</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">Le informazioni del tuo profilo sono state aggiornate.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">Registrazione terminata</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">Registrazione terminata</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">Sei abilitato ad utilizzare DSpace. E' possibile iscriversi alle collezioni per ricevere via email gli aggiornamenti sulle nuove immissioni.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">Password cancellata</message>
 	<message key="xmlui.EPerson.ResetPassword.head">Password cancellata</message>
@@ -436,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">Password cancellata</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Scegliere una password di almeno sei caratteri</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Inserire nuovamente la password per confermare</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">Password dimenticata</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">Password dimenticata</message>
@@ -445,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Inserisci l'indirizzo di posta elettronica utilizzato per la registrazione.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Indirizzo email non trovato.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Invia informazioni</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Nuova registrazione</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">Email gia' utilizzata</message>
@@ -458,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">Questo indirizzo email verra' verificato e potra'essere utilizzato nella fase di login.</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Impossile mandare una email a questo indirizzo di posta elettronica.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">Registra</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">Verifica invio email</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">Verifica invio email</message>
@@ -470,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -486,7 +622,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">Vai a MyDSpace Home</message>
 	<message key="xmlui.Submission.general.submission.title">Immissione Item</message>
 	<message key="xmlui.Submission.general.submission.trail">Immissione Item</message>
-	<message key="xmlui.Submission.general.submission.head">Immissione Item</message>	
+	<message key="xmlui.Submission.general.submission.head">Immissione Item</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Precedente</message>
 	<message key="xmlui.Submission.general.submission.save">Salva / Annulla</message>
 	<message key="xmlui.Submission.general.submission.next">Prossimo &gt;</message>
@@ -498,25 +634,25 @@
 	<message key="xmlui.Submission.general.showsimple">Mostra il record semplice dell'item </message>
 	<message key="xmlui.Submission.general.default.title">Immissione</message>
 	<message key="xmlui.Submission.general.default.trail">Immissione</message>
-  
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Immetti un nuovo item nella Collezione</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Immissioni</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Immissioni &amp; Workflow</message>
 	<message key="xmlui.Submission.Submissions.trail">Immissioni</message>
 	<message key="xmlui.Submission.Submissions.head">Immissioni &amp; Workflow</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Senza titolo</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">email: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Workflow</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Di seguito gli items in attesa di approvazione . Vi sono due tipologie di incarichi, una per quelli che hai accettato e un'altra per quelli ancora non assegnati.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Tuoi incarichi</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Incarichi</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Item</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Collezioni</message>
@@ -535,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Queste sono le immissioni incomplete. Potete anche </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">iniziare una nuova immissione</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Titolo</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Collezione</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Utente</message>
@@ -559,26 +695,34 @@
 	<message key="xmlui.Submission.Submissions.status_6">Immissione in attesa di modifica</message>
 	<message key="xmlui.Submission.Submissions.status_7">Immissione archiviata</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Stato sconosciuto</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Domande Iniziali</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Descrivi</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Carica</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Carica</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Verifica</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-	<message key="xmlui.Submission.submit.progressbar.license">Licenza</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Licenza</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Fine</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Riprendi</message>
-	<message key="xmlui.Submission.submit.ResumeStep.submit_cancel">Annulla</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
 	<message key="xmlui.Submission.submit.SelectCollection.head">Scegli una collezione</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection">Collezione</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Scegli la collezione nella quale vuoi inserire l'item.</message>
 	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Scegli una collezione...</message>
-	<message key="xmlui.Submission.submit.SelectCollection.submit">Prossimo</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Salva o annulla la tua immissione?</message>
@@ -587,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Salva, continuero' il lavoro piu' tardi</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Rimuovi l'immissione</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Domande Iniziali</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Nota Importante: </message>
@@ -596,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Titolo aggiuntivi</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'item ha piu' di un titolo, <i>es. un titolo tradotto</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">L'item ha piu' di un titolo, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Se la casella soprastante e' deselezionata i metadati di riferimento verranno rimossi dall'item: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Pubblicazione</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">L'item e' stato pubblicato o distribuito pubblicamente prima d'ora</message>
@@ -604,36 +748,85 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data di pubblicazione</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Citazione</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Editore</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">Descrizione Item</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Errore: Campo sconosciuto</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Questo campo e' obbligatorio</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognome, <i>e.s. Rossi</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nome, <i>e.s. Mario</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Cognome, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Nome, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Anno</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Mese</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Giorno</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nome Serie</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Numero del report o paper.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Carica File</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">File</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Inserire l'intero percorso del file dal tuo computer corrispondente all'item. Cliccando "Sfoglia...", una nuova finestra ti permettera' di selezionare il file dal tuo computer.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">L'item puo' contenere piu' di un file.</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">Si e' verificato un problema durante il trasferimento (upload) del file: nome del file non e' corretto, si e' verificato un problema di rete che ha impedito il corretto trasferimento del file o hai selezionato un file il cui formato e' stato dichiarato interno dagli amministratori. Riprova.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Descrizione</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Articolo principale</i>", or "<i>Report istituzionale</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Descrizione</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Carica file &amp; aggiungi</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">File Caricato</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Principale</message>
-	<message key="xmlui.Submission.submit.UploadStep.column1"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
 	<message key="xmlui.Submission.submit.UploadStep.column2">File</message>
 	<message key="xmlui.Submission.submit.UploadStep.column3">Dimensione</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Descrizione</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Sconosciuto</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">formato sconosciuto</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Supportato)</message>
@@ -642,21 +835,54 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">modifica</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">Revisione File:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Rimuovi i files selezionati</message>
-	
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Modifica File</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">File</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Descrizione File</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">E' possibile fornire una breve descrizione del contenuto, per esempio "<i>Articolo principale</i>", or "<i>Report istituzionale</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Scegliere il formato del file dalla lista sottostante, per esempio "<i>Adobe PDF</i>" o "<i>Microsoft Word</i>." <strong>Se il formato non e' presente nella lista</strong>, descriverlo nel box sottostante .</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">E' possibile fornire una breve descrizione del contenuto, per esempio "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Scegliere il formato del file dalla lista sottostante, per esempio "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato individuato</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Formato Selezionato</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formato non in lista</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Se il formato non appare nella lista sottostante, <strong>selezionare "formato non in lista"</strong> e descrivere il formato del file nel box sottostante.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Se il formato non appare nella lista sottostante, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Altro formato</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Il nome dell'applicazione utilizzato per creare il file, e il numero della versione (fper esempio, "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	<message key="xmlui.Submission.submit.EditFileStep.submit_save">Salva</message>
-	<message key="xmlui.Submission.submit.EditFileStep.submit_cancel">Cancella</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Revisione Immissione</message>
@@ -673,18 +899,21 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">sconosciuto</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">conosciuto</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">supportato</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Licenza Creative Commons</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">E' possibile aggiungere  una <a href="http://creativecommons.org/">Creative Commons</a> Licenza all'item. <strong>Le licenza Creative Commons definiscono i diritti di accesso degli utenti sull'item pubblicato.</strong> Se si vuole selezionare una licenza Creative Commons cliccare il tasto sottostante. E' possibile accedere al sito web Creative Common, in cui sono presenti diverse tipologie di licenze. Dopo aver selezionato una licenza, e' possibile tornare a questa pagina.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Accedere al sito web Creative Commons per selezionare una licenza</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Licenza</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">Rimuovere questa licenza Creative Commons </message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Nessuna licenza Creative Commons selezionata</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Licenza Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">E' possibile aggiungere  una <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Accedere al sito web Creative Commons per selezionare una licenza</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Licenza</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Nessuna licenza Creative Commons selezionata</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Licenza di distribuzione</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Un ultimo passaggio:</strong> Per garantire la riproduzione, traduzione e distribuzione del materiale immesso, si devono accettare i seguenti termini.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Accetta la licenza di  distribuzione standard selezionando 'Accetta la licenza'; e poi clicca su  'Completa Immissione'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Per domande relative a queste licenze contattare l'amministratore di sistema.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licenza di distribuzione</message>
@@ -694,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">Immissione rimossa</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">L' immissione e' stata cancellata, e gli item incompleti rimossi dal sistema.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ritornare alla pagina di immissione</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Ritornare alla pagina di immissione</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Immissione completa</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">L'immissione e' stata inserita nel processo di revisione di questa collezione. Riceverai una email di notifica non appena la tua immissione verra' inserita nella collezione, o se si verificheranno problemi. E' possibile verificare lo stato di revisione dell'item accedendo alla pagina delle immissioni.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ritornare alla pagina di immissione</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Immetti un nuovo item</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Immissione completa</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">L'immissione e' stata inserita nel processo di revisione di questa collezione. Riceverai una email di notifica non appena la tua immissione verra' inserita nella collezione, o se si verificheranno problemi. E' possibile verificare lo stato di revisione dell'item accedendo alla pagina delle immissioni.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Ritornare alla pagina di immissione</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Immetti un nuovo item</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Azioni che puoi portare a termine:</message>
@@ -712,38 +941,40 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Approva item</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Una volta che l'item e' stato modificato, utilizzare questa opzione per inserire l'item nella comunità.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Inserisci nella comunità</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se l'item e' stato revisionato e <strong>non</strong> e' conforme per essere incluso nella collezione, selezionare "Rifiuta".  E' possibile inserire un messaggio per spiegare le motivazioni della non conformita' dell'item, e in che misura l'utente potra' apportare modifiche e ricaricare il file.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se l'item e' stato revisionato e <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rifiuta item</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Selezione questa voce per modificare i metadati.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">modifica metadato</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Riporta l'incarico nel gruppo delle revisioni per affidarlo ad un altro revisore.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Riporta l'incarico nel gruppo delle revisioni</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.cancel_submit">Cancella</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
 	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Inserire le motivazioni che hanno portato al rifiuto dell'item nel box sottostante, indicando in che misura l'utente potra' apportare modifiche e ricaricare il file  .</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Motivazione</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Il campo Motivazione e' obbligatorio</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Rifiuta Item</message>
-	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_cancel">Cancella</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L'utente e' stato aggiunto con successo.</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">L'utente e' stato aggiunto con successo.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">L'utente e' stato modificato con successo.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">una comunicazione email verra' inviata all'utente contenente un applicativo da utilizzare per scegliere una nuova password.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">L'utente e' stato cancellato con successo.</message>
-  <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">L'utente(i) indicati non sono stati cancellati a causa di vincoli che ne impediscono la rimozione, consultate la pagine dei dettagli dell'eperson per ulteriori informazioni.</message>
-  <message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Il gruppo e' stato modificato con successo.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">L'utente(i) indicati non sono stati cancellati a causa di vincoli che ne impediscono la rimozione, consultate la pagine dei dettagli dell'eperson per ulteriori informazioni.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Il gruppo e' stato modificato con successo.</message>
 	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Il gruppo selezionato e' stato eliminato con successo.</message>
 	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Il nuovo schema e' stato creato con successo.</message>
 	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Lo schema e' stato cancellato con successo.</message>
@@ -757,16 +988,18 @@
 	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Nuovi metadati sono stati aggiunti.</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">L'item e' stato nascosto.</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">L'item e' stato ripristinato .</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">The item has been moved.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">The selected destination collection could not be found.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Un nuovo bitstream e' stato aggiornato con successo.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Errore nel caricamento del file.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Il bitstream e' stato modificato.</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">I bitstreams selezionati sono stati cancellati.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">Gli items sono stati mappati con successo.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">La mappatura dell'item e' stata eliminata..</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Gestione E-people</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Amministrazione</message>
@@ -778,9 +1011,10 @@
 	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Crea sotto-comunità</message>
 	<message key="xmlui.administrative.Navigation.context_create_community">Crea comunità</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">Esporta l'item</message>
-	<message key="xmlui.administrative.Navigation.context_export_collection">Esporta la collezione</message>
-	<message key="xmlui.administrative.Navigation.context_export_community">Esporta la comunità</message>
-	
+        <message key="xmlui.administrative.Navigation.context_export_collection">Esporta la collezione</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Esporta la comunità</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Export Metadata</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Pannello di controllo</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">Controllo accesso</message>
@@ -790,15 +1024,20 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Registri</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadati</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Formati</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Items</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Nascondi item</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Pannello di controllo</message>
-	<message key="xmlui.administrative.Navigation.statistics">Statistiche</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Pannello di controllo</message>
+    <message key="xmlui.administrative.Navigation.statistics">Statistiche</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Import Metadata</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Le mie esportazioni</message>
-	
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Archivio delle esportazioni</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">L'item id fornito non è valido.</message>
@@ -811,9 +1050,10 @@
 	<message key="xmlui.administrative.ItemExport.collection.success">La collezione è stata esportata con successo. Riceverai una e-mail quando il file di esportazione sarà pronto per il download.  Puoi utilizzare anche il link 'Le mie esportazioni' per consultare la lista dei files di esportazioni già disponibili.</message>
 	<message key="xmlui.administrative.ItemExport.community.success">La comunità è stata esportata con successo. Riceverai una e-mail quando il file di esportazione sarà pronto per il download.  Puoi utilizzare anche il link 'Le mie esportazioni' per consultare la lista dei files di esportazioni già disponibili.</message>
 	<message key="xmlui.administrative.ItemExport.available.head">Files di esportazione disponibili per il download:</message>
-		
-		
-	<!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
+
+
+
+    <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Amministra E-person</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Amministrazione E-person</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Azioni</message>
@@ -825,15 +1065,14 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-People possono essere cercate inserendo parte della email o del nome </message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Sotto la lista di E-Person che rispondono alla tua ricerca. Seleziona l' E-Person che vuoi cancellare e clicca il bottone cancella o clicca la email dell'E-Person'per modificarla.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Cerca risultati</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nome</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Cancella E-Person</message>
-	 <message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Impersona l'E-Person</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">La tua ricerca non ha prodotto risultati...</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Aggiungi E-Person</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Aggiungi E-Person</message>
@@ -847,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Richiedi Certificato</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">E' possibile effettuare il Log In</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Crea E-Person</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Modifica E-Person</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Modifica E-Person</message>
@@ -863,19 +1102,20 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Cancella Password</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">You may also permanently remove this E-Person from the system or reset his/her password. When resetting a password the user will be sent an email containing a special link they can follow to choose a new password.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Cancella questa E-Person</message>
-	
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Impersona l'E-Person</message>
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Questa e-person non puo' essere cancellata a causa dei seguenti vincoli:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">e</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">eperson ha immesso uno o piu' item</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">eperson ha un workflow di immissione attivo</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">eperson ha un workflow task in attesa della loro attenzione</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">eperson ha un vincolo non identificato col sistema</message>
-  
-  <message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Gruppi di cui questa E-Person fa parte:</message>
+
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Gruppi di cui questa E-Person fa parte:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(via group: {0})</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">nessuno</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Conferma cancellazione E-Person</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Conferma cancellazione</message>
@@ -900,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Cerca i gruppi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Cercare i gruppi inserendo una parte del nome.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Cerca risultati.</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nome</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membri</message>
@@ -922,6 +1162,7 @@
 	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Aggiungi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Rimuovi</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Questo gruppo e' associato con la collezione: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">This group is associated with community: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_name">Cambia il nome del gruppo: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Questo gruppo e' associato ad una collezione specifica e il nome non puo' essere modificato.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_search">Cerca i membri da aggiungere: </message>
@@ -931,24 +1172,24 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Email</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membri</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Collezione</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">Mostra</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membri</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">gruppo: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">gruppo: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Questo gruppo non ha membri.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[in sospeso]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Rimuovi membri</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Rimuovi membri</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Conferma cancellazione gruppo</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Conferma cancellazione</message>
@@ -958,11 +1199,11 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nome</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">E-People</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Gruppi</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Formato registro</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registro Metadati</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Registro Metadati</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Cancella formati dei Bitstream</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Cancella formati dei Bitstream</message>
@@ -976,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Cancella Campi</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Cancella Campi</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Conferma cancellazione</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Sei <b>assolutamente</b> sicuro di voler cancellare questi campi? Se un item contiene metadati corrispondenti a questi campi, il campo/i campi non possono essere cancellati. Devi essere sicuro che in nessun item sono in uso questi campi.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Sei <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ATTENZIONE: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Questo potrebbe causare un errore se i campi sono contenuti in un item.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -987,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Cancella Schema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Cancella schema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Conferma cancellazione</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Sei <b>assolutamente</b> sicuro di voler cancellare questi schemi? Se un item contiene metadati corrispondenti a questi schemi, gli schemi  non possono essere cancellati. Devi essere sicuro che in nessun item sono in uso questi schemi.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Sei <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ATTENZIONE: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Questo potrebbe causare un errore se gli schemi sono contenuti in un item.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1022,12 +1263,11 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Schema metadata: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Questo e' lo schema metadata per "{0}". E' possibile aggiungere o midificare i campi dei metadati di questo schema. I campi possono anche essere selezionati per la cancellazione o lo spostamento in un altro schema. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Campi Schema metadata</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota di notifica</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Nessun campo metadato</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_return">Indietro</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Cancella campi</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Muovi i campi in un altro schema</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Aggiungi nuovi campi metadati</message>
@@ -1037,7 +1277,6 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Aggiungi un nuovo campo di metadati</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aggiorna: {0}</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aggiorna campo</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_cancel">Cancella</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Errore</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Il nome campo e' gia' in uso, tutti gli elementi e i qualificatori devono essere unici.</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">L'elemento campo e' obbligatorio.</message>
@@ -1051,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registro formato Bitstreams</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Questa lista di formati bitstreams contiene informazioni relative ai formati conosciuti e ai loro livelli di supporto. e' possibile mmodificare o aggiungere nuovi formati bitstreams con questo strumento. I formati indicati come "interni" sono nascosti agli utenti, e usati per scopi amministrativi.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Aggiungi un nuovo formato bitstream.</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nome</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Type</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Livello di supporto</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>interno</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Sconosciuto</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conosciuto</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Supportato</message>
@@ -1066,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registro Metadati</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registro Metadati</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Il registro metadati mantiene una lista di tutti i campi metadati disponibili nella comunità. Questi campi devono essere divisi fra molti schemi.  Tuttavia, DSpace richiede lo schema qualificato Dublin Core. E' possibile estendere lo schema Dublin Core scon campi addizionali o aggiungere nuovi schemi al registro.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Nome Schema</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nome</message>
@@ -1090,15 +1329,14 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Nota di notifica</message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Sposta lo schema: </message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Sposta campi</message>
-	<message key="xmlui.administrative.registries.MoveMetadataField.submit_cancel">Cancella</message>
 
-	
-	
-	
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">Autorizzazione</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Lista politiche</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Politiche di autorizzazione dell'ammistratore</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Politiche di autorizzazione dell'ammistratore</message>
@@ -1111,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Clicca qui per amministrare le politiche di autorizzazione dell'item.</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autorizzazioni comunità/Collezioni</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Clicca su una comunità o Collezione per modificare le sue politiche.</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Modifica Politiche</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Lista Politiche</message>
@@ -1122,13 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Clicca qui per aggiungere una nuova politica. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Aggiungi</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Azione</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Gruppo</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Cancella Selezione</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Modifica</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Modifica politiche dell'Item</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Lista Politiche</message>
@@ -1141,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Aggiungi una nuova politica dell'Item</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Aggiungi una nuova politica dell'Item</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Aggiungi una nuova politica del Bitstream</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Nessuna politica trovata per questo oggetto.</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Modifica Politica</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Modifica Politica</message>
@@ -1152,11 +1393,11 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Modifica politica {0} per {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Nessun gruppo selezionato</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Nessuna azione selezionata</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nome</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Azioni per questa risorsa</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Set</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">corrente</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Cerca risultati</message>
@@ -1164,9 +1405,17 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Cerca un gruppo</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Cerca</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Seleziona l'azione</message>
-    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Amministratore autorizzazioni avanzate</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizzazioni avanzate</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Amministratore politiche avanzate</message>
@@ -1181,7 +1430,17 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Collezione</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Aggiungi politiche</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Cancella politiche</message>
-	
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Conferma cancellazione politica</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Conferma cancellazione</message>
@@ -1190,32 +1449,70 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Azione</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Gruppo</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Item</message>
+	<message key="xmlui.administrative.item.general.template_head">Edit Template Item for Collection: {0}</message>
 	<message key="xmlui.administrative.item.general.option_head">Modifica Item</message>
 	<message key="xmlui.administrative.item.general.option_status">Stato Item</message>
 	<message key="xmlui.administrative.item.general.option_bitstreams">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.general.option_metadata">Item Metadati</message>
 	<message key="xmlui.administrative.item.general.option_view">Mostra Item</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">Curate</message>
+        <message key="xmlui.administrative.item.general.option_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">Carica Bitstream</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Carica bitstream</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Carica un nuovo bitstream</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bundle</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_original">Contenuto del file (predefinito)</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_metadata">Metadata File</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_thumbnail">Thumbnails</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_license">Licenze</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_cc_license"> Licenze Creative Commons</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Content Files (default)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadata Files</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Thumbnails</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licenses</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">File</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">inserire il nome del file sul tuo computer corrispondente all'item. Se digiti "Sfoglia...", una nuova finestra apparira' nella quale potrai selezionare il file dal tuo computer.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descrizione</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Articolo principale</i>", o "<i>Paper</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Carica</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Sono necessari i privilegi AGGIUNGI &amp; SCRIVI per caricare un nuovo bitstreams.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Conferma cancellazione</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Conferma cancellazione</message>
@@ -1224,7 +1521,7 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nome</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Descrizione</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Formato</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Conferma</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Conferma</message>
@@ -1235,9 +1532,21 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Campo</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Valore</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Linguaggio</message>
-	<message key="xmlui.administrative.item.ConfirmItemForm.submit_delete">Cancella</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Nascondi</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Ripristina</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Move</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Move item: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Collection</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Select the collection you wish to move this item to.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Select a collection...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Move</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Inherit policies</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Inherit the default policies of the destination collection</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">Modifica Bitstream</message>
@@ -1248,31 +1557,39 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">si'</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">no</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descrizione</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Articolo principale</i>", o "<i>Paper</i>"."</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Selezionare il formato del file dalla lista sottostante, per esempio "<i>Adobe PDF</i>" o "<i>Microsoft Word</i>", <b>O</b> se il formato non e' presente nella lista, descriverlo nel box sottostante.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">E' possibile fornire una breve descrizione del file, per esempio "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Selezionare il formato del file dalla lista sottostante, per esempio "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Seleziona formato</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formato non in lista</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se il formato non e' presente nella lista sottostantet, <strong>seleziona "formato non in lista" sotto</strong> e descrivilo nel campo sottostante.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se il formato non e' presente nella lista sottostantet, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Altro formato</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">L'applicazione utilizzata per usare il file, e il numero di versione (per esempio, "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nome</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descrizione</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Mostra</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (primario) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Mostra</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Carica un nuovo bitstream</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Cancella bitstreams</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Sono necessari i privilegi AGGIUNGI &amp; SCRIVI per caricare un nuovo bitstreams.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">E' necessario il privilegio  RIMUOVI  per canellare il bitstreams dall'item.</message>
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadati Item</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadati Item</message>
@@ -1300,75 +1617,134 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth"> Autorizzazioni Item</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Nascondi item</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Ripristina Item</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Move item to another collection</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Cancella completamente item</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Modifica Autorizzazioni</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Nascondi...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Ripristina...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Move...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Cancella in maniera permanente</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_return">Ritorna all'item</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(solo amministratore di sistema)</message>
-	
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(collection administrators only)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(you are not allowed to perform this action)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Mostra Item</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Mostra Item</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Task</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Trova Item</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Trova Item</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_label"> ID/Item Handle interno</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Impossibile giungere ad un identificatore.</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">Trova</message>
-	
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Import Metadata</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">changes</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">No changes were detected</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">New item</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Upload successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Upload failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unknown metadata element in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import successful</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import failed</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Number of changes exceeds maximum allowed. Limit changes or alter bulkedit.gui-item-limit in dspace.cfg</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Upload CSV</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Successfully processed</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Changes applied to item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Added: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Removed: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Added to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Removed from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Mapped to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Unmapped from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Add: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Remove: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Add to owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Remove from owning collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Map to collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Un-map from collection</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Changes pending for item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Apply changes</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Pending changes are listed below for review</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Mappatura Item</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Mappatura item</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Mappatura item - Mappa Item da un'altra Collezione</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Collezione: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Questo strumento di mappatura permette all'amministratore di collezione di mappare gli items da altre collezioni a questa collezione. E'' possibile cercare l'item nell'altra collezione e mapparlo, o sfogliare la lista degli items attualmente mappati.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statistiche</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} di {1}</strong> items in questa collezione sono mappati da altre collezioni</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Cerca</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Cerca Item</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Sfoglia gli items mappati</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Richiede il privilegio AGGIUNGERE)</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Cerca Item</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Cerca item</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Cerca items inserendo l'autore: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Item mappati selezionati</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Collezione</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autore</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Titolo</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Sfoglia Item mappati</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Sfoglia Item mappati</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Sfoglia Item mappati</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Item selezionati non mappati</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Collezione</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autore</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Titolo</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">E' necessario RIMUOVERE  i privilegi su questa collezione per eliminare la mappatura agli items di questa collezione.</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">Collezioni</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Modifica Metadati</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Assegna ruoli</message>	
-	
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">Collezioni</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Modifica Metadati</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Assegna ruoli</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Modifica i ruoli della collezione</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Ruoli</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Modifica Collezione: {0}</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">nessuno</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Crea...</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.delete">Cancella</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Limita...</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Gli amministratori della collezione decidono chi deve immettere items nella collezione, nascondere gli items, modificare i metadati (dopo l'immissione), e aggiungere (mappare) items esistenti da altre collezioni a questa collezione (previa autorizzazione).</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">I responsabili di questa fase possono accettare o rifiutare le immissioni. Tuttavia non possono modificare i metadati.</message>
@@ -1383,12 +1759,21 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Gruppo associato</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Amministratori</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Workflow steps</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Fase Accetto/Rifiuto</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Fase Accetto/Rifiuto/Modifica Metadati</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Fase modifica Metadati</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Utenti</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Accesso di default di SOLA LETTURA</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(solo amministratore di sistema)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curate Collection: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curate Collection</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Conferma cancellazione</message>
@@ -1398,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Tutti gli items e le immissioni incomplete in questa collezione non presenti in altre collezioni.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">I contenuti di tutti gli item.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Tutte le politiche di accesso associate.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Conferma cancellazione del ruolo</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Conferma</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Conferma cancellazione del ruolo di {0}</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Si e' sicuri di voler cancellare questo ruolo? Cancellando questo gruppo si abilitano tutti gli utilizzatori alla funzione SOLA LETTURA di tutti gli items immessi d'ora in avanti nella collezione. Questa modifica non e' retroattiva. Gli items presenti nel sistema saranno ancora ristretti ai membri definiti dal ruole in via di cancellazione.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Si e' sicuri di voler cancellare questo ruolo? Tutti i cambiamenti e  le personalizzazioni apportati al gruppo {0} verranno perse e dovranno essere assegnate nuovamente.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Modifica i metadati della collezione</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadati</message>
@@ -1422,18 +1807,110 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Template dell'item</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Crea...</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Modifica...</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_template">Cancella</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Rimuovi logo</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Cancella collezione</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Salva aggiornamenti</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(solo amministratore di sistema)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Crea Collezione</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Crea Collezione</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Inserisci i metadati per la nuova collezione di {0}</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Crea</message>
-	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_cancel">Crea</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Collection Harvesting Settings</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Content Source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Content source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">This is a standard DSpace collection</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">This collection harvests its content from an external source</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Save</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Harvesting Options</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Metadata Format</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">The url of the target repository's OAI provider service</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">The persistent identifier used by the OAI provider to designate the target collection</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">You must provide a set id of the target collection.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Test Settings</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Harvested Collection Location</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Metadata format</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Last Harvest Result</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">This collection has not yet been harvested.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Current harvest status</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Collection ready for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Collection is currently being harvested</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Collection is in queue for harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">OAI error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Unexpected error occurred during last harvest</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (full replication).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Change Settings</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Import Now</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Reset and Reimport Collection</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Harvest Scheduler Controls</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Actions</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Start Harvester</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Reset Harvest Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Resume</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pause</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Collections set up for harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Active harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Queued harvests</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAI errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Internal errors</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Generator Settings</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE source</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Harvester Settings</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Communities</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Edit Metadata</message>
+	<message key="xmlui.administrative.community.general.options_roles">Assign Roles</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.community.general.options_queue">Queue</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Edit Community Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Roles</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edit Community: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">none</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Create...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Community administrators can create sub-communities or collections, and manage or assign management for those sub-communities or collections.  In addition, they decide who can submit items to any sub-collections, edit item metadata (after submission), and add (map) existing items from other collections (subject to authorization).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">This community uses custom default access settings. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Default read for incoming items and bitstreams is currently set to Anonymous.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Edit authorization policies directly.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Associated group</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administrators</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curate Community: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curate Community</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Conferma cancellazione</message>
@@ -1444,7 +1921,13 @@
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">tutti gli item e le immissioni incomplete in questa comunità che non siano contenute in altre Comunità</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">I contenuti degli items</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Tutte le politiche di accesso associate</message>
-	
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Confirm role deletion</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Confirm</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Confirm deletion for role {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Are you sure you want to delete this role? All changes and customizations made to the {0} group will be lost and would have to be created anew.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Modifica i metadati della comunità</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadati</message>
@@ -1459,15 +1942,13 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Logo in uso</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Rimuovi logo</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Cancella comunità</message>
-	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_save">Aggiorna</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Crea comunità</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Crea comunità</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Inserisci i metadati per una nuova sotto-comunità{0}</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Inserisci i metadati per una nuova comunità</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Crea</message>
-	<message key="xmlui.administrative.community.CreateCommunityForm.submit_cancel">Cancella</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
@@ -1492,7 +1973,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Allocated memory</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Memoria Utilizzata</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Memoria Libera</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">Impostazioni DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">DSpace Installation Directory</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">DSpace Base URL</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">DSpace Host Name</message>
@@ -1508,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Feedback Riceventi</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">General Site Administration E-mail</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">System-wide Alerts</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts sara' effettivo solo per il nodo per cui e' stato creato. E' necessario asicurarsi che ogni nodo riceve il comando di alert attivata.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Alert message</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Il sistema non sara' in funzione per regolare manutenzione.Salvare il proprio lavoro e uscire.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Conto alla rovescia</message>
@@ -1522,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Consenti la prosecuzione delle sessioni autenticate</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Impedisci l'autenticazione ma consenti la prosecuzione delle sessioni già attive</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Impedisci l'autenticazione e termina le sessioni attive</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Attenzione:</strong>Le opzioni di gestione delle sessioni non si applicano agli amministratori di sistema</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Attivato</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Disattivato</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Attività corrente (massimo {0} pagine)</message>
@@ -1535,14 +2025,14 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP Address</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL Page</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-Agent</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymous {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymous {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Non sono state registrate visite.</message>
-	
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">Utilizza le seguenti tabelle per selezionare le informazioni da mostrare</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minuti</strong>: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Non autorizzato</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">Non autorizzato</message>
@@ -1551,17 +2041,108 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">l'amministratore di sistema</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Accedere con un altro utente</message>
-	
-	
-	
-	
-	
-	
-	
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">Statistics</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">Total Visits</message>
+    <message key="xmlui.statistics.visits.month">Total Visits Per Month</message>
+    <message key="xmlui.statistics.visits.views">Views</message>
+    <message key="xmlui.statistics.visits.countries">Top country views</message>
+    <message key="xmlui.statistics.visits.cities">Top cities views</message>
+    <message key="xmlui.statistics.visits.bitstreams">File Visits</message>
+    <message key="xmlui.statistics.Navigation.title">Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">Statistics</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
+
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -1570,20 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University 
-			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes. 
-			For more information visit 
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
 			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
-			<a href="http://dspace.org">http://dspace.org</a>                            
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Contattaci</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Manda Feedback</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace -  Digital Repository Unimib</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Profilo: </message>
@@ -1592,15 +2173,17 @@
 
 	<message key="xmlui.dri2xhtml.structural.search">Cerca in DSpace</message>
 	<message key="xmlui.dri2xhtml.structural.search-advanced">Ricerca Avanzata</message>
-  <message key="xmlui.dri2xhtml.structural.search-in-community">Questa comunità</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">Questa comunità</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">Questa Collezione</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">Pagina Precedente</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">Items {0}-{1} di {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">Prossima Pagina</message>
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Licenza originale</message>
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -1613,7 +2196,7 @@
         case in dri2xhtml to perform the needed function, or create your template to match 
         whatever profile you use.
     </message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Anteprima</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Titolo</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autore</message>
@@ -1623,22 +2206,25 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Editore</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Soggetto</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Files in questo item</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Files</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Dimensione</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Mostra</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Mostra/<wbr/>Apri</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Description</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Mostra/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Nessun files in questo item.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">I seguenti file di Licenza sono associati a questo Item:</message>
-		
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		The summaryView of a collection is not currently used or implemented. This can be fixed 
 		by overriding the dri2xhtml's template named collectionSummaryView.
@@ -1647,33 +2233,34 @@
 		The summaryView of a community is not currently used or implemented. This can be fixed 
 		by overriding the dri2xhtml's template named communitySummaryView.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo della Collezione</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo della comunità</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Nessun logo</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.news">News</message>	
-	<message key="xmlui.dri2xhtml.METS-1.0.copyright">Copyright e Licenza</message>		
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.news">News</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
 		Qualified Dublin Core (QDC) non e' applicabile alle comunità e alle collezioni in questo momento. Usando QDC, e' possibile usare QDC per gli items in DSpacee gli altri 
 		DIM o MODS per processare comunità e collezioni.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementi Dublin Core</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termini Dublin Core</message>
-	
-	
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Anteprima</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Titolo</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Autore</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
-	
+
   <!--###### File Format MIME Type Mappings ######-->
 
   <!-- Application-based formats -->
@@ -1748,7 +2335,160 @@
   <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
   <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 video</message>
   <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime video</message>
-	
-</catalogue>
 
- 	  	 
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Confidence was never recorded for this value</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">No reasonable confidence value was returned from the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">The authority recommends this submission be rejected</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">The authority encountered an internal failure</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">There are no matching answers in the authority</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">There are multiple matching authority values of equal validity</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">Value is singular and valid but has not been seen and accepted by a human so it is still uncertain</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">This authority value has been confirmed as accurate by an interactive user</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Unlock the authority key value for manual editing, or toggle it locked again</message>
+
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">DSpace Value Lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Accept</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Add</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Cancel</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">See More Results</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Results @1@ to @2@ of @3@ for "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
+
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up Publisher</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Non-authority value: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Name in "Last, First" format</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Last name, e.g. "Smith"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">First name(s) e.g. "Fred"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Name Authority author lookup</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Local value "@1@" (not in Naming Authority)</message>
+
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
+</catalogue>

--- a/src/main/webapp/i18n/messages_ja.xml
+++ b/src/main/webapp/i18n/messages_ja.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ja">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_ja.xml
+++ b/src/main/webapp/i18n/messages_ja.xml
@@ -1,28 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="ja" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">ホーム</message>
 	<message key="xmlui.general.search">検索</message>
@@ -35,44 +25,60 @@
 	<message key="xmlui.general.delete">削除</message>
 	<message key="xmlui.general.next">次</message>
 	<message key="xmlui.general.untitled">タイトルなし</message>
-	
-	<!-- 
-		Page not found keys 
-		
+        <message key="xmlui.general.perform">実行</message>
+        <message key="xmlui.general.queue">キュー</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">指定のページが見つかりません</message>
 	<message key="xmlui.PageNotFound.head">指定のページが見つかりません</message>
 	<message key="xmlui.PageNotFound.para1">指定のページを見つけることができませんでした。</message>
-	
-	
+
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">サイト管理者だけが別のユーザとしてログインすることができます。</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">管理者権限を持つユーザだけが別のユーザとしてログインできます。</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">別の管理者としてログインすることはできません。</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">DSpaceは、デジタル研究資料を補足、格納、索引化、保存、配布するデジタルリポジトリシステムです。 </message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">チャネル画像</message>
 	<message key="xmlui.feed.untitled">タイトルなし</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">通知</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">コミュニティの検索結果: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">コレクションの検索結果: {0}</message>
@@ -111,7 +117,7 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">識別子</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">言語コード</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">キーワード</message>
-   
+
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">貢献者</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">作者</message>
@@ -126,16 +132,17 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">移動先の先頭数文字を入力してください:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">これらの文字で始まるアイテムをブラウズします。</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">特定の日付に移動:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">（月を選択）</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">（年を選択）</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">特定の日付に移動:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">（月を選択）</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">（年を選択）</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">移動する日付を入力: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">指定した日付以降のアイテムをブラウズします。</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">表示すべきデータがありません。</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> ソート項目: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> ソート順: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> 表示件数: </message><!-- /Page -->
@@ -158,17 +165,37 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">主題 {1} のブラウズ: {0}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">主題ブラウズ {0}</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">タイトル {1} のブラウズ: {0}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">タイトルブラウズ {0}</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">公開日 {1} のブラウズ: {0}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">公開日ブラウズ {0}</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">投稿日 {1} のブラウズ: {0}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">投稿日ブラウズ {0}</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">検索範囲</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">リポジトリ全体</message>
@@ -179,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">日付</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">詳細検索</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">最新登録資料</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">コミュニティリスト</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">コミュニティリスト</message>
@@ -198,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">このコミュニティのサブコミュニティ</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">このコミュニティのコレクション</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">最新登録資料</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">連絡先</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">連絡先</message>
@@ -208,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">オンラインフォーム</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">ご意見</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">メールアドレス</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">ご意見をお聞かせください</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">ご意見をお聞かせください</message>
@@ -218,23 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">このメールアドレスは貴方に連絡する必要がある場合のみ使用いたします。</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">ご意見</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">送信</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">ご意見をお聞かせください</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">ご意見をお聞かせください</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">送信完了</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">ご意見を承りました。ありがとうございました。</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">リポジトリの検索</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">検索語を入力してください。</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">アイテム表示</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">このアイテムは次のコレクションに所属しています</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">アイテムの簡略レコードを表示する</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">アイテムの詳細レコードを表示する</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">ブラウズ</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">リポジトリ全体</message>
@@ -246,14 +271,14 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">投稿日</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">このコレクション</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">このコミュニティ</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">検索</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">検索</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">検索</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">検索範囲</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">全文検索</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">このリソースの利用は制限されています</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">制限</message>
@@ -263,19 +288,25 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">このアイテムの利用は制限されています</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">このビットストリームの利用は制限されています</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">あなたはこの制限されたリソースにアクセスする資格を持っていません。</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">あなたはこの制限されたコミュニティ <b>{0}</b> にアクセスする資格を持っていません。</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">あなたはこの制限されたコレクション <b>{0}</b> にアクセスする資格を持っていません。</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">あなたはこの制限されたアイテム <b>{0}</b> にアクセスする資格を持っていません。</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">あなたはこの制限されたビットストリーム <b>{0}</b> にアクセスする資格を持っていません。</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">あなたはこの制限されたコミュニティ <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">あなたはこの制限されたコレクション <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">あなたはこの制限されたアイテム <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">あなたはこの制限されたビットストリーム <b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">コレクション</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">コミュニティ</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">ビットストリーム</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">アイテム</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">リソース</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">不明</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">このアイテムの利用は制限されています</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">このアイテムの利用は制限されています</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">ご指定のアイテムは利用が制限されており、閲覧には資格が必要です。下のリンクからログインしてください。</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">月次報告書</message>
@@ -285,34 +316,140 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">このサービスには現在利用可能な報告書はありません。後ほどチェックしてください。</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-	<message key="xmlui.BitstreamReader.auth_header">このファイルの利用は制限されています</message>	
+	<message key="xmlui.BitstreamReader.auth_header">このファイルの利用は制限されています</message>
 	<message key="xmlui.BitstreamReader.auth_message">ご指定のファイルは利用が制限されており、閲覧には資格が必要です。下のリンクからログインしてください。</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">このアーカイブのエクスポートは制限されていますThis export archive is restricted.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">ご指定のアーカイブのエクスポートは制限されており、閲覧には資格が必要です。下のリンクからログインしてください。</message>
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">新規ユーザ登録</message>
 	<message key="xmlui.EPerson.trail_forgot_password">パスワードをお忘れですか</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">登録機能は利用できません</message>
 	<message key="xmlui.EPerson.CannotRegister.head">登録機能は利用できません</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">リポジトリの設定により、登録が許可されておりません。ご不明な点がございましたら、<a href="../contact">サイト管理者</a>にご連絡ください。</message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">リポジトリの設定により、登録が許可されておりません。ご不明な点がございましたら、<a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">利用者情報の更新</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">利用者情報の作成</message>
@@ -323,6 +460,7 @@
 	<message key="xmlui.EPerson.EditProfile.first_name">名</message>
 	<message key="xmlui.EPerson.EditProfile.last_name">姓</message>
 	<message key="xmlui.EPerson.EditProfile.telephone">電話番号</message>
+        <message key="xmlui.EPerson.EditProfile.Language">言語</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions">購読</message>
 	<message key="xmlui.EPerson.EditProfile.subscriptions_help">コレクションを購読すると、購読したコレクションに新規登録されたアイテムが毎日メールで通知されます。コレクションはいくつでも購読できます。コレクションを購読する代わりにコレクションのRSSフィードを利用すること藻できます。</message>
 	<message key="xmlui.EPerson.EditProfile.email_subscriptions">購読コレクション</message>
@@ -339,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">所属の権限グループ</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">利用者情報</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">パスワード</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">メールアドレスの確認</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">プロフィールの作成</message>
@@ -352,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">パスワードのリセット</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">パスワードのリセット</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">パスワードはリセットされました。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">不正なトークン</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">不正なトークン</message>
 	<message key="xmlui.EPerson.InvalidToken.head">不正なトークン</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">ご指定のURLは間違っています。メールソフト上でURLが次のように複数の行に分割されていませんでしたか:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">もしそうなら、リンクをクリックするのではなく、URL全体をコピーしてブラウザのアドレスバーにコピーしてください。その場合、アドレスバーは次のようになります:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">登録利用者</message>
 	<message key="xmlui.EPerson.Navigation.profile">利用者情報</message>
@@ -379,7 +517,7 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">新規利用者登録</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">新規アイテムのメール通知やアイテムの投稿には利用者登録が必要です。</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">ここをクリックして、登録をしてください。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">ログイン</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">ログイン</message>
@@ -388,12 +526,13 @@
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">ユーザ名またはパスワードが間違っています。</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">パスワード</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">ログイ</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">ログイン方法の選択</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">ログイン方法の選択</message>
 	<message key="xmlui.EPerson.LoginChooser.head1">ログイン方法の選択</message>
 	<message key="xmlui.EPerson.LoginChooser.para1">ログイン方法:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth認証</message>
 	<message key="org.dspace.eperson.LDAPAuthentication.title">LDAP認証</message>
 	<message key="org.dspace.eperson.PasswordAuthentication.title">パスワード認証</message>
 	<message key="org.dspace.eperson.X509Authentication.title">Web証明書認証</message>
@@ -405,24 +544,24 @@
 	<message key="xmlui.EPerson.FailedAuthentication.title">認証失敗</message>
     <message key="xmlui.EPerson.FailedAuthentication.trail">認証失敗</message>
     <message key="xmlui.EPerson.FailedAuthentication.h1">認証失敗</message>
-	
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">認証方法が見つかりません</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">認証方法が見つかりませんでした。サイト管理者にご連絡ください。</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">シボレスログイン失敗</message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">現在シボレス認証が利用できません。 サイト管理者にご連絡ください。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">利用者情報の更新</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">利用者情報更新</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">利用者情報の更新</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">利用者情報が更新されました。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">登録作業終了</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">登録作業終了</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">リポジトリに登録されました。新規アイテムのメール通知を受け取るコレクションを登録することができます。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">パスワードのリセット</message>
 	<message key="xmlui.EPerson.ResetPassword.head">パスワードのリセット</message>
@@ -433,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">パスワードのリセット</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">少なくとも6文字以上のパスワードを指定してください。</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">確認のため、もう一度パスワードを入力してください。</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">パスワード再発行</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">パスワード再発行</message>
@@ -442,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">登録時に指定したメールアドレスを入力してください。</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">メールアドレスが見つかりません。</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">送信</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">新規利用者登録</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">メールアドレスは既に登録されています</message>
@@ -455,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">このメールアドレスは確認後、ログイン名として使用されます。</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">このメールアドレスにメールを送信できません。</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">登録</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">確認用メールの送信</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">確認用メールの送信</message>
@@ -467,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -483,7 +622,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">マイリポジトリホームへ戻る</message>
 	<message key="xmlui.Submission.general.submission.title">アイテム投稿</message>
 	<message key="xmlui.Submission.general.submission.trail">アイテム投稿</message>
-	<message key="xmlui.Submission.general.submission.head">アイテム投稿</message>	
+	<message key="xmlui.Submission.general.submission.head">アイテム投稿</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; 前ページ</message>
 	<message key="xmlui.Submission.general.submission.save">保存して終了</message>
 	<message key="xmlui.Submission.general.submission.next">次ページ &gt;</message>
@@ -495,25 +634,25 @@
 	<message key="xmlui.Submission.general.showsimple">アイテムの簡略レコードを表示</message>
 	<message key="xmlui.Submission.general.default.title">投稿</message>
 	<message key="xmlui.Submission.general.default.trail">投稿</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">このレクションにアイテムを投稿する</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">投稿</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">投稿とワークフロー</message>
 	<message key="xmlui.Submission.Submissions.trail">投稿</message>
 	<message key="xmlui.Submission.Submissions.head">投稿とワークフロー作業</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>タイトルなし</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">メールアドレス: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">ワークフロー作業</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">以下はリポジトリへの追加のために承認待ちをしているアイテムに対する作業です。作業待ちには2種類あり、1つは貴方が作業をお子なることを選択したもので、もう一つはまだ作業をする人が決まっていないものです。</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">選択済みの作業</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">作業</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">アイテム</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">コレクション</message>
@@ -525,14 +664,14 @@
 	<message key="xmlui.Submission.Submissions.workflow_info3">未選択の作業はありません</message>
 	<!-- Same transformer, submissions section -->
 	<message key="xmlui.Submission.Submissions.submit_head1">投稿</message>
-	<message key="xmlui.Submission.Submissions.submit_info1a"></message>
+	<message key="xmlui.Submission.Submissions.submit_info1a"/>
 	<message key="xmlui.Submission.Submissions.submit_info1b">ここをクリックして投稿を開始することができます。</message>
 	<message key="xmlui.Submission.Submissions.submit_info1c">作業内容は、アイテムのメタデータの登録とアイテムを構成するファイルのアップロードです。投稿ポリシーを設定しているコミュニティ/コレクションがあります。</message>
 	<message key="xmlui.Submission.Submissions.submit_head2">未完了の投稿</message>
 	<message key="xmlui.Submission.Submissions.submit_info2a">以下は、投稿が完了していないアイテムです。</message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">ここをクリック</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">して別の投稿を開始することもできます。</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">タイトル</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">コレクション</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">投稿者</message>
@@ -556,16 +695,26 @@
 	<message key="xmlui.Submission.Submissions.status_6">編集中</message>
 	<message key="xmlui.Submission.Submissions.status_7">保管済</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">状態不明</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">質問</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">記述</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">アップロード</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">アップロード</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">確認</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">クリエイティブ・コモンズ</message>
-	<message key="xmlui.Submission.submit.progressbar.license">ライセンス</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
+    <message key="xmlui.Submission.submit.progressbar.license">ライセンス</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">完了</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">再開</message>
 
@@ -582,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">保存して、後で再開</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">投稿を削除</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">最初の質問</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">重要なお知らせ: </message>
@@ -591,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">（</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">）</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">複数のタイトル</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">アイテムは、<i>翻訳タイトルなど</i>、複数のタイトルを持っている。</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">アイテムは、<i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">上のチェックボックスをチェックしないと、次のタイトルがアイテムから削除されます: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">出版（公開）済み</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">アイテムは以前に出版または公開さている。</message>
@@ -599,26 +748,76 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">公開日</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">引用</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">出版者</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">アイテムの記述</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">エラー: 未知のフィードタイプです</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">このフィールドは必須です</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">姓。 <i>例、山田</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">名。 <i>例、 太郎</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">姓。 <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">名。 <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">年</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">月</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">日</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">シリーズ名</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">番号</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">ファイルのアップロード</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">ファイル</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">アップロードするファイルの完全パス名を入力してください。[参照...]を押すとファイル選択画面が表示されます。</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">アイテムは少なくともファイルを1つ含んでいなければなりません。</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">ファイル記述</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">オプションで、ファイルに関する簡単な記述を提供することができます。例えば、"<i>主論文</i>" や "<i>実験データ</i>"など。</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">ファイルのアップロード中に問題が発生しました。ファイル名、ファイルフォーマットを確認してください。ネットワーク障害の可能性もあります。</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">ファイル記述</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">オプションで、ファイルに関する簡単な記述を提供することができます。例えば、"<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">アップロードして、さらに追加</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">アップロードされたファイル</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">主ファイル</message>
@@ -627,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">サイズ</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">記述</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">フォーマット</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">不明</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">不明フォーマット</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">（既サポート）</message>
@@ -636,19 +835,54 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">編集</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">チェックサム:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">選択したファイルを削除</message>
-	
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">ファイルの編集</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">ファイル</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">ファイル記述</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">オプションで、ファイルに関する簡単な記述を提供することができます。例えば、"<i>主論文</i>" や "<i>実験データ</i>"など。</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">ファイルフォーマットを以下のリストから選択してください（例えば、"<i>Adobe PDF</i>" や "<i>Microsoft Word</i>"）。<strong>リストにないフォーマットの場合は</strong>、リストの下の入力欄に入力してください。</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">オプションで、ファイルに関する簡単な記述を提供することができます。例えば、"<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">ファイルフォーマットを以下のリストから選択してください（例えば、"<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">検出されたフォーマット</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">選択されたフォーマット</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">リストにないフォーマット</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">上のリストにフォーマットがない場合は、<strong>"リストにないフォーマット" を選択して</strong>下の入力欄にファイルのフォーマットを記述してください。</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">上のリストにフォーマットがない場合は、<strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">その他のフォーマット</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">ファイルの作成に使用したアプリケーションソフト名とそのバージョン（例えば、"<i>ACMESoft SuperApp version 1.5</i>"）。</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">ファイルの作成に使用したアプリケーションソフト名とそのバージョン（例えば、"<i>ACMESoft SuperApp version 1.5</i>").</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">投稿の確認</message>
@@ -665,18 +899,21 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">不明</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">既知</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">既サポート</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">クリエイティブ･コモンズ ライセンス</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">希望する場合は、 <a href="http://creativecommons.org/">クリエイティブ･コモンズ</a> ライセンスをアイテムに与えることができます。<strong>クリエイティブ･コモンズ ライセンスは、貴方の作品を読む人が、その作品で何をすることができるかを決定します</strong>。クリエイティブ･コモンズ ライセンスを選択する場合は、以下のボタンをクリックしてください。クリエイティブ･コモンズのWebサイトが表示され、いくつかのライセンスの選択肢が提示されます。ライセンスを選択すると、このページに戻ってきます。</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">クリエイティブ･コモンズのサイトでライセンスを選択</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">ライセンス</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">このクリエイティブ･コモンズ ライセンスを削除</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">クリエイティブ･コモンズ ライセンスが選択されていません。</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">クリエイティブ･コモンズ ライセンス</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">希望する場合は、 <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">クリエイティブ･コモンズのサイトでライセンスを選択</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">ライセンス</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">クリエイティブ･コモンズ ライセンスが選択されていません。</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">配布ライセンス</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>最後にしていただく処理があります:</strong> このリポジトリが貴方の投稿したアイテムを世界中に複製、翻訳、配布するために、貴方に次の条項を承認していただく必要があります。</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">「ライセンスを承諾」を選択して、[投稿完了]をクリックすることにより、標準配布ライセンスを承諾してください。</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">このライセンスに関して疑問のある方は、システム管理者にご連絡ください。</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">配布ライセンス</message>
@@ -686,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">投稿の削除</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">投稿がキャンセルされ、未完のアイテムはシステムから削除されました。</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">投稿ページに移動する</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">投稿ページに移動する</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">投稿完了</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">貴方の投稿は、このコレクションの査読処理にまわされました。コレクションに追加された場合や問題が発生した場合は、すぐにメールでお知らせします。投稿ページにアクセスすることにより処理状況をチェックすることもできます。</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">投稿ページに移動する</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">別のアイテムを投稿する</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">投稿完了</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">貴方の投稿は、このコレクションの査読処理にまわされました。コレクションに追加された場合や問題が発生した場合は、すぐにメールでお知らせします。投稿ページにアクセスすることにより処理状況をチェックすることもできます。</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">投稿ページに移動する</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">別のアイテムを投稿する</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">このタスクで行う作業:</message>
@@ -704,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">アイテムを承認</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">アイテムの編集後に、アイテムをリポジトリに追加する場合は、このオプションを使ってください。</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">リポジトリに追加</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">このアイテムを査読して、コレクションに追加することがふさわしく<strong>ない</strong>場合は、[却下]を選択してください。何故アイテムの追加がふさわしくないか、投稿者は修正して再投稿するべきか否かを示すコメントの入力が求められます。</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">このアイテムを査読して、コレクションに追加することがふさわしく<strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">アイテムを却下</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">アイテムのメタデータを変更する場合はこのオプションを使用してください。</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">メタデータの編集</message>
@@ -717,18 +954,22 @@
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">このフィールドは必須です。</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">アイテムを却下</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">ユーザの追加に成功しました。</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">ユーザの追加に成功しました。</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">ユーザの編集に成功しました。</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">新パスワードの選択に使用されるトークンを含むメールがユーザに送信されました。</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">ユーザの削除に成功しました。</message>
@@ -747,16 +988,18 @@
 	<message key="xmlui.administrative.FlowItemUtils.metadata_added">新しいメタデータが追加されました。</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">アイテムが取り下げられました。</message>
 	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">アイテムが復活されました。</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">アイテムを移動しました。</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">選択したコレクションが見つかりません。</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">新しいビットストリームのアップロードに成功しました。</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">ファイルのアップロード中に発生したエラー</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">ビットストリームが更新されました。</message>
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">選択したビットストリームが削除されました。</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">アイテムのマッピングに成功しました。</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">アイテムはマッピングが解除されました。</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">利用者の管理</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">コンテキスト</message>
@@ -768,9 +1011,10 @@
 	<message key="xmlui.administrative.Navigation.context_create_subcommunity">サブコミュニティの作成</message>
 	<message key="xmlui.administrative.Navigation.context_create_community">コミュニティの作成</message>
 	<message key="xmlui.administrative.Navigation.context_export_item">アイテムのエクスポート</message>
-    <message key="xmlui.administrative.Navigation.context_export_collection">コレクションのエクスポート</message>
-    <message key="xmlui.administrative.Navigation.context_export_community">コミュニティのエクスポート</message>
-	
+        <message key="xmlui.administrative.Navigation.context_export_collection">コレクションのエクスポート</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">コミュニティのエクスポート</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">メタデータのエクスポート</message>
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">管理作業</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">アクセスコントロール</message>
@@ -780,15 +1024,20 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">レジストリ</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">メタデータ</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">フォーマット</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">アイテム</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">取り下げアイテム</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">コントロールパネル</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">コントロールパネル</message>
     <message key="xmlui.administrative.Navigation.statistics">統計</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">メタデータのインポート</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">マイ･エクスポート</message>
-	
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">アーカイブのエクスポート</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">ご指定のアイテムIDは間違っています。</message>
@@ -797,10 +1046,11 @@
 	<message key="xmlui.administrative.ItemExport.item.not.found">リクエストされたアイテムは見つかりませんでした。</message>
 	<message key="xmlui.administrative.ItemExport.collection.not.found">リクエストされたコレクションは見つかりませんでした。</message>
 	<message key="xmlui.administrative.ItemExport.community.not.found">リクエストされたコミュニティは見つかりませんでした。</message>
+	<message key="xmlui.administrative.ItemExport.item.success">アイテムをエクスポートしました。ダウンロードの準備ができたらメールを送信します。「マイエクスポート」リンクから利用可能なエクスポートファイルリストを見ることができます</message>
 	<message key="xmlui.administrative.ItemExport.collection.success">コレクションのエクスポートに成功しました。アーカイブのダウンロードの準備ができたらメールで通知されるはずです。「マイ･エクスポート」リンクを使用することにより、利用可能なアーカイブのリストを閲覧することができます。</message>
 	<message key="xmlui.administrative.ItemExport.community.success">コミュニティのエクスポートに成功しました。アーカイブのダウンロードの準備ができたらメールで通知されるはずです。「マイ･エクスポート」リンクを使用することにより、利用可能なアーカイブのリストを閲覧することができます</message>
 	<message key="xmlui.administrative.ItemExport.available.head">ダウンロード可能なエクスポートアーカイブ:</message>
-	
+
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
@@ -815,14 +1065,14 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">利用者のメールアドレスと名前の部分一致で検索できます。</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">以下は、検索語に一致した利用者の一覧です。利用者を削除する場合は、利用者を選択して[削除]ボタンを押してください。編集する場合は、メールアドレスか名前をクリックしてください。</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">検索結果</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">名前</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">メールアドレス</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">削除</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">該当する利用者はありません。</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">利用者の追加</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">利用者の追加</message>
@@ -836,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">証明書が必要</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">ログイン可能</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">作成</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">利用者の編集</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">利用者の編集</message>
@@ -853,19 +1103,19 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">この利用者の削除とパスワードのリセットをすることができます。パスワードをリセットすると、新しいパスワードを設定するためのURLが利用者に送信されます。</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">利用者の削除</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">この利用者としてログイン</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">この利用者は次の制約があり削除することができません:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">、および</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">1つ以上のアイテムの投稿がある</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">処理中の投稿ワークフローがある</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">選択すべきワークフロータスクがある</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">識別できない制約を持っている</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">この利用者が所属するグループ:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">（間接的グループ: {0}）</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">なし</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">利用者削除の確認</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">削除の確認</message>
@@ -890,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">グループの検索</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">グループ名の部分一致で検索できます。</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">検索結果</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">名前</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">メンバー</message>
@@ -912,6 +1162,7 @@
 	<message key="xmlui.administrative.group.EditGroupForm.submit_add">追加</message>
 	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">削除</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_para">このグループに関連するコレクション: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">このグループは次のコミュニティと関係しています: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_name">グループ名の変更: </message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">このグループは特別なコレクションに関係しているので、名前を変更することができません。</message>
 	<message key="xmlui.administrative.group.EditGroupForm.label_search">追加するメンバーの検索: </message>
@@ -921,24 +1172,24 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">名前</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">メールアドレス</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">名前</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">メンバー</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">コレクション</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">閲覧</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">メンバー</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">名前</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">メールアドレス</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">グループ: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">グループ: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">このグループにはメンバーがいません。</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[保留]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">メンバーの削除</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">メンバーの削除</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">グループ削除の確認</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">削除の確認</message>
@@ -948,16 +1199,16 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">名前</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">利用者</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">グループ</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">フォーマットレジストリ</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">メタデータレジストリ</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">メタデータレジストリ</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">ビットストリームフォーマットの削除</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">ビットストリームフォーマットの削除</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">削除の確認</message>
-	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">このフォーマットを<b>本当に</b>削除しますか。このファーマットの既存のビットストリームのフォーマットは不明になります。</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">このフォーマットを</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">MIMEタイプ</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">名前</message>
@@ -966,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">フィールドの削除</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">フィールドの削除</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">削除の確認</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">このフィールドを<b>本当に</b>削除しますか。このフィールドのメタデータを持つアイテムが存在する場合は、フィールドを削除できません。このフィールド持つアイテムがないことを確認する必要があります。</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">このフィールドを<b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">警告: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">このフィールドのメタデータを持つアイテムが存在する場合は、エラーが発生します。</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -977,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">スキーマの削除</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">スキーマの削除</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">削除の確認</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">このスキーマを<b>本当に</b>削除しますか。このスキーマに含まれるフィールドのメタデータを持つアイテムが存在する場合は、スキーマを削除できません。このスキーマのメタデータを持つアイテムがないことを確認する必要があります。</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">このスキーマを<b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">警告: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">このスキーマのメタデータを持つアイテムが存在する場合は、エラーが発生します。</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -994,6 +1245,7 @@
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">このフォーマットのユニークな名前（例えば、Microsoft Word XP や Microsoft Word 2000）</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">名前フィールドは必須です。</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">MIMEタイプ</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">このフォーマットに関するMIMEタイプは一意である必要はありません。</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">記述</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">サポートレベル</message>
 	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">貴方の機関がこのフォーマットに保証するサポートレベル</message>
@@ -1011,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">メタデータスキーマ: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">"{0}" のメタデータスキーマです。このスキーマに新たにメタデータフィールドを追加したり、既存のメタデータフィールドを編集したりすることができます。フィールドを削除したり、別のスキーマに移動したりすることもできます。</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">スキーマメタデータフィールド</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">フィールド</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">適用注記</message>
@@ -1038,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">ビットストリームフォーマットレジストリ</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">このビットストリームフォーマットのリストは、既知のフォーマットとそのサポートレベルに関する情報を提供します。このツールを使って、ビットストリームフォーマットを編集したり、新規に追加したりすることができます。内部使用とマークされたフォーマットはユーザには隠され、管理用途のみに使用されます。</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">新規ビットストリームフォーマットの追加</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">名前</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIMEタイプ</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">サポートレベル</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>内部使用</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">未知</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">既知</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">サポート</message>
@@ -1053,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">メタデータレジストリ</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">メタデータレジストリ</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">メタデータレジストリは、このリポジトリで利用できる全てのメタデータフィールドのリストを管理します。これらのフィールドは複数のスキーマに分割することができます。しかし、DSpaceは限定子付のダブリンコアスキーマを必要とします。ダブリンコアスキーマにフィールドを追加して拡張したり、レジストリに新規のスキーマを追加したりすることができます。</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">名前空間</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">名前</message>
@@ -1078,13 +1330,13 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">移動先のスキーマ: </message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">フィールドの移動</message>
 
-	
-	
-	
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">権限管理</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">ポリシーリスト</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">権限ポリシーの管理</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">権限ポリシーの管理</message>
@@ -1097,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">アイテムのワイルドカードによるポリシー管理ツールを使用する場合は、ここをクリックしてください</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">コミュニティ/コレクションの権限</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">権限を編集するコミュニティまたはコレクションをクリックしてください。</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">ポリシーの編集</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">ポリシー一覧</message>
@@ -1108,13 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">新しいポリシーの追加はここをクリックしてください。</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">追加</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">アクション</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">グループ</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">選択したポリシーを削除</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">編集</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">アイテムポリシーの編集</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">ポリシー一覧</message>
@@ -1127,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">新規アイテムポリシーの追加</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">新規バンドルポリシーの追加</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">新規ビットストリームポリシーの追加</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">このオブジェクトにはポリシーがありません。</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">ポリシーの編集</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">ポリシーの編集</message>
@@ -1138,11 +1393,11 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">{1} {2}の{0} ポリシーの編集</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">グループが選択されていません</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">アクションが選択されていません</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">名前</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">このリソースに対するアクション</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">設定</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">現在</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">検索結果</message>
@@ -1150,9 +1405,17 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">グループの検索</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">検索</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">アクションの選択</message>
-    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">高機能権限ツール</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">高機能ツール</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">高機能ポリシー管理ツール</message>
@@ -1167,7 +1430,17 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">コレクション</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">ポリシーの追加</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">ポリシーのクリア</message>
-	
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">ポリシー削除の確認</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">削除の確認</message>
@@ -1176,15 +1449,53 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">アクション</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">グループ</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">アイテム</message>
+	<message key="xmlui.administrative.item.general.template_head">コレクション: {0} のテンプレートアイテムの編集</message>
 	<message key="xmlui.administrative.item.general.option_head">アイテムの編集</message>
 	<message key="xmlui.administrative.item.general.option_status">アイテムの状態</message>
 	<message key="xmlui.administrative.item.general.option_bitstreams">アイテムのビットストリーム</message>
 	<message key="xmlui.administrative.item.general.option_metadata">アイテムのメタデータ</message>
 	<message key="xmlui.administrative.item.general.option_view">アイテムを閲覧</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">管理作業</message>
+        <message key="xmlui.administrative.item.general.option_queue">キュー</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">ビットストリームのアップロード</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">ビットストリームのアップロード</message>
@@ -1194,14 +1505,14 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">メタデータファイル</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">サムネイル</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">ライセンス</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">クリエイティブ･コモンズ ライセンス</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">ファイル</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">アイテムに対応するコンピュータ上のファイル名を入力してください。[参照...]ボタンをクリックすると、コンピュータ上のファイルを表示･選択する画面が表示されます。</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">記述</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">オプションとして、ファイルの簡単な説明を入力することができます。例えば、"<i>主論文</i>" や "<i>実験データ</i>" です。</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">オプションとして、ファイルの簡単な説明を入力することができます。例えば、"<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">アップロード</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">新規ビットストリームのアップロードには、少なくとも1つのバンドルに対する ADD &amp; WRITE 権限が必要です。</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">削除の確認</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">削除の確認</message>
@@ -1210,7 +1521,7 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">名前</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">記述</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">フォーマット</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">確認</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">確認</message>
@@ -1223,6 +1534,19 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">言語</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">取下げ</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">復帰</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
+
+    <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
+	<message key="xmlui.administrative.item.MoveItemForm.title">移動</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">移動</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">アイテム: {0} の移動</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">コレクション</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">移動先のコレクションを選択してください。</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">コレクションの選択...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">移動</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">ポリシーの継承</message>
+    <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">移動先コレクションのデフォルトポリシーを継承する</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
 	<message key="xmlui.administrative.item.EditBitstreamForm.title">ビットストリームの編集</message>
@@ -1233,31 +1557,39 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">はい</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">いいえ</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">記述</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">オプションとして、ファイルの簡単な説明を入力できます。例えば、"<i>主論文</i>" や "<i>実験データ</i>" です。"</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">下のリストからファイルのフォーマットを選択してください。例えば、"<i>Adobe PDF</i>"、"<i>Microsoft Word</i>"です。<b>あるいは</b>、該当するフォーマットがリストにない場合は、下の入力欄に記述してください。</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">オプションとして、ファイルの簡単な説明を入力できます。例えば、"<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">下のリストからファイルのフォーマットを選択してください。例えば、"<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">選択されたフォーマット</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">リストにないフォーマット</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">該当するフォーマットが上のリストにない場合は、<strong>"リストにないフォーマット" を選択して</strong>、下の入力欄に記述してください。</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">該当するフォーマットが上のリストにない場合は、<strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">その他のフォーマット</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">ファイルを作成した際に使用したソフトおよびそのバージョン数（例えば、"<i>ACMESoft SuperApp version 1.5</i>"）。</message>
-	
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">ファイルを作成した際に使用したソフトおよびそのバージョン数（例えば、"<i>ACMESoft SuperApp version 1.5</i>").</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">アイテムのビットストリーム</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">アイテムのビットストリーム</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">ビットストリーム</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">名前</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">記述</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">フォーマット</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">閲覧</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>バンドル: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label">（主たるファイル）</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">閲覧</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">新規ビットストリームのアップロード</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">ビットストリームの削除</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">新規ビットストリームをアップロードするには、アイテムとバンドルに対する ADD &amp; WRITE 権限が必要です。</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">ビットストリームを削除するには、アイテムとバンドルに対する REMOVE 権限が必要です。</message>
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">アイテムのメタデータ</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">アイテムのメタデータ</message>
@@ -1266,7 +1598,7 @@
 	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">値</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">言語</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">新規メタデータの追加</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">注意: ここでの変更は検証が一切行われません。貴方には正しいフォーマットでデータを入力する責任があります。フォーマットが何であるか自信がない場合は、変更<storng>しない</storng>でください。</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">注意: ここでの変更は検証が一切行われません。貴方には正しいフォーマットでデータを入力する責任があります。フォーマットが何であるか自信がない場合は、変更</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">メタデータ</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">削除</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">名前</message>
@@ -1285,67 +1617,128 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">アイテムの権限</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">アイテムのリポジトリからの取下げ</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">アイテムのリポジトリへの復帰</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">アイテムの所有コレクションの移動</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">アイテムの完全な消去</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">権限の編集</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">取下げ...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">復帰...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">移動...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">永久に削除</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">利用不可</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">（システム管理者のみ）</message>
-	
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">（コレクション管理者のみ）</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">（この作業を行う権限がありません）</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">アイテムの閲覧</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">アイテムの閲覧</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">アイテム: {0} の管理作業</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">アイテムの管理</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">管理作業</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">タスク</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">アイテムの検索</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">アイテムの検索</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_label">アイテムの内部ID/ハンドル</message>
 	<message key="xmlui.administrative.item.FindItemForm.identifier_error">識別子を解決できませんでした。</message>
 	<message key="xmlui.administrative.item.FindItemForm.find">検索</message>
-	
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">メタデータのインポート</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">メタデータのインポート</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">メタデータのインポート</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">変更</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">変更が見つかりませんでした</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">新アイテム</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">アップロード成功</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">アップロード失敗</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">見出し行に不明なスキーマがあります</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">見出し行に不明なメタデータ要素があります</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">インポート成功</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">インポート失敗</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">変更件数が上限を超えました。ファイルを分割するか、dspace.cfg の "bulkedit.gui-item-limit" を変更してください。</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">CSVのアップロード</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">処理が終了しました</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">変更適用アイテム</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">追加: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">削除: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">新所有コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">旧所有コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">新規マッピングコレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">マッピング解除コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">追加: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">削除: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">新所有コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">旧所有コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">新規マッピングコレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">マッピング解除コレクション</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">ペンディング中の変更</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">変更の適用</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">ペンディングされた変更は次の通りです。</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
+
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">アイテムマッパー</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">アイテムマッパー</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">アイテムマッパー - アイテムを他のコレクションにマップする</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para1">コレクション: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">これはアイテムマッパーツールです。コレクション管理者はアイテムをこのコレクションから他のコレクションにマップすることができます。他のコレクションからアイテムを検索して、マップすることができます。また、現在マップされているアイテムの一覧をブラウズすることができます。</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">統計</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info">このコレクションの <strong>{0} / {1}</strong> のアイテムが他のコレクションにマップされています。</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info">このコレクションの <strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">検索</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">アイテムの検索</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">マップされたアイテムのブラウズ</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">（コレクションの ADD 権限が必要です）</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">アイテムの検索</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">アイテムの検索</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">検索語: "{0}" による検索結果</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">選択したアイテムをマップ</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">コレクション</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">著者</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">タイトル</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">マップされたアイテムのブラウズ</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">マップされたアイテムのブラウズ</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">マップされたアイテムのブラウズ</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">選択したアイテムのマップ解消</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">コレクション</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">著者</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">タイトル</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">このコレクションからアイテムのマップを解消するにはこのコレクションに対する REMOVE 権限が必要です。</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">コレクション</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">メタデータの編集</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">役割の付与</message>	
-	
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">コレクション</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">メタデータの編集</message>
+	<message key="xmlui.administrative.collection.general.options_roles">役割の付与</message>
+        <message key="xmlui.administrative.collection.general.options_curate">管理作業</message>
+        <message key="xmlui.administrative.collection.general.options_queue">キュー</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">コレクションの役割の編集</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">役割</message>
@@ -1366,12 +1759,21 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">関連するグループ</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">管理者</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">ワークフロー･ステップ</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">受理/却下ステップ</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">受理/却下/メタデータ編集ステップ</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">メタデータ編集ステップ</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">投稿者</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">デフォルト閲覧アクセス</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>（システム管理者のみ）</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">コレクション: {0} の管理作業</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">コレクションの管理作業</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">管理作業</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">タスク</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">削除の確認</message>
@@ -1381,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">他のコレクションに含まれていないこのコレクションのすべてのアイテムと投稿途中のアイテム</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">それらのアイテムのコンテンツ</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">関連するすべての権限ポリシー</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">役割の削除の確認</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">確認</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">役割 {0} の削除の確認</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">本当にこの役割を削除しても良いですか。このグループの削除により、今後このコレクションに投稿されるすべてのアイテムに対してすべてのユーザに READ 権限を与えることになります。この変更は遡及的には適用されないことに注意してください。このシステムに既に存在するアイテムは、削除しようとしている役割で定義されたメンバにはこの先も制限が続きます。</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">本当にこの役割を削除しても良いですか。グループ {0} に対して行った追加や変更はすべて失われ、新たに作成し直さないといけなくなります。</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">コレクションメタデータの編集</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">メタデータ</message>
@@ -1408,13 +1810,107 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">ロゴの削除</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">コレクションの削除</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">保存</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>（システム管理者のみ）</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">コレクションの作成</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">コレクションの作成</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">{0} の新規コレクションのメタデータの入力</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">作成</message>
+
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">ハーベスト設定</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">ハーベスト</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">コレクションのコンテンツ</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">コレクションのコンテンツ</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">通常通りDSpaceで作成</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">外部情報源からハーベスト</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">保存</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">ハーベスト対象プロバイダ</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">ハーベストオプション</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAIプロバイダURL</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAIセット値</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">メタデータフォーマット</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">ハーベスト対象のOAIプロバイダのURL</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">ハーベスト対象のプロバイダURLを指定する必要があります。</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">ハーベスト対象のOAIプロバイダが使用している永続的識別子</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">ハーベスト対象のセット値を指定する必要があります。</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">ハーベストする内容</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">&gt;メタデータのみをハーベスト</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">メタデータとビットストリームのURLをハーベスト（OREサポートが必要）</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">メタデータとビットストリームをハーベスト（OREサポートが必要）</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">設定のテスト</message>
+
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">ハーベスト対象プロバイダ</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAIプロバイダ</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAIセット値</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">メタデータフォーマット</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">ハーベストするコンテンツ</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">前回のハーベスト結果</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">このコレクションはまだハーベストされていません。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">現在のハーベスト状態</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">ハーベストの準備が整いました。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">現在ハーベスト中です。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">ハーベスト待機中です。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">前回のハーベスト中にOAIエラーが発生しました。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">前回のハーベスト中に想定外のエラーが発生しました。</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">メタデータのみをハーベスト</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">メタデータとビットストリームのURLをハーベスト</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">メタデータとビットストリームをハーベスト（完全な複製）</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">設定を変更</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">インポート開始</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">リセットして再インポート</message>
+
+	<message key="xmlui.administrative.ControlPanel.option_harvest">ハーベスト中</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">ハーベストスケジュール管理</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">状態</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">アクション</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">ハーベスト開始</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">状態のリセット</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">再開</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">中断</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">停止</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">ハーベスト先コレクションの設定</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">実行中のハーベスト</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">待機中のハーベスト</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAIエラー</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">内部エラーー</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">ジェネレータの設定</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">OREソース</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">ハーベスタの設定</message>
+
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">コミュニティ</message>
+	<message key="xmlui.administrative.community.general.options_metadata">メタデータの編集</message>
+	<message key="xmlui.administrative.community.general.options_roles">役割の付与</message>
+        <message key="xmlui.administrative.community.general.options_curate">管理作業</message>
+        <message key="xmlui.administrative.community.general.options_queue">キュー</message>
+
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">コミュニティの役割の編集</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">役割</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">コミュニティ: {0} の編集</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">なし</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">作成...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">コミュニティ管理者は、サブコミュニティとコレクションの作成ができます。さらに、投稿できるユーザの決定、（投稿された）アイテムのメタデータの修正、既存のアイテムの別のコレクションへのマッピングができます。</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">このコミュニティは独自のデフォルトアクセス設定を使用します。</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">新規アイテム･ビットストリームのデフォルトのリード権限はAnonymousに設定されています。</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">権限ポリシーを直接編集する。</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">役割</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">設定されたグループ</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">管理者</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">コミュニティ: {0} の管理作業</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">コミュニティの管理</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">管理作業</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">タスク</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">削除の確認</message>
@@ -1425,7 +1921,13 @@
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">他のコミュニティに含まれていないこのコミュニティのすべてのアイテムと投稿途中のアイテム</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">これらのアイテムのコンテンツ</message>
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">関連するすべての権限ポリシー</message>
-	
+
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">削除の確認</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">確認</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">役割 {0} の削除の確認</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">グループ {0} に行ったすべての変更･カスタマイズが失われますが、この役割を本当に削除しても良いですか。</message>
+
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">コミュニティメタデータの編集</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">メタデータ</message>
@@ -1440,7 +1942,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">現在のロゴ</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">ロゴの削除</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">コミュニティの削除</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">コミュニティの作成</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">コミュニティの作成</message>
@@ -1471,7 +1973,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">アロケートメモリ</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">使用メモリ</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">フリーメモリ</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">DSpaceの設定</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">DSpaceインストールディレクトリ</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">DSpaceベースURL</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">DSpaceホスト名</message>
@@ -1487,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">フィードバック受信者</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">全般的なサイト管理者メールアドレス</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">システム全体への警告</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>ロードバランスシステムへの警告</strong>: システム全般への警告は活性化されたノードに対してのみ有効です。設定された各システムが活性化警告コマンドを受信することを保証する必要があります。</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">警告メッセージ</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">定期保守のため、システムはまもなく停止されます。作業を保存してログアウトしてください。</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">カウントダウン</message>
@@ -1497,27 +2008,31 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 分</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 時間</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">現在のカウントダウンタイマーを保持する</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">セッション管理</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">認証セッションの許可を続ける</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">認証を制限するが現在のセッションは保持する</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">認証を制限し、現在のセッションを停止する</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>注:</strong> サイト管理者はセッション管理を免除されます。</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">セッション管理</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">認証セッションの許可を続ける</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">認証を制限するが現在のセッションは保持する</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">認証を制限し、現在のセッションを停止する</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">活性化</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">非活性化</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">現在のアクティビティ（最大 {0} ページ）</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ユーザの利用記録を停止。</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">ユーザの利用記録を開始。</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">botの利用記録を停止。</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">botの利用記録を開始。</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_time">タイムスタンプ</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_user">利用者</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IPアドレス</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">ページURL</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">ユーザエージェント</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymous {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonymous {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">過去 {0} ページに貴方以外のページビューはありません。</message>
-	
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">上のタブを使って表示する情報を選択してください。</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>{0} 分以内</strong>: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">権限がありません</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">権限がありません</message>
@@ -1526,17 +2041,108 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">システム管理者</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">にご連絡ください。</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">別の利用者としてログイン</message>
-	
-	
-	
-	
-	
-	
-	
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+    <message key="xmlui.statistics.title">統計</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
+    <message key="xmlui.statistics.visits.total">総閲覧数</message>
+    <message key="xmlui.statistics.visits.month">月別閲覧数</message>
+    <message key="xmlui.statistics.visits.views">件数</message>
+    <message key="xmlui.statistics.visits.countries">国別閲覧数</message>
+    <message key="xmlui.statistics.visits.cities">都市別閲覧数</message>
+    <message key="xmlui.statistics.visits.bitstreams">ファイルダウンロード数</message>
+    <message key="xmlui.statistics.Navigation.title">統計</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
+    <message key="xmlui.statistics.trail">統計</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
+
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -1545,16 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-	        このサイトは、テキサスA&amp;M大学が開発した<a href="http://dspace.org">DSpace</a>の新フロントエンド <a href="http://di.tamu.edu">Manakin</a> を使用しています。
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">連絡先</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">ご意見をお寄せ下さい</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">DSpace/Manakin Repository</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">プロフィール: </message>
@@ -1565,15 +2175,15 @@
 	<message key="xmlui.dri2xhtml.structural.search-advanced">詳細検索</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-community">このコミュニティ</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">このコレクション</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">前ページ</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">{0}-{1} / {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">次ページ</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">オリジナルライセンス</message>
-		
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -1583,7 +2193,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
 		これはMETS 1.0プロファイルに準拠したDSpaceオブジェクトではありません。そのため、うまく解析することができません。必要な機能を実行するために dri2xhtml の一般的なケースを処理するテンプレートを上書きするか、貴方が使用するプロファイルにあった独自のテンプレートを作成してください。
     </message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">プレビュー</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">タイトル</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">著者</message>
@@ -1593,315 +2203,286 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">日付</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">出版者</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">主題</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">このアイテムのファイル</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">ファイル</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">名前</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">サイズ</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">フォーマット</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">閲覧</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">閲覧/開く</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">記述</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">閲覧/開く<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">このアイテムに関連するファイルは存在しません。</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">バイト</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">このファイルには次のライセンスファイルが添付されています。</message>
-		
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		コレクションのsummaryViewは現在使用されていないか、実装されていません。これは、collectionSummaryView という名の dri2xhtml のテンプレートを上書きすることにより修正することができます。
 	</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
 		コミュニティのsummaryViewは現在使用されていないか、実装されていません。これは、communitySummaryView という名の dri2xhtml のテンプレートを上書きすることにより修正することができます。
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">コレクションのロゴ</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">コミュニティのロゴ</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">ロゴはありません</message>		
-	<message key="xmlui.dri2xhtml.METS-1.0.news">ニュース</message>	
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">ロゴはありません</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">ニュース</message>
 
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
 		現在のところ、限定子付きダブリンコア（QDC）はDSpaceのコミュニティとコレクションには適用されません。QDCを使う場合は、DSpaceアイテムにはQDCクロスウォークを、コミュニティとコレクションの処理にはDIMかMODSのいずれかを使用してください。
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">ダブリンコア要素</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">ダブリンコア用語</message>
-	
-	
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">プレビュー</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">日付</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">タイトル</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">著者</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
-	<message key="org.dspace.authenticate.ShibAuthentication.title">Shibboleth認証</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">表示すべきデータがありません。</message>
-	<message key="xmlui.ChoiceLookupTransformer.accept">この値を使用</message>
-	<message key="xmlui.ChoiceLookupTransformer.add">追加</message>
-	<message key="xmlui.ChoiceLookupTransformer.cancel">キャンセル</message>
-	<message key="xmlui.ChoiceLookupTransformer.fail">選択データのロードに失敗しました: </message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">"姓, 名" 形式の名前</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">名、 たとえば "太郎"</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">姓、たとえば "山田"</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">DSpace入力値 '@1@'</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC著者名典拠検索</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">出版者名</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">非典拠値: @1@</message>
-	<message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">出版者の検索</message>
-	<message key="xmlui.ChoiceLookupTransformer.more">次ページ</message>
-	<message key="xmlui.ChoiceLookupTransformer.results">"@4@"の結果: @1@ - @2@ / @3@</message>
-	<message key="xmlui.ChoiceLookupTransformer.title">DSpace入力値の検索</message>
-	<message key="xmlui.EPerson.EditProfile.Language">言語</message>
-	<message key="xmlui.Submission.submit.UploadStep.upload_error">ファイルのアップロード中に問題が発生しました。ファイル名、ファイルフォーマットを確認してください。ネットワーク障害の可能性もあります。</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">ジェネレータの設定</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">ハーベスタの設定</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">アクション</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_active">実行中のハーベスト</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">ハーベスト先コレクションの設定</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">内部エラーー</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">OAIエラー</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">OREソース</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">待機中のハーベスト</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_label_status">状態</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">ハーベストスケジュール管理</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">中断</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">状態のリセット</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">再開</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">ハーベスト開始</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">停止</message>
-	<message key="xmlui.administrative.ControlPanel.option_harvest">ハーベスト中</message>
-	<message key="xmlui.administrative.ControlPanel.start_anonymous">ユーザの利用記録を開始。</message>
-	<message key="xmlui.administrative.ControlPanel.start_bot">botの利用記録を開始。</message>
-	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ユーザの利用記録を停止。</message>
-	<message key="xmlui.administrative.ControlPanel.stop_bot">botの利用記録を停止。</message>
-	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">選択したコレクションが見つかりません。</message>
-	<message key="xmlui.administrative.FlowItemUtils.item_moved">アイテムを移動しました。</message>
-	<message key="xmlui.administrative.ItemExport.item.success">アイテムをエクスポートしました。ダウンロードの準備ができたらメールを送信します。「マイエクスポート」リンクから利用可能なエクスポートファイルリストを見ることができます</message>
-	<message key="xmlui.administrative.Navigation.administrative_import_metadata">メタデータのインポート</message>
-	<message key="xmlui.administrative.Navigation.context_export_metadata">メタデータのエクスポート</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">ワークフロー･ステップ</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>（設定権限がありません）</nobr></message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">タスク</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">コレクション: {0} の管理作業</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.title">コレクションの管理作業</message>
-	<message key="xmlui.administrative.collection.CurateCollectionForm.trail">管理作業</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">このコレクションはまだハーベストされていません。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">現在ハーベスト中です。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">前回のハーベスト中にOAIエラーが発生しました。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">ハーベスト待機中です。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">ハーベストの準備が整いました。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">前回のハーベスト中に想定外のエラーが発生しました。</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">ハーベストするコンテンツ</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">前回のハーベスト結果</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">現在のハーベスト状態</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">メタデータフォーマット</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAIプロバイダ</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAIセット値</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">ハーベスト対象プロバイダ</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">メタデータとビットストリームをハーベスト（完全な複製）</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">メタデータとビットストリームのURLをハーベスト</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">メタデータのみをハーベスト</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">設定を変更</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">インポート開始</message>
-	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">リセットして再インポート</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">コレクションのコンテンツ</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">コレクションのコンテンツ</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">外部情報源からハーベスト</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">通常通りDSpaceで作成</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">保存</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">ハーベスト設定</message>
-	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">ハーベスト</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">ハーベスト対象のセット値を指定する必要があります。</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">ハーベスト対象のプロバイダURLを指定する必要があります。</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">ハーベスト対象のOAIプロバイダが使用している永続的識別子</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">ハーベスト対象のOAIプロバイダのURL</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">ハーベストする内容</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">メタデータフォーマット</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">OAIプロバイダURL</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAIセット値</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">ハーベスト対象プロバイダ</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">メタデータとビットストリームをハーベスト（OREサポートが必要）</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">メタデータとビットストリームのURLをハーベスト（OREサポートが必要）</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">>メタデータのみをハーベスト</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">ハーベストオプション</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">設定のテスト</message>
-	<message key="xmlui.administrative.collection.general.options_curate">管理作業</message>
-	<message key="xmlui.administrative.collection.general.options_queue">キュー</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.create">作成...</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">新規アイテム･ビットストリームのデフォルトのリード権限はAnonymousに設定されています。</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">このコミュニティは独自のデフォルトアクセス設定を使用します。</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">権限ポリシーを直接編集する。</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">コミュニティ管理者は、サブコミュニティとコレクションの作成ができます。さらに、投稿できるユーザの決定、（投稿された）アイテムのメタデータの修正、既存のアイテムの別のコレクションへのマッピングができます。</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">管理者</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">コミュニティ: {0} の編集</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">なし</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">設定されたグループ</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">役割</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>（システム管理者のみ）</nobr></message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.title">コミュニティの役割の編集</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">役割</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.label_name">タスク</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.main_head">コミュニティ: {0} の管理作業</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.title">コミュニティの管理</message>
-	<message key="xmlui.administrative.community.CurateCommunityForm.trail">管理作業</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">役割 {0} の削除の確認</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">グループ {0} に行ったすべての変更･カスタマイズが失われますが、この役割を本当に削除しても良いですか。</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">削除の確認</message>
-	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">確認</message>
-	<message key="xmlui.administrative.community.general.community_trail">コミュニティ</message>
-	<message key="xmlui.administrative.community.general.options_curate">管理作業</message>
-	<message key="xmlui.administrative.community.general.options_metadata">メタデータの編集</message>
-	<message key="xmlui.administrative.community.general.options_queue">キュー</message>
-	<message key="xmlui.administrative.community.general.options_roles">役割の付与</message>
-	<message key="xmlui.administrative.group.EditGroupForm.community_para">このグループは次のコミュニティと関係しています: </message>
-	<message key="xmlui.administrative.item.CurateItemForm.label_name">タスク</message>
-	<message key="xmlui.administrative.item.CurateItemForm.main_head">アイテム: {0} の管理作業</message>
-	<message key="xmlui.administrative.item.CurateItemForm.title">アイテムの管理</message>
-	<message key="xmlui.administrative.item.CurateItemForm.trail">管理作業</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">（コレクション管理者のみ）</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">アイテムの所有コレクションの移動</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">（この作業を行う権限がありません）</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">移動...</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection">コレクション</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_default">コレクションの選択...</message>
-	<message key="xmlui.administrative.item.MoveItemForm.collection_help">移動先のコレクションを選択してください。</message>
-	<message key="xmlui.administrative.item.MoveItemForm.head1">アイテム: {0} の移動</message>
-	<message key="xmlui.administrative.item.MoveItemForm.inherit_policies">ポリシーの継承</message>
-	<message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">移動先コレクションのデフォルトポリシーを継承する</message>
-	<message key="xmlui.administrative.item.MoveItemForm.submit_move">移動</message>
-	<message key="xmlui.administrative.item.MoveItemForm.title">移動</message>
-	<message key="xmlui.administrative.item.MoveItemForm.trail">移動</message>
-	<message key="xmlui.administrative.item.general.option_curate">管理作業</message>
-	<message key="xmlui.administrative.item.general.option_queue">キュー</message>
-	<message key="xmlui.administrative.item.general.template_head">コレクション: {0} のテンプレートアイテムの編集</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">変更適用アイテム</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">新規マッピングコレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">新所有コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">旧所有コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">マッピング解除コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">追加: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">削除: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">処理が終了しました</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">CSVのアップロード</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">ペンディング中の変更</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">新規マッピングコレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">新所有コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">旧所有コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">マッピング解除コレクション</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">ペンディングされた変更は次の通りです。</message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">追加: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">削除: </message>
-	<message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">変更の適用</message>
-	<message key="xmlui.administrative.metadataimport.flow.import_failed">インポート失敗</message>
-	<message key="xmlui.administrative.metadataimport.flow.import_successful">インポート成功</message>
-	<message key="xmlui.administrative.metadataimport.flow.over_limit">変更件数が上限を超えました。ファイルを分割するか、dspace.cfg の "bulkedit.gui-item-limit" を変更してください。</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_badelement">見出し行に不明なメタデータ要素があります</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_badschema">見出し行に不明なスキーマがあります</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_failed">アップロード失敗</message>
-	<message key="xmlui.administrative.metadataimport.flow.upload_successful">アップロード成功</message>
-	<message key="xmlui.administrative.metadataimport.general.changes">変更</message>
-	<message key="xmlui.administrative.metadataimport.general.head1">メタデータのインポート</message>
-	<message key="xmlui.administrative.metadataimport.general.new_item">新アイテム</message>
-	<message key="xmlui.administrative.metadataimport.general.no_changes">変更が見つかりませんでした</message>
-	<message key="xmlui.administrative.metadataimport.general.title">メタデータのインポート</message>
-	<message key="xmlui.administrative.metadataimport.general.trail">メタデータのインポート</message>
-	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">このフォーマットに関するMIMEタイプは一意である必要はありません。</message>
-	<message key="xmlui.authority.confidence.description.cf_accepted">ユーザにより確認済み</message>
-	<message key="xmlui.authority.confidence.description.cf_ambiguous">同値の典拠データが複数存在</message>
-	<message key="xmlui.authority.confidence.description.cf_failed">内部エラーが発生</message>
-	<message key="xmlui.authority.confidence.description.cf_notfound">マッチする典拠データなし</message>
-	<message key="xmlui.authority.confidence.description.cf_novalue">適当な典拠データなし</message>
-	<message key="xmlui.authority.confidence.description.cf_rejected">使用しないことを推奨</message>
-	<message key="xmlui.authority.confidence.description.cf_uncertain">ユーザによる確認が必要</message>
-	<message key="xmlui.authority.confidence.description.cf_unset">典拠値が記録されていない</message>
-	<message key="xmlui.authority.confidence.unlock.help">編集のために典拠値をアンロックする。アンロックされている場合はロックする。</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">記述</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">名前</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/marc">MARCレコード</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/octet-stream">不明</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-	<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-	<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/gif">GIF image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/jp2">JPEG 2000 image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/jpeg">JPEG image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/png">PNG image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/tiff">TIFF image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP image</message>
-	<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/css">CSSファイル</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/csv">CSVファイル</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/plain">テキストファイル</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/richtext">RTF file</message>
-	<message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/avi">AVI video</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 video</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG video</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
-	<message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime video</message>
-	<message key="xmlui.general.perform">実行</message>
-	<message key="xmlui.general.queue">キュー</message>
-	<message key="xmlui.statistics.Navigation.title">統計</message>
-	<message key="xmlui.statistics.Navigation.view">閲覧統計</message>
-	<message key="xmlui.statistics.title">統計</message>
-	<message key="xmlui.statistics.trail">統計</message>
-	<message key="xmlui.statistics.visits.bitstreams">ファイルダウンロード数</message>
-	<message key="xmlui.statistics.visits.cities">都市別閲覧数</message>
-	<message key="xmlui.statistics.visits.countries">国別閲覧数</message>
-	<message key="xmlui.statistics.visits.month">月別閲覧数</message>
-	<message key="xmlui.statistics.visits.total">総閲覧数</message>
-	<message key="xmlui.statistics.visits.views">件数</message>
-	<message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">別の管理者としてログインすることはできません。</message>
-	<message key="xmlui.utils.AuthenticationUtil.onlyAdmins">サイト管理者だけが別のユーザとしてログインすることができます。</message>
-	<message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">管理者権限を持つユーザだけが別のユーザとしてログインできます。</message>
+  <!--###### File Format MIME Type Mappings ######-->
 
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">MARCレコード</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">不明</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">GIF image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">JPEG 2000 image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">JPEG image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">PNG image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">TIFF image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP image</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">CSSファイル</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">CSVファイル</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">テキストファイル</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">RTF file</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">AVI video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">MPEG video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime video</message>
+
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">典拠値が記録されていない</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">適当な典拠データなし</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">使用しないことを推奨</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">内部エラーが発生</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">マッチする典拠データなし</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">同値の典拠データが複数存在</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">ユーザによる確認が必要</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">ユーザにより確認済み</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">編集のために典拠値をアンロックする。アンロックされている場合はロックする。</message>
+
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
+    -->
+  <message key="xmlui.ChoiceLookupTransformer.title">DSpace入力値の検索</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">この値を使用</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">追加</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">キャンセル</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">次ページ</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">"@4@"の結果: @1@ - @2@ / @3@</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">選択データのロードに失敗しました: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
+
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">出版者名</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">出版者の検索</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">非典拠値: @1@</message>
+
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">"姓, 名" 形式の名前</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">姓、たとえば "山田"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">名、 たとえば "太郎"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC著者名典拠検索</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">DSpace入力値 '@1@'</message>
+
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_pl.xml
+++ b/src/main/webapp/i18n/messages_pl.xml
@@ -1,134 +1,124 @@
-<?xml version="1.0"?>
-<!--
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
+	<!--
+		The format used by all keys is as follows
 
-    http://www.dspace.org/license/
+		xmlui.<Aspect>.<Java Class>.<name>
 
--->
-<!--
-    Translation Kamil Gałuszka
-    Translation Mateusz Neumann &lt;M.Neumann@icm.edu.pl&gt;
--->
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
+		   because they are used very frequently.
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
 
-<catalogue xml:lang="pl" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+	<!-- General keys -->
+	<message key="xmlui.general.dspace_home">Strona główna DSpace</message>
+	<message key="xmlui.general.search">Szukaj</message>
+	<message key="xmlui.general.go">Idź</message>
+	<message key="xmlui.general.go_home">Przejdź do strony głównej DSpace</message>
+	<message key="xmlui.general.save">Zapisz</message>
+	<message key="xmlui.general.cancel">Anuluj</message>
+	<message key="xmlui.general.return">Powróć</message>
+	<message key="xmlui.general.update">Aktualizuj</message>
+	<message key="xmlui.general.delete">Skasuj</message>
+	<message key="xmlui.general.next">Dalej</message>
+	<message key="xmlui.general.untitled">Bez tytułu</message>
+        <message key="xmlui.general.perform">Wykonaj</message>
+        <message key="xmlui.general.queue">Do kolejki</message>
 
-    <!--
-        The format used by all keys is as follows
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
-        xmlui.<Aspect>.<Java Class>.<name>
+	<!--
+		Page not found keys
 
-        There are a few exceptions to this naming format,
-        1) Some general keys are in the xmlui.general namespace
-           because they are used very frequently.
-        2) Some general keys which are specific to a particular aspect
-           may be found at xmlui.<Aspect> without specifying a
-           particular java class.
-        -->
-
-    <!-- General keys -->
-    <message key="xmlui.general.dspace_home">Strona główna DSpace</message>
-    <message key="xmlui.general.search">Szukaj</message>
-    <message key="xmlui.general.go">Idź</message>
-    <message key="xmlui.general.go_home">Przejdź do strony głównej DSpace</message>
-    <message key="xmlui.general.save">Zapisz</message>
-    <message key="xmlui.general.cancel">Anuluj</message>
-    <message key="xmlui.general.return">Powróć</message>
-    <message key="xmlui.general.update">Aktualizuj</message>
-    <message key="xmlui.general.delete">Skasuj</message>
-    <message key="xmlui.general.next">Dalej</message>
-    <message key="xmlui.general.untitled">Bez tytułu</message>
-    <message key="xmlui.general.perform">Wykonaj</message>
-    <message key="xmlui.general.queue">Do kolejki</message>
-
-    <!--
-        Page not found keys
-
-        This is a special component that is not part of any aspect but is added
-        by manakin to all aspect chains.
-        -->
-    <message key="xmlui.PageNotFound.title">Strona nie znaleziona</message>
-    <message key="xmlui.PageNotFound.head">Strona nie znaleziona</message>
-    <message key="xmlui.PageNotFound.para1">Nie można znaleźć żądanej strony.</message>
+		This is a special component that is not part of any aspect but is added
+		by manakin to all aspect chains.
+		-->
+	<message key="xmlui.PageNotFound.title">Strona nie znaleziona</message>
+	<message key="xmlui.PageNotFound.head">Strona nie znaleziona</message>
+	<message key="xmlui.PageNotFound.para1">Nie można znaleźć żądanej strony.</message>
 
 
-    <!--
-       The "utils" non-aspect
+	<!--
+	   The "utils" non-aspect
        -->
     <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Tylko administratorzy mogą logować się jako inni użytkownicy.</message>
     <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Jedynie zalogowani administratorzy mogą zalogować się jako inny użytkownik.</message>
     <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Nie możesz zalogować się jako inny administrator.</message>
 
 
-    <!--
-        This section is for feed syndications (RSS, atom, etc)
-    -->
-    <message key="xmlui.feed.general_description">Repozytorium cyfrowe DSpace zapisuje, przechowuje, indeksuje i udostępnia cyfrowe materiały.</message>
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
+	-->
+	<message key="xmlui.feed.general_description">Repozytorium cyfrowe DSpace zapisuje, przechowuje, indeksuje i udostępnia cyfrowe materiały.</message>
     <message key="xmlui.feed.header">RSS Feeds</message>
-    <message key="xmlui.feed.logo_title">Obrazek kanału</message>
-    <message key="xmlui.feed.untitled">Bez tytułu</message>
+	<message key="xmlui.feed.logo_title">Obrazek kanału</message>
+	<message key="xmlui.feed.untitled">Bez tytułu</message>
 
-    <!--
-        Default notice header
-        -->
-    <message key="xmlui.general.notice.default_head">Informacja</message>
-
-
-
-    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-                     ArtifactBrowser Aspect
-
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+	<!--
+		Default notice header
+	 	-->
+	<message key="xmlui.general.notice.default_head">Informacja</message>
 
 
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		             ArtifactBrowser Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
 
 
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Wyniki wyszukiwania dla zbioru: {0}</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Wyniki wyszukiwania dla kolekcji: {0}</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Wyniki wyszukiwania</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Twoje zapytanie "{0}" zwróciło {1} wynik(ów).</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Zbiór lub kolekcję zgodne z Twoim zapytaniem</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Pozycje pasujące do twojego zapytania</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Wyszukiwanie nie dało żadnych wyników.</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Całe DSpace</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">tytuł</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data wydania</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data dodania</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">istotność</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Sortuj pozycje według</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order">w porządku</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">rosnącym</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">malejącym</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Wyników na stronie</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Wyniki wyszukiwania dla zbioru: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Wyniki wyszukiwania dla kolekcji: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Wyniki wyszukiwania</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Twoje zapytanie "{0}" zwróciło {1} wynik(ów).</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Zbiór lub kolekcję zgodne z Twoim zapytaniem</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Pozycje pasujące do twojego zapytania</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Wyszukiwanie nie dało żadnych wyników.</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Całe DSpace</message>
+
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">tytuł</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data wydania</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data dodania</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">istotność</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Sortuj pozycje według</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">w porządku</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">rosnącym</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">malejącym</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Wyników na stronie</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Szukanie zaawansowane</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Szukanie zaawansowane</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Szukanie zaawansowane</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Zakres przeszukiwania</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Ogranicz Twoje wyszukiwanie do zbioru lub kolekcji.</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Powiązanie</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Typ szukania</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Szukaj</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Tytuł</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Temat</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Streszczenie</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Seria</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Instytucja finansująca badania</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identyfikator</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Język (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Słowo kluczowe</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Szukanie zaawansowane</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Szukanie zaawansowane</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Szukanie zaawansowane</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Zakres przeszukiwania</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Ogranicz Twoje wyszukiwanie do zbioru lub kolekcji.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Powiązanie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Typ szukania</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Szukaj</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Autor</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Tytuł</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Temat</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Streszczenie</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Seria</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Instytucja finansująca badania</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Identyfikator</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Język (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Słowo kluczowe</message>
 
-   <!--     some common other possibilities for Advanced Search Fields -->
+   <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Współpracownik</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Twórca</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Opis</message>
@@ -144,163 +134,180 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NIE</message>
 
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Lub dodaj kilka pierwszych liter:</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Przeglądaj pozycje, które zaczynają się tymi literami</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Przeskocz do punktu w indeksie:</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Wybierz miesiąc)</message>    
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Wybierz rok)</message>    
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Lub podaj w roku: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Przeglądaj pozycje, które pochodzą z podanego roku.</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Sortuj według: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Kolejność: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Wyniki: </message><!-- /Page -->
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Autorzy/Pozycja: </message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Nie ma niestety pozycji dla takich parametrów przeglądania.</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Lub dodaj kilka pierwszych liter:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Przeglądaj pozycje, które zaczynają się tymi literami</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Przeskocz do punktu w indeksie:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Wybierz miesiąc)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Wybierz rok)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Lub podaj w roku: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Przeglądaj pozycje, które pochodzą z podanego roku.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Nie ma niestety pozycji dla takich parametrów przeglądania.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Sortuj według: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Kolejność: </message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Wyniki: </message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Autorzy/Pozycja: </message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Wszystko</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Wszystko</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">tytuł</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data wydania</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data dodania</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">tytuł</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">data wydania</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">data dodania</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">rosnąco</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">malejąco</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">rosnąco</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">malejąco</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Autor</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Temat</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">Autor</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">Temat</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Przeglądaj {0} według autora {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Przeglądaj {0} według autora</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Przeglądaj {0} według autora {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Przeglądaj {0} według autora</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Przeglądaj {0} według tematu {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Przeglądaj {0} według tematu</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Przeglądaj {0} według tematu {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Przeglądaj {0} według tematu</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Przeglądaj {0} według tytułu {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Przeglądaj {0} według tytułu</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Przeglądaj {0} według tytułu {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Przeglądaj {0} według tytułu</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Przeglądaj {0} według daty wydania {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Przeglądaj {0} według daty wydania</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Przeglądaj {0} według daty wydania {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Przeglądaj {0} według daty wydania</message>
 
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Przeglądaj {0} według daty dodania {1}</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Przeglądaj {0} według daty dodania</message>
-
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Zakres przeszukiwania</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Całe DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Szukaj w tej kolekcji:</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Przeglądaj według</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Tytułu</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autorstwa</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Daty</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Szukanie zaawansowane</message>
-    <message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Najnowsze pozycje</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Lista zbiorów</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Lista zbiorów</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Zbiory w DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Wybierz zbiór, którego kolekcje chcesz przeglądać.</message>
-
-    <!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Zakres wyszukiwania</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Wszystko z DSpace</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Szukaj w tym zbiorze i jego kolekcjach:</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Przeglądaj według</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Tytułu</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autorstwa</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Daty</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Szukanie zaawansowane</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Podzbiory w tym zbiorze</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Kolekcje w tym zbiorze</message>
-    <message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Najnowsze pozycje</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Przeglądaj {0} według daty dodania {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Przeglądaj {0} według daty dodania</message>
 
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-    <message key="xmlui.ArtifactBrowser.Contact.title">Kontakt z nami</message>
-    <message key="xmlui.ArtifactBrowser.Contact.trail">Kontakt z nami</message>
-    <message key="xmlui.ArtifactBrowser.Contact.head">Kontakt z nami</message>
-    <message key="xmlui.ArtifactBrowser.Contact.para1">{0} z administatorami można się skontaktować:</message>
-    <message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formularz on-line</message>
-    <message key="xmlui.ArtifactBrowser.Contact.feedback_link">Opinia</message>
-    <message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.title">Kontakt</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Kontakt</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.head">Kontakt</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Dziękujemy za podzielenie się Twoją opinią na temat systemu DSpace. Twoje komentarze są mile widziane!</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.email">Twój email</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Ten adres zostanie użyty do kontaktu.</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Wiadomość</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Wyślij</message>
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.title">Kontakt</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Kontakt</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.head">Wiadomość wysłana</message>
-    <message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Otrzymaliśmy Twoją wiadomość.</message>
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-    <message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Przeszukaj DSpace</message>
-    <message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">W formularzu poniżej wpisz tekst, którego chcesz szukać w DSpace.</message>
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-    <message key="xmlui.ArtifactBrowser.ItemViewer.trail">Zobacz pozycję</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Pozycja umieszczona jest w następujących kolekcjach</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Pokaż uproszczony rekord</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Pokaż pełny rekord</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Pozycja została wycofana i nie jest już dostępna.</message>
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-    <message key="xmlui.ArtifactBrowser.Navigation.head_browse">Przeglądaj</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Całe DSpace</message>                
-    <message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Zbiory i kolekcje </message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_title">Tytuły</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autorzy</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Tematy</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Daty wydania</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Data dodania</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Ta kolekcja</message>
-    <message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Ten zbiór</message>
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.title">Szukaj</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Szukaj</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.head">Szukaj</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Zakres przeszukiwania</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Wyszukiwanie pełnotekstowe</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Zakres przeszukiwania</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Całe DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Szukaj w tej kolekcji:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Przeglądaj według</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Tytułu</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Autorstwa</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Daty</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Szukanie zaawansowane</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Najnowsze pozycje</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.title">Ten zasób jest zastrzeżony</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Zastrzeżony</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Ten zasób jest zastrzeżony</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Ten zbiór jest zastrzeżony</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Ta kolekcja jest zastrzeżona</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Ta pozycja jest zastrzeżona</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Ten plik jest zastrzeżony</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Brak uprawnień dostępu do zastrzeżonego zasobu.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Brak uprawnień dostępu do zastrzeżonego zbioru <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Brak uprawnień dostępu do zastrzeżonej kolekcji <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Brak uprawnień dostępu do zastrzeżonej pozycji <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Brak uprawnień dostępu do zastrzeżonego pliku <b>{0}</b>.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">kolekcja</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">zbiór</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">plik</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">pozycja</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">zasób</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">nieznany</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Przejdź do ekranu logowania</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Lista zbiorów</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Lista zbiorów</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Zbiory w DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Wybierz zbiór, którego kolekcje chcesz przeglądać.</message>
 
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Ta pozycja została wycofana</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Wybrana pozycja została wycofana i nie jest już dostępna.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Wybrana pozycja ma ograniczenia w dostępie do przeglądania.     Zaloguj się proszę aby uzyskać dostęp.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Nie masz wystarczających uprawnień aby przeglądać tę pozycję.  W przypadku wątpliwości, skontaktuj się z administratorem.</message>
+	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Zakres wyszukiwania</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Wszystko z DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Szukaj w tym zbiorze i jego kolekcjach:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Przeglądaj według</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Tytułu</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Autorstwa</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Daty</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Szukanie zaawansowane</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Podzbiory w tym zbiorze</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Kolekcje w tym zbiorze</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Najnowsze pozycje</message>
 
-    <!-- Authentication messages used at the top of the login page:     -->
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Pozycja jest zastrzeżona</message>    
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Pozycja, do której próbujesz uzyskać dostęp, jest zastrzeżona i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
+	<message key="xmlui.ArtifactBrowser.Contact.title">Kontakt z nami</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Kontakt z nami</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Kontakt z nami</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">{0} z administatorami można się skontaktować:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">Formularz on-line</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Opinia</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Kontakt</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Kontakt</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Kontakt</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Dziękujemy za podzielenie się Twoją opinią na temat systemu DSpace. Twoje komentarze są mile widziane!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Twój email</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Ten adres zostanie użyty do kontaktu.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Wiadomość</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Wyślij</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Kontakt</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Kontakt</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Wiadomość wysłana</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Otrzymaliśmy Twoją wiadomość.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Zobacz pozycję</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Pozycja umieszczona jest w następujących kolekcjach</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Pokaż uproszczony rekord</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Pokaż pełny rekord</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Pozycja została wycofana i nie jest już dostępna.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Przeglądaj</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Całe DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Zbiory i kolekcje </message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Tytuły</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Autorzy</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Tematy</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Daty wydania</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Data dodania</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Ta kolekcja</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Ten zbiór</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Szukaj</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Szukaj</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Szukaj</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Zakres przeszukiwania</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Wyszukiwanie pełnotekstowe</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Ten zasób jest zastrzeżony</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Zastrzeżony</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Ten zasób jest zastrzeżony</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Ten zbiór jest zastrzeżony</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Ta kolekcja jest zastrzeżona</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Ta pozycja jest zastrzeżona</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Ten plik jest zastrzeżony</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Brak uprawnień dostępu do zastrzeżonego zasobu.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">Brak uprawnień dostępu do zastrzeżonego zbioru <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">Brak uprawnień dostępu do zastrzeżonej kolekcji <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">Brak uprawnień dostępu do zastrzeżonej pozycji <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">Brak uprawnień dostępu do zastrzeżonego pliku <b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">kolekcja</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">zbiór</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">plik</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">pozycja</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">zasób</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">nieznany</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Przejdź do ekranu logowania</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Ta pozycja została wycofana</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Wybrana pozycja została wycofana i nie jest już dostępna.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Wybrana pozycja ma ograniczenia w dostępie do przeglądania.     Zaloguj się proszę aby uzyskać dostęp.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Nie masz wystarczających uprawnień aby przeglądać tę pozycję.  W przypadku wątpliwości, skontaktuj się z administratorem.</message>
+        
+	<!-- Authentication messages used at the top of the login page:  -->
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Pozycja jest zastrzeżona</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Pozycja, do której próbujesz uzyskać dostęp, jest zastrzeżona i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Raporty miesięczne</message>
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Statystyki</message>
@@ -309,350 +316,456 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Brak raportów dla tej usługi. Sprawdź później.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-    <message key="xmlui.BitstreamReader.auth_header">Plik jest zastrzeżony</message>    
-    <message key="xmlui.BitstreamReader.auth_message">Plik, do którego próbujesz uzyskać dostęp, jest zastrzeżony i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
+	<message key="xmlui.BitstreamReader.auth_header">Plik jest zastrzeżony</message>
+	<message key="xmlui.BitstreamReader.auth_message">Plik, do którego próbujesz uzyskać dostęp, jest zastrzeżony i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
 
-    <!-- Export Archive download messages -->
-    <message key="xmlui.ItemExportDownloadReader.auth_header">Archiwum eksportu jest zastrzeżone</message>
-    <message key="xmlui.ItemExportDownloadReader.auth_message">Archiwum eksportu, do którego próbujesz uzyskać dostęp jest zastrzeżone i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
-
-    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-                        EPerson Aspect
-
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+	<!-- Export Archive download messages -->
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Archiwum eksportu jest zastrzeżone</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">Archiwum eksportu, do którego próbujesz uzyskać dostęp jest zastrzeżone i wymaga uprawnień do oglądania. Aby uzyskać dostęp, zaloguj się poniżej.</message>
 
 
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                EPerson Aspect
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
 
 
 
-    <!-- General keys used by the EPerson aspect -->
-    <message key="xmlui.EPerson.trail_new_registration">Rejestracja nowego użytkownika</message>
-    <message key="xmlui.EPerson.trail_forgot_password">Zapomniałem hasła</message>
 
-    <!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-    <message key="xmlui.EPerson.CannotRegister.title">Rejestracja niedostępna</message>
-    <message key="xmlui.EPerson.CannotRegister.head">Rejestracja niedostępna</message>
-    <message key="xmlui.EPerson.CannotRegister.para1">Obecna konfiguracja DSpace nie pozwala na rejestrację . Skontaktuj się z <a href="../feedback">administratorem strony</a>.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-    <message key="xmlui.EPerson.EditProfile.title_update">Aktualizacja profilu</message>
-    <message key="xmlui.EPerson.EditProfile.title_create">Tworzenie profilu</message>
-    <message key="xmlui.EPerson.EditProfile.trail_update">Aktualizacja profilu</message>
-    <message key="xmlui.EPerson.EditProfile.head_update">Aktualizacja profilu</message>
-    <message key="xmlui.EPerson.EditProfile.head_create">Tworzenie profilu</message>
-    <message key="xmlui.EPerson.EditProfile.email_address">Adres email</message>
-    <message key="xmlui.EPerson.EditProfile.first_name">Imię</message>
-    <message key="xmlui.EPerson.EditProfile.last_name">Nazwisko</message>
-    <message key="xmlui.EPerson.EditProfile.telephone">Kontakt</message>
-    <message key="xmlui.EPerson.EditProfile.Language">Język</message>
-    <message key="xmlui.EPerson.EditProfile.subscriptions">Subskrybcja</message>
-    <message key="xmlui.EPerson.EditProfile.subscriptions_help">Możesz raz dziennie otrzymywać wiadomość e-mail z informacjami o nowych pozycjach w subskrybowanych kolekcjach. Możesz subskrybować tyle kolekcji, ile chcesz. Możesz też skorzystać z oferowanej dla wszystkich kolekcji funkcji RSS.</message>
-    <message key="xmlui.EPerson.EditProfile.email_subscriptions">Subskrybcje email</message>
-    <message key="xmlui.EPerson.EditProfile.select_collection">( Wybierz kolekcję )</message>
-    <message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcjonalnie możesz podać nowe hasło w formularzu i potwierdzić je, wpisując ponownie do drugiego formularza poniżej. Powinno ono mieć co najmniej 6 znaków.</message>
-    <message key="xmlui.EPerson.EditProfile.create_password_instructions">Podaj nowe hasło w formularzu i potwierdź je przez ponowne wpisanie do drugiego formularza poniżej. Hasło powinno mieć co najmniej 6 znaków.</message>
-    <message key="xmlui.EPerson.EditProfile.password">Hasło</message>
-    <message key="xmlui.EPerson.EditProfile.confirm_password">Powtórz hasło</message>
-    <message key="xmlui.EPerson.EditProfile.submit_update">Zakończ rejestrację</message>
-    <message key="xmlui.EPerson.EditProfile.submit_create">Aktualizuj profil</message>
-    <message key="xmlui.EPerson.EditProfile.error_required">To pole jest wymagane</message>
-    <message key="xmlui.EPerson.EditProfile.error_invalid_password">Wybierz hasło składające się z co najmniej 6 znaków</message>
-    <message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Wpisz ponownie hasło, aby je potwierdzić.</message>
-    <message key="xmlui.EPerson.EditProfile.head_auth">Grupy autoryzacyjne do których należysz:</message>
-    <message key="xmlui.EPerson.EditProfile.head_identify">Identyfikacja</message>
-    <message key="xmlui.EPerson.EditProfile.head_security">Bezpieczeństwo</message>
-    
-    <!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-    <message key="xmlui.EPerson.EPersonUtils.register_verify_email">Zweryfikuj email</message>
-    <message key="xmlui.EPerson.EPersonUtils.register_create_profile">Utwórz profil</message>
-    <message key="xmlui.EPerson.EPersonUtils.register_finished">Zakończona</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Zweryfikuj email</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Zresetuj hasło</message>
-    <message key="xmlui.EPerson.EPersonUtils.forgot_finished">Zakończone</message>
+	<!-- General keys used by the EPerson aspect -->
+	<message key="xmlui.EPerson.trail_new_registration">Rejestracja nowego użytkownika</message>
+	<message key="xmlui.EPerson.trail_forgot_password">Zapomniałem hasła</message>
 
-    <!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-    <message key="xmlui.EPerson.ForgotPasswordFinished.title">Reset hasła</message>
-    <message key="xmlui.EPerson.ForgotPasswordFinished.head">Reset hasła</message>
-    <message key="xmlui.EPerson.ForgotPasswordFinished.para1">Twoje hasło zostało zresetowane.</message>
+	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
+	<message key="xmlui.EPerson.CannotRegister.title">Rejestracja niedostępna</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Rejestracja niedostępna</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Obecna konfiguracja DSpace nie pozwala na rejestrację . Skontaktuj się z <a href="../contact">site administrator</a> with questions or comments.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-    <message key="xmlui.EPerson.InvalidToken.title">Nieprawidłowy token</message>
-    <message key="xmlui.EPerson.InvalidToken.trail">Nieprawidłowy token</message>
-    <message key="xmlui.EPerson.InvalidToken.head">Nieprawidłowy token</message>
-    <message key="xmlui.EPerson.InvalidToken.para1">Podany adres URL jest niepoprawny. Być może URL został przerwany przez zapisanie go w wielu liniach wiadomości e-mail, np.:</message>
-    <message key="xmlui.EPerson.InvalidToken.para2">Jeśli tak się stało, skopiuj i wklej cały URL do paska adresowego przeglądarki.  Jest to metoda pewniejsza niż proste kliknięcie adresu w oknie programu obsługującego pocztę. Pasek adresowy przeglądarki powinien zawierać wówczas coś takiego:</message>
+	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
+	<message key="xmlui.EPerson.EditProfile.title_update">Aktualizacja profilu</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Tworzenie profilu</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Aktualizacja profilu</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Aktualizacja profilu</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Tworzenie profilu</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Adres email</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Imię</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Nazwisko</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Kontakt</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Język</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Subskrybcja</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Możesz raz dziennie otrzymywać wiadomość e-mail z informacjami o nowych pozycjach w subskrybowanych kolekcjach. Możesz subskrybować tyle kolekcji, ile chcesz. Możesz też skorzystać z oferowanej dla wszystkich kolekcji funkcji RSS.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Subskrybcje email</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">( Wybierz kolekcję )</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">Opcjonalnie możesz podać nowe hasło w formularzu i potwierdzić je, wpisując ponownie do drugiego formularza poniżej. Powinno ono mieć co najmniej 6 znaków.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Podaj nowe hasło w formularzu i potwierdź je przez ponowne wpisanie do drugiego formularza poniżej. Hasło powinno mieć co najmniej 6 znaków.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Hasło</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Powtórz hasło</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Zakończ rejestrację</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Aktualizuj profil</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">To pole jest wymagane</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Wybierz hasło składające się z co najmniej 6 znaków</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Wpisz ponownie hasło, aby je potwierdzić.</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Grupy autoryzacyjne do których należysz:</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Identyfikacja</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Bezpieczeństwo</message>
 
-    <!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-    <message key="xmlui.EPerson.Navigation.my_account">Moje konto</message>
-    <message key="xmlui.EPerson.Navigation.profile">Profil</message>
-    <message key="xmlui.EPerson.Navigation.logout">Wyloguj</message>
-    <message key="xmlui.EPerson.Navigation.login">Zaloguj</message>
-    <message key="xmlui.EPerson.Navigation.register">Zarejestruj</message>
+	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Zweryfikuj email</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Utwórz profil</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Zakończona</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Zweryfikuj email</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Zresetuj hasło</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Zakończone</message>
 
-    <!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-    <message key="xmlui.EPerson.PasswordLogin.title">Logowanie</message>
-    <message key="xmlui.EPerson.PasswordLogin.trail">Zaloguj</message>
-    <message key="xmlui.EPerson.PasswordLogin.head1">Logowanie do DSpace</message>
-    <message key="xmlui.EPerson.PasswordLogin.email_address">Adres email</message>
-    <message key="xmlui.EPerson.PasswordLogin.error_bad_login">Podany adres email i/lub hasło nie są prawidłowe.</message>
-    <message key="xmlui.EPerson.PasswordLogin.password">Hasło</message>
-    <message key="xmlui.EPerson.PasswordLogin.forgot_link">Zapomniałeś hasła?</message>
-    <message key="xmlui.EPerson.PasswordLogin.submit">Zaloguj</message>
-    <message key="xmlui.EPerson.PasswordLogin.head2">Rejestracja nowego użytkownika</message>
-    <message key="xmlui.EPerson.PasswordLogin.para1">Utwórz konto, aby dodawać nowe pozycje do DSpace i subskrybować aktualizacje kolekcji.</message>
-    <message key="xmlui.EPerson.PasswordLogin.register_link">Kliknij tutaj, aby zarejestrować.</message>
+	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Reset hasła</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Reset hasła</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Twoje hasło zostało zresetowane.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-    <message key="xmlui.EPerson.LDAPLogin.title">Logowanie</message>
-    <message key="xmlui.EPerson.LDAPLogin.trail">Zaloguj</message>
-    <message key="xmlui.EPerson.LDAPLogin.head1">Logowanie do DSpace</message>
-    <message key="xmlui.EPerson.LDAPLogin.username">Nazwa użytkownika</message>
-    <message key="xmlui.EPerson.LDAPLogin.error_bad_login">Podana nazwa użytkownika i/lub hasło nie są prawidłowe.</message>
-    <message key="xmlui.EPerson.LDAPLogin.password">Hasło</message>
-    <message key="xmlui.EPerson.LDAPLogin.submit">Zaloguj</message>
+	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
+	<message key="xmlui.EPerson.InvalidToken.title">Nieprawidłowy token</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Nieprawidłowy token</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Nieprawidłowy token</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">Podany adres URL jest niepoprawny. Być może URL został przerwany przez zapisanie go w wielu liniach wiadomości e-mail, np.:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Jeśli tak się stało, skopiuj i wklej cały URL do paska adresowego przeglądarki.  Jest to metoda pewniejsza niż proste kliknięcie adresu w oknie programu obsługującego pocztę. Pasek adresowy przeglądarki powinien zawierać wówczas coś takiego:</message>
 
-    <!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-    <message key="xmlui.EPerson.LoginChooser.title">Wybierz metodę logowania</message>
-    <message key="xmlui.EPerson.LoginChooser.trail">Wybierz login</message>
-    <message key="xmlui.EPerson.LoginChooser.head1">Wybierz metodę logowania</message>
-    <message key="xmlui.EPerson.LoginChooser.para1">Zaloguj się używając:</message>
-    <message key="org.dspace.authenticate.ShibAuthentication.title">Uwierzytelniania Shibboleth</message>
-    <message key="org.dspace.eperson.LDAPAuthentication.title">Uwierzytelniania LDAP</message>
-    <message key="org.dspace.eperson.PasswordAuthentication.title">Uwierzytelniania hasłem</message>
-    <message key="org.dspace.eperson.X509Authentication.title">Uwierzytelniania certyfikatem</message>
+	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
+	<message key="xmlui.EPerson.Navigation.my_account">Moje konto</message>
+	<message key="xmlui.EPerson.Navigation.profile">Profil</message>
+	<message key="xmlui.EPerson.Navigation.logout">Wyloguj</message>
+	<message key="xmlui.EPerson.Navigation.login">Zaloguj</message>
+	<message key="xmlui.EPerson.Navigation.register">Zarejestruj</message>
 
-    <!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-    <message key="xmlui.EPerson.FailedAuthentication.BadCreds">Błędna nazwa użytkownika i/lub hasło.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.BadArgs">Błędne argumenty funkcji potwierdzającej tożsamość, operacja nie powiodła się.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Nieznany użytkownik o podanej nazwie.</message>
-    <message key="xmlui.EPerson.FailedAuthentication.title">Sprawdzanie tożsamości nie powiodło się</message>
+	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
+	<message key="xmlui.EPerson.PasswordLogin.title">Logowanie</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Zaloguj</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Logowanie do DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Adres email</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Podany adres email i/lub hasło nie są prawidłowe.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Hasło</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">Zapomniałeś hasła?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Zaloguj</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Rejestracja nowego użytkownika</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Utwórz konto, aby dodawać nowe pozycje do DSpace i subskrybować aktualizacje kolekcji.</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Kliknij tutaj, aby zarejestrować.</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
+	<message key="xmlui.EPerson.LDAPLogin.title">Logowanie</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Zaloguj</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Logowanie do DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Nazwa użytkownika</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Podana nazwa użytkownika i/lub hasło nie są prawidłowe.</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Hasło</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Zaloguj</message>
+
+	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
+	<message key="xmlui.EPerson.LoginChooser.title">Wybierz metodę logowania</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Wybierz login</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Wybierz metodę logowania</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Zaloguj się używając:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Uwierzytelniania Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Uwierzytelniania LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Uwierzytelniania hasłem</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Uwierzytelniania certyfikatem</message>
+
+	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Błędna nazwa użytkownika i/lub hasło.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Błędne argumenty funkcji potwierdzającej tożsamość, operacja nie powiodła się.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">Nieznany użytkownik o podanej nazwie.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Sprawdzanie tożsamości nie powiodło się</message>
     <message key="xmlui.EPerson.FailedAuthentication.trail">Nie powiodło się sprawdzenie tożsamości użytkownika</message>
     <message key="xmlui.EPerson.FailedAuthentication.h1">Sprawdzanie tożsamości nie powiodło się</message>
 
-    <!-- Login xml files -->
-    <message key="xmlui.eperson.noAuthMethod.head">Nieznana metoda uwierzytelniania</message>
-    <message key="xmlui.eperson.noAuthMethod.p1">Nie znaleziono żadnej zdefiniowanej metody uwierzytelniania. Skontaktuj się z administratorem strony.</message>
-    <message key="xmlui.eperson.shibbLoginFailure.head">Nie powiodło się logowanie Shibboleth</message>
-    <message key="xmlui.eperson.shibbLoginFailure.p1">Uwierzytelnianie Shibboleth jest w tej chwili niedostępne. Skontaktuj się z administratorem strony.</message>
+	<!-- Login xml files -->
+	<message key="xmlui.eperson.noAuthMethod.head">Nieznana metoda uwierzytelniania</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">Nie znaleziono żadnej zdefiniowanej metody uwierzytelniania. Skontaktuj się z administratorem strony.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">Nie powiodło się logowanie Shibboleth</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">Uwierzytelnianie Shibboleth jest w tej chwili niedostępne. Skontaktuj się z administratorem strony.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-    <message key="xmlui.EPerson.ProfileUpdated.title">Profil zaktualizowany</message>
-    <message key="xmlui.EPerson.ProfileUpdated.trail">Aktualizacja Profilu</message>
-    <message key="xmlui.EPerson.ProfileUpdated.head">Profil zaktualizowany</message>
-    <message key="xmlui.EPerson.ProfileUpdated.para1">Informacje w Twoim profilu zostały zaktualizowane.</message>
+	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
+	<message key="xmlui.EPerson.ProfileUpdated.title">Profil zaktualizowany</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Aktualizacja Profilu</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Profil zaktualizowany</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">Informacje w Twoim profilu zostały zaktualizowane.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-    <message key="xmlui.EPerson.RegistrationFinished.title">Rejestracja zakończona</message>
-    <message key="xmlui.EPerson.RegistrationFinished.head">Rejestracja zakończona</message>
-    <message key="xmlui.EPerson.RegistrationFinished.para1">Jesteś zarejestrowanym użytkownikem DSpace.     Możesz subskrybować kolekcje, aby otrzymywać informacje o nowych pozycjach.</message>
+	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
+	<message key="xmlui.EPerson.RegistrationFinished.title">Rejestracja zakończona</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Rejestracja zakończona</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Jesteś zarejestrowanym użytkownikem DSpace.     Możesz subskrybować kolekcje, aby otrzymywać informacje o nowych pozycjach.</message>
 
-    <!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-    <message key="xmlui.EPerson.ResetPassword.title">Reset hasła</message>
-    <message key="xmlui.EPerson.ResetPassword.head">Reset hasła</message>
-    <message key="xmlui.EPerson.ResetPassword.para1">Podaj nowe hasło w formularzu i potwierdź je przez ponowne wpisanie do drugiego formularza poniżej. Hasło powinno mieć co najmniej 6 znaków.</message>
-    <message key="xmlui.EPerson.ResetPassword.email_address">Adres email</message>
-    <message key="xmlui.EPerson.ResetPassword.new_password">Nowe hasło</message>
-    <message key="xmlui.EPerson.ResetPassword.confirm_password">Wpisz ponownie, aby potwierdzić</message>
-    <message key="xmlui.EPerson.ResetPassword.submit">Reset hasła</message>
-    <message key="xmlui.EPerson.ResetPassword.error_invalid_password">Wybierz hasło złożone z co najmniej sześciu znaków</message>
-    <message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Powtórz hasło, aby je potwierdzić</message>
+	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
+	<message key="xmlui.EPerson.ResetPassword.title">Reset hasła</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Reset hasła</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Podaj nowe hasło w formularzu i potwierdź je przez ponowne wpisanie do drugiego formularza poniżej. Hasło powinno mieć co najmniej 6 znaków.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Adres email</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Nowe hasło</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Wpisz ponownie, aby potwierdzić</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Reset hasła</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Wybierz hasło złożone z co najmniej sześciu znaków</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Powtórz hasło, aby je potwierdzić</message>
 
-    <!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-    <message key="xmlui.EPerson.StartForgotPassword.title">Zapomniane hasło</message>
-    <message key="xmlui.EPerson.StartForgotPassword.head">Przypominanie hasła</message>
-    <message key="xmlui.EPerson.StartForgotPassword.para1">Wpisz adres email, który podałeś podczas rejestracji w DSpace. Na ten adres zostanie wysłany email z dalszymi instrukcjami.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.email_address">Adres email</message>
-    <message key="xmlui.EPerson.StartForgotPassword.email_address_help">Wpisz ten sam adres, którego użyłeś podczas rejestracji.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.error_not_found">Nie znaleziono adresu email.</message>
-    <message key="xmlui.EPerson.StartForgotPassword.submit">Wyślij informacje</message>
+	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
+	<message key="xmlui.EPerson.StartForgotPassword.title">Zapomniane hasło</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Przypominanie hasła</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Wpisz adres email, który podałeś podczas rejestracji w DSpace. Na ten adres zostanie wysłany email z dalszymi instrukcjami.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Adres email</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Wpisz ten sam adres, którego użyłeś podczas rejestracji.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Nie znaleziono adresu email.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Wyślij informacje</message>
 
-    <!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-    <message key="xmlui.EPerson.StartRegistration.title">Rejestracja nowego użytkownika</message>
-    <message key="xmlui.EPerson.StartRegistration.head1">Adres email jest już używany</message>
-    <message key="xmlui.EPerson.StartRegistration.para1">Ten adres email jest już powiązany z innym kontem. Jeżeli chcesz zresetować hasło dla tego konta, naciśnij przycisk "Zresetuj hasło".</message>
-    <message key="xmlui.EPerson.StartRegistration.reset_password_for">Zresetuj hasło dla</message>
-    <message key="xmlui.EPerson.StartRegistration.submit_reset">Zresetuj hasło</message>
-    <message key="xmlui.EPerson.StartRegistration.head2">Rejestracja nowego użytkownika</message>
-    <message key="xmlui.EPerson.StartRegistration.para2">Zarejestruj konto, aby dodawać nowe pozycje do DSpace, subskrybować kolekcje i otrzymywać emaile z aktualizacjami.</message>
-    <message key="xmlui.EPerson.StartRegistration.email_address">Adres email</message>
-    <message key="xmlui.EPerson.StartRegistration.email_address_help">Adres będzie sprawdzony i użyty jako nazwa dla Twojego konta.</message>
-    <message key="xmlui.EPerson.StartRegistration.error_bad_email">Nie można wysłać emaila na podany adres.</message>
-    <message key="xmlui.EPerson.StartRegistration.submit_register">Zarejestruj</message>
+	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
+	<message key="xmlui.EPerson.StartRegistration.title">Rejestracja nowego użytkownika</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Adres email jest już używany</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Ten adres email jest już powiązany z innym kontem. Jeżeli chcesz zresetować hasło dla tego konta, naciśnij przycisk "Zresetuj hasło".</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Zresetuj hasło dla</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Zresetuj hasło</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Rejestracja nowego użytkownika</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Zarejestruj konto, aby dodawać nowe pozycje do DSpace, subskrybować kolekcje i otrzymywać emaile z aktualizacjami.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Adres email</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">Adres będzie sprawdzony i użyty jako nazwa dla Twojego konta.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Nie można wysłać emaila na podany adres.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Zarejestruj</message>
 
-    <!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-    <message key="xmlui.EPerson.VerifyEmail.title">Wysłano email weryfikacyjny</message>
-    <message key="xmlui.EPerson.VerifyEmail.head">Wysłano email weryfikacyjny</message>
-    <message key="xmlui.EPerson.VerifyEmail.para">Email do {0} został wysłany, zawiera specjalny adres URL i kolejne instrukcje.</message>
-
-
-
-
-
-
-    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-                       Submission Aspect
-
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
+	<message key="xmlui.EPerson.VerifyEmail.title">Wysłano email weryfikacyjny</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Wysłano email weryfikacyjny</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">Email do {0} został wysłany, zawiera specjalny adres URL i kolejne instrukcje.</message>
 
 
 
 
 
 
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    <!-- general submission aspect messages -->
-    <message key="xmlui.Submission.general.mydspace_home">Moje DSpace strona główna</message>
-    <message key="xmlui.Submission.general.go_mydspace">Idź do Mojego DSpace strona główna</message>
-    <message key="xmlui.Submission.general.submission.title">Dodawanie pozycji</message>
-    <message key="xmlui.Submission.general.submission.trail">Dodawanie pozycji</message>
-    <message key="xmlui.Submission.general.submission.head">Dodawanie pozycji</message>    
-    <message key="xmlui.Submission.general.submission.previous">&lt; Poprzedni krok</message>
-    <message key="xmlui.Submission.general.submission.save">Zapisz i wyjdź</message>
-    <message key="xmlui.Submission.general.submission.next">Następny krok &gt;</message>
-    <message key="xmlui.Submission.general.submission.complete">Zdeponuj</message>
-    <message key="xmlui.Submission.general.workflow.title">Dodawanie pozycji</message>
-    <message key="xmlui.Submission.general.workflow.trail">Dodawanie pozycji</message>
-    <message key="xmlui.Submission.general.workflow.head">Dodawanie pozycji</message>
-    <message key="xmlui.Submission.general.showfull">Pokaż pełny rekord pozycji</message>
-    <message key="xmlui.Submission.general.showsimple">Pokaż prosty rekord pozycji</message>
-    <message key="xmlui.Submission.general.default.title">Dodawanie</message>
-    <message key="xmlui.Submission.general.default.trail">Dodawanie</message>
+		               Submission Aspect
 
-    <!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-    <message key="xmlui.Submission.CollectionViewer.link1">Dodaj nową pozycję do tej kolekcji</message>
-
-    <!-- org.dspace.app.xmlui.submission.Navigation -->
-    <message key="xmlui.Submission.Navigation.submissions">Dodane pozycje</message>
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
-    <!-- org.dspace.app.xmlui.Submission.submissions -->
-    <message key="xmlui.Submission.Submissions.title">Dodane pozycje i przepływ pracy</message>
-    <message key="xmlui.Submission.Submissions.trail">Dodane pozycje</message>
-    <message key="xmlui.Submission.Submissions.head">Dodane pozycje i zadania przepływu pracy</message>
-    <message key="xmlui.Submission.Submissions.untitled"><i>Bez tytułu</i></message>
-    <message key="xmlui.Submission.Submissions.email">email: </message>
-    <!-- Same transformer, workflow section -->
-    <message key="xmlui.Submission.Submissions.workflow_head1">Zadania przepływu pracy</message>
-    <message key="xmlui.Submission.Submissions.workflow_info1">Te zadania wymagają zatwierdzenie zanim zostaną zapisane w repozytorium. Dwie kolejki zadań poniżej to lista zadań oczekujących na Twoje działanie, druga - zadań oczekujących na działanie kogoś innego.</message>
-    <message key="xmlui.Submission.Submissions.workflow_head2">Twoje zadania</message>
-    <message key="xmlui.Submission.Submissions.workflow_column1"></message>
-    <message key="xmlui.Submission.Submissions.workflow_column2">Działanie</message>
-    <message key="xmlui.Submission.Submissions.workflow_column3">Pozycja</message>
-    <message key="xmlui.Submission.Submissions.workflow_column4">Kolekcja</message>
-    <message key="xmlui.Submission.Submissions.workflow_column5">Dodane przez</message>
-    <message key="xmlui.Submission.Submissions.workflow_submit_return">Zwróć wybrane zadania do puli</message>
-    <message key="xmlui.Submission.Submissions.workflow_info2">Żadne zadania nie są Tobie przypisane</message>
-    <message key="xmlui.Submission.Submissions.workflow_head3">Zadania w puli</message>
-    <message key="xmlui.Submission.Submissions.workflow_submit_take">Przypisz sobie zaznaczone zadania</message>
-    <message key="xmlui.Submission.Submissions.workflow_info3">Brak zadań w puli</message>
-    <!-- Same transformer, submissions section -->
-    <message key="xmlui.Submission.Submissions.submit_head1">Dodane pozycje</message>
-    <message key="xmlui.Submission.Submissions.submit_info1a">Możesz </message>
-    <message key="xmlui.Submission.Submissions.submit_info1b">dodać nową pozycję</message>
-    <message key="xmlui.Submission.Submissions.submit_info1c">Proces dodawania nowej pozycji składa się z opisania jej i przesłania składających się na nią plików. W ramach każdego zbioru lub kolekcja możliwe jest zdefiniowanie różnych reguł dodawania pozycji.</message>
-    <message key="xmlui.Submission.Submissions.submit_head2">Dodawanie nieukończone</message>
-    <message key="xmlui.Submission.Submissions.submit_info2a">Niektóre pozycje nie zostały dodane.  Możesz również </message>
-    <message key="xmlui.Submission.Submissions.submit_info2b">dodać inną pozycję</message>
-    <message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-    <message key="xmlui.Submission.Submissions.submit_column1"></message>
-    <message key="xmlui.Submission.Submissions.submit_column2">Tytuł</message>
-    <message key="xmlui.Submission.Submissions.submit_column3">Kolekcja</message>
-    <message key="xmlui.Submission.Submissions.submit_column4">Dodający</message>
-    <message key="xmlui.Submission.Submissions.submit_head3">Autorstwo:</message>
-    <message key="xmlui.Submission.Submissions.submit_info3">Brak pozycji, których dodawanie nie zostało ukończone.</message>
-    <message key="xmlui.Submission.Submissions.submit_head4">Nadzór:</message>
-    <message key="xmlui.Submission.Submissions.submit_submit_remove">Usuń zaznaczone dodane pozycje</message>
-    <!-- Same transformer, inprogress section -->
-    <message key="xmlui.Submission.Submissions.progress_head1">Sprawdzane dodane pozycje</message>
-    <message key="xmlui.Submission.Submissions.progress_info1">To są dodane przez Ciebie pozycje, które są obecnie przeglądane przez administratorów kolekcji.</message>
-    <message key="xmlui.Submission.Submissions.progress_column1">Tytuł</message>
-    <message key="xmlui.Submission.Submissions.progress_column2">Kolekcja</message>
-    <message key="xmlui.Submission.Submissions.progress_column3">Status</message>
-    <!-- Same transformer, workflow status -->
-    <message key="xmlui.Submission.Submissions.status_0">Dodane</message>
-    <message key="xmlui.Submission.Submissions.status_1">Oczekująca na recenzenta</message>
-    <message key="xmlui.Submission.Submissions.status_2">Pozycja przeglądana</message>
-    <message key="xmlui.Submission.Submissions.status_3">Oczekująca na redaktora</message>
-    <message key="xmlui.Submission.Submissions.status_4">Pozycja redagowana</message>
-    <message key="xmlui.Submission.Submissions.status_5">Oczekująca na ostateczną redakcję</message>
-    <message key="xmlui.Submission.Submissions.status_6">Pozycja redagowana</message>
-    <message key="xmlui.Submission.Submissions.status_7">Pozycja zarchiwizowana</message>
-    <message key="xmlui.Submission.Submissions.status_unknown">Nieznany status</message>
-    <!-- Same transformer, completed submissions section -->
-    <message key="xmlui.Submission.Submissions.completed.head">Zarchiwizowane pozycje</message>
-    <message key="xmlui.Submission.Submissions.completed.info">To są dodane przez Ciebie pozycje, które zostały zaakceptowane w DSpace.</message>
-    <message key="xmlui.Submission.Submissions.completed.column1">Data akceptacji</message>
-    <message key="xmlui.Submission.Submissions.completed.column2">Tytuł</message>
-    <message key="xmlui.Submission.Submissions.completed.column3">Kolekcja</message>
-    <message key="xmlui.Submission.Submissions.completed.limit">Powyżej wyświetlone jest tylko 50 dodanych przez Ciebie pozycji.</message>
-    <message key="xmlui.Submission.Submissions.completed.displayall">Pokaż wszystkie moje zarchiwizowane pozycje.</message>
 
-    <!-- submission progress bar messages -->
-    <message key="xmlui.Submission.submit.progressbar.initial-questions">Pytania początkowe</message>
-    <message key="xmlui.Submission.submit.progressbar.describe">Opisz</message>
+
+
+
+
+	<!-- general submission aspect messages -->
+	<message key="xmlui.Submission.general.mydspace_home">Moje DSpace strona główna</message>
+	<message key="xmlui.Submission.general.go_mydspace">Idź do Mojego DSpace strona główna</message>
+	<message key="xmlui.Submission.general.submission.title">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.submission.trail">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.submission.head">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Poprzedni krok</message>
+	<message key="xmlui.Submission.general.submission.save">Zapisz i wyjdź</message>
+	<message key="xmlui.Submission.general.submission.next">Następny krok &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Zdeponuj</message>
+	<message key="xmlui.Submission.general.workflow.title">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.workflow.trail">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.workflow.head">Dodawanie pozycji</message>
+	<message key="xmlui.Submission.general.showfull">Pokaż pełny rekord pozycji</message>
+	<message key="xmlui.Submission.general.showsimple">Pokaż prosty rekord pozycji</message>
+	<message key="xmlui.Submission.general.default.title">Dodawanie</message>
+	<message key="xmlui.Submission.general.default.trail">Dodawanie</message>
+
+	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
+	<message key="xmlui.Submission.CollectionViewer.link1">Dodaj nową pozycję do tej kolekcji</message>
+
+	<!-- org.dspace.app.xmlui.submission.Navigation -->
+	<message key="xmlui.Submission.Navigation.submissions">Dodane pozycje</message>
+
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Dodane pozycje i przepływ pracy</message>
+	<message key="xmlui.Submission.Submissions.trail">Dodane pozycje</message>
+	<message key="xmlui.Submission.Submissions.head">Dodane pozycje i zadania przepływu pracy</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">email: </message>
+	<!-- Same transformer, workflow section -->
+	<message key="xmlui.Submission.Submissions.workflow_head1">Zadania przepływu pracy</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Te zadania wymagają zatwierdzenie zanim zostaną zapisane w repozytorium. Dwie kolejki zadań poniżej to lista zadań oczekujących na Twoje działanie, druga - zadań oczekujących na działanie kogoś innego.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Twoje zadania</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Działanie</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Pozycja</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Kolekcja</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Dodane przez</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Zwróć wybrane zadania do puli</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">Żadne zadania nie są Tobie przypisane</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Zadania w puli</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Przypisz sobie zaznaczone zadania</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">Brak zadań w puli</message>
+	<!-- Same transformer, submissions section -->
+	<message key="xmlui.Submission.Submissions.submit_head1">Dodane pozycje</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Możesz </message>
+	<message key="xmlui.Submission.Submissions.submit_info1b">dodać nową pozycję</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">Proces dodawania nowej pozycji składa się z opisania jej i przesłania składających się na nią plików. W ramach każdego zbioru lub kolekcja możliwe jest zdefiniowanie różnych reguł dodawania pozycji.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Dodawanie nieukończone</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">Niektóre pozycje nie zostały dodane.  Możesz również </message>
+	<message key="xmlui.Submission.Submissions.submit_info2b">dodać inną pozycję</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Tytuł</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Kolekcja</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Dodający</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Autorstwo:</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">Brak pozycji, których dodawanie nie zostało ukończone.</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Nadzór:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Usuń zaznaczone dodane pozycje</message>
+	<!-- Same transformer, inprogress section -->
+	<message key="xmlui.Submission.Submissions.progress_head1">Sprawdzane dodane pozycje</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">To są dodane przez Ciebie pozycje, które są obecnie przeglądane przez administratorów kolekcji.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Tytuł</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Kolekcja</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Status</message>
+	<!-- Same transformer, workflow status -->
+	<message key="xmlui.Submission.Submissions.status_0">Dodane</message>
+	<message key="xmlui.Submission.Submissions.status_1">Oczekująca na recenzenta</message>
+	<message key="xmlui.Submission.Submissions.status_2">Pozycja przeglądana</message>
+	<message key="xmlui.Submission.Submissions.status_3">Oczekująca na redaktora</message>
+	<message key="xmlui.Submission.Submissions.status_4">Pozycja redagowana</message>
+	<message key="xmlui.Submission.Submissions.status_5">Oczekująca na ostateczną redakcję</message>
+	<message key="xmlui.Submission.Submissions.status_6">Pozycja redagowana</message>
+	<message key="xmlui.Submission.Submissions.status_7">Pozycja zarchiwizowana</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Nieznany status</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Zarchiwizowane pozycje</message>
+        <message key="xmlui.Submission.Submissions.completed.info">To są dodane przez Ciebie pozycje, które zostały zaakceptowane w DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Data akceptacji</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Tytuł</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Kolekcja</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Powyżej wyświetlone jest tylko 50 dodanych przez Ciebie pozycji.</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Pokaż wszystkie moje zarchiwizowane pozycje.</message>
+
+	<!-- submission progress bar messages -->
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Pytania początkowe</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Opisz</message>
     <message key="xmlui.Submission.submit.progressbar.access">Dostęp</message>
     <message key="xmlui.Submission.submit.progressbar.upload">Prześlij</message>
-    <message key="xmlui.Submission.submit.progressbar.verify">Przejrzyj</message>
-    <message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-    <message key="xmlui.Submission.submit.progressbar.CClicense">Licencja CC</message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Przejrzyj</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">Licencja CC</message>
     <message key="xmlui.Submission.submit.progressbar.license">Licencja</message>
-    <message key="xmlui.Submission.submit.progressbar.complete">Zakończ</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Zakończ</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-    <message key="xmlui.Submission.submit.ResumeStep.submit_resume">Kontynuuj</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Kontynuuj</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-    <message key="xmlui.Submission.submit.SelectCollection.head">Wybierz kolekcję</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection">Kolekcja</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection_help">Wybierz kolekcję, do której chcesz dodać pozycję.</message>
-    <message key="xmlui.Submission.submit.SelectCollection.collection_default">Wybierz kolekcję...</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
+	<message key="xmlui.Submission.submit.SelectCollection.head">Wybierz kolekcję</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Kolekcja</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Wybierz kolekcję, do której chcesz dodać pozycję.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Wybierz kolekcję...</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Zapisać czy anulować dodawanie?</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Czy chcesz usunąć dodawaną pozycję, czy przerwać pracę i wrócić do niej później? Możesz kontynuować proces dodawania, jeśli przycisnąłeś przycisk Opuść przypadkowo.</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Kontynuacja dodawania</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Zapisz, wrócę do tego później</message>
-    <message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Usuń dodawaną pozycję</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Zapisać czy anulować dodawanie?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Czy chcesz usunąć dodawaną pozycję, czy przerwać pracę i wrócić do niej później? Możesz kontynuować proces dodawania, jeśli przycisnąłeś przycisk Opuść przypadkowo.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Kontynuacja dodawania</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Zapisz, wrócę do tego później</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Usuń dodawaną pozycję</message>
 
 
-    <!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.head">Podstawowe pytania</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Uwaga: </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.and"> i </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.separator">, </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Wiele tytułów</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Pozycja ma więcej niż jeden tytuł, <i>np. tytuł oryginalny i przetłumaczony</i></message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Jeśli powyższy checkbox nie jest zaznaczony, następujące tytuły zostaną usunięte z opisu tej pozycji: </message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Opublikowane</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Pozycja była już opublikowana.</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Jeśli powyższy checkbox nie jest zaznaczony, z opisu tej pozycji zostaną usunięte:</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data wydania</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cytat</message>
-    <message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Wydawca</message>
+	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Podstawowe pytania</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Uwaga: </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and"> i </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">, </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Wiele tytułów</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Pozycja ma więcej niż jeden tytuł, <i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Jeśli powyższy checkbox nie jest zaznaczony, następujące tytuły zostaną usunięte z opisu tej pozycji: </message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Opublikowane</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Pozycja była już opublikowana.</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Jeśli powyższy checkbox nie jest zaznaczony, z opisu tej pozycji zostaną usunięte:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Data wydania</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Cytat</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Wydawca</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-    <message key="xmlui.Submission.submit.DescribeStep.head">Opisz pozycję</message>
-    <message key="xmlui.Submission.submit.DescribeStep.unknown_field">Błąd: nieznany typ pola</message>
-    <message key="xmlui.Submission.submit.DescribeStep.required_field">To pole jest wymagane</message>
-    <message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nazwisko, <i>np. Kowalski</i></message>
-    <message key="xmlui.Submission.submit.DescribeStep.first_name_help">Imię <i>np. Donald</i></message>
-    <message key="xmlui.Submission.submit.DescribeStep.year">Rok</message>
-    <message key="xmlui.Submission.submit.DescribeStep.month">Miesiąc</message>
-    <message key="xmlui.Submission.submit.DescribeStep.day">Dzień</message>
-    <message key="xmlui.Submission.submit.DescribeStep.series_name">Nazwa serii</message>
-    <message key="xmlui.Submission.submit.DescribeStep.report_no">Numer raportu lub dokumentu</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Kategorie tematów</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Kategorie tematów</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtruj tematy</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtruj</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Trwa ładowanie słownika.</message>
-    <message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Pojawiły się problemy z ładowaniem słownika, proszę spróbować ponownie później.</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
+	<message key="xmlui.Submission.submit.DescribeStep.head">Opisz pozycję</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Błąd: nieznany typ pola</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">To pole jest wymagane</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Nazwisko, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Imię <i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Rok</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Miesiąc</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">Dzień</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Nazwa serii</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Numer raportu lub dokumentu</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Kategorie tematów</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Kategorie tematów</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filtruj tematy</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filtruj</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Trwa ładowanie słownika.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Pojawiły się problemy z ładowaniem słownika, proszę spróbować ponownie później.</message>
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
@@ -662,16 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo - dostęp ograniczony do określonego dnia</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Widoczny/Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Nazwa</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Opis</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Powód</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Potwierdź ustawienia dostępu i dodaj następny</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Grupy</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Błąd formatu daty</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Konfiguracja ograniczonego dostępu (embargo) wymaga podania daty</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Takie ustawienia dostępu są już skonfigurowane.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Lista ustawień dostępu</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Pozycja prywatna</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Wybór tej opcji sprawi, że pozycja nie będzie pojawiała się w wynikach wyszukiwania</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Nazwa</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Działanie</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Grupa</message>
@@ -680,38 +799,43 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edycja</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Usuń</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Akceptowane formaty: rrrr, rrrr-mm, rrrr-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
 
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Edycja ustawień dostępu</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-    <message key="xmlui.Submission.submit.UploadStep.head">Wyśij plik(i)</message>
-    <message key="xmlui.Submission.submit.UploadStep.file">Plik</message>
-    <message key="xmlui.Submission.submit.UploadStep.file_help">Podaj pełną ścieżkę pliku dodawanej pozycji na Twoim komputerze. Naciśnięcie przycisku "Przeglądaj..." spowoduje otwarcie nowego okna, które ułatwi ten wybór.</message>
-    <message key="xmlui.Submission.submit.UploadStep.file_error">Pozycja musi posiadać co najmniej jeden plik.</message>
-    <message key="xmlui.Submission.submit.UploadStep.upload_error">Podczas wysyłania pliku pojawił się problem.    Być może błędna jest nazwa pliku, może kłopot wystąpił na poziomie transmisji pliku siecią albo próbujesz wysłać plik oznaczony jako plik tylko do użytku na (Twoim) lokalnym komputerze. Spróbuj jeszcze raz.</message>
-    <message key="xmlui.Submission.submit.UploadStep.virus_error">Plik nie został zapisany ponieważ prawdopodobnie zawiera wirusa.  Skontaktuj się z administratorem.</message>
+	<message key="xmlui.Submission.submit.UploadStep.head">Wyśij plik(i)</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Plik</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Podaj pełną ścieżkę pliku dodawanej pozycji na Twoim komputerze. Naciśnięcie przycisku "Przeglądaj..." spowoduje otwarcie nowego okna, które ułatwi ten wybór.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">Pozycja musi posiadać co najmniej jeden plik.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Podczas wysyłania pliku pojawił się problem.    Być może błędna jest nazwa pliku, może kłopot wystąpił na poziomie transmisji pliku siecią albo próbujesz wysłać plik oznaczony jako plik tylko do użytku na (Twoim) lokalnym komputerze. Spróbuj jeszcze raz.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">Plik nie został zapisany ponieważ prawdopodobnie zawiera wirusa.  Skontaktuj się z administratorem.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Wystąpił problem techniczny podczas próby skanowania pliku w poszukiwaniu wirusów.  Skontaktuj się z administratorem.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Opis pliku</message>
-    <message key="xmlui.Submission.submit.UploadStep.description_help">Krótki opis pliku, np. „<i>Główna część artykułu</i>” lub „<i>Wyniki doświadczeń</i>”. (Pole nieobowiązkowe)</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_upload">Dodaj plik i kolejne</message>
-    <message key="xmlui.Submission.submit.UploadStep.head2">Wysłane pliki</message>
-    <message key="xmlui.Submission.submit.UploadStep.column0">Podstawowy</message>
-    <message key="xmlui.Submission.submit.UploadStep.column1"> </message>
-    <message key="xmlui.Submission.submit.UploadStep.column2">Plik</message>
-    <message key="xmlui.Submission.submit.UploadStep.column3">Rozmiar</message>
-    <message key="xmlui.Submission.submit.UploadStep.column4">Opis</message>
-    <message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadStep.column6"></message>
-    <message key="xmlui.Submission.submit.UploadStep.unknown_name">Nieznany</message>
-    <message key="xmlui.Submission.submit.UploadStep.unknown_format">nieznany format</message>
-    <message key="xmlui.Submission.submit.UploadStep.supported">(Obsługiwany)</message>
-    <message key="xmlui.Submission.submit.UploadStep.known">(Znany)</message>
-    <message key="xmlui.Submission.submit.UploadStep.unsupported">(Nieobsługiwany)</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_edit">Edytuj</message>
-    <message key="xmlui.Submission.submit.UploadStep.checksum">Suma kontrolna pliku:</message>
-    <message key="xmlui.Submission.submit.UploadStep.submit_remove">Usuń zaznaczone pliki</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Krótki opis pliku, np. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Dodaj plik i kolejne</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Wysłane pliki</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Podstawowy</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"> </message>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Plik</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Rozmiar</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Opis</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Nieznany</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">nieznany format</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Obsługiwany)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Znany)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Nieobsługiwany)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Edytuj</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Suma kontrolna pliku:</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Usuń zaznaczone pliki</message>
+
 
 
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Wyślij plik(i)</message>
@@ -722,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Plik nie został zapisany ponieważ prawdopodobnie zawiera wirusa.     Skontaktuj się z administratorem.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Wystąpił problem techniczny podczas próby skanowania pliku w poszukiwaniu wirusów.     Skontaktuj się z administratorem.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Opis pliku</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Krótki opis pliku, np. „<i>Główna część artykułu</i>” lub „<i>Wyniki doświadczeń</i>”. (Pole nieobowiązkowe)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Krótki opis pliku, np. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Dodaj plik i kolejne</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Wysłane pliki</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Podstawowy</message>
@@ -731,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Rozmiar</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Opis</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Nieznany</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">nieznany format</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Obsługiwany)</message>
@@ -742,543 +866,546 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Usuń zaznaczone pliki</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Ustawienia dostępu</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-    <message key="xmlui.Submission.submit.EditFileStep.head">Edytuj plik</message>
-    <message key="xmlui.Submission.submit.EditFileStep.file">Plik</message>
-    <message key="xmlui.Submission.submit.EditFileStep.description">Opis pliku</message>
-    <message key="xmlui.Submission.submit.EditFileStep.description_help">Krótki opis pliku, np. „<i>Główna część artykułu</i>” lub „<i>Wyniki doświadczeń</i>”.(Pole nieobowiązkowe).</message>
-    <message key="xmlui.Submission.submit.EditFileStep.info1">Wybierz format pliku z listy poniżej, na przykład „<i>Adobe PDF</i>” lub „<i>Microsoft Word</i>”. <strong>Jeśli format nie znajduje się na poniższej liście</strong>, opisz go w polu poniżej.</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_detected">Wykryty format</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_selected">Wybrany format</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_default">Format nie znajduje się na liście</message>
-    <message key="xmlui.Submission.submit.EditFileStep.info2">Jeśli format pliku nie znajduje się na powyższej liście, <strong>wybierz opcję „format nie znajduje się na liście” powyżej</strong> i opisz format pliku w polu poniżej.</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_user">Inny format</message>
-    <message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nazwa aplikacji użytej przy tworzeniu pliku i numer wersji (na przykład „<i>ACMESoft SuperApp wersja 1.5</i>”).</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
+	<message key="xmlui.Submission.submit.EditFileStep.head">Edytuj plik</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Plik</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Opis pliku</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Krótki opis pliku, np. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Wybierz format pliku z listy poniżej, na przykład „<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Wykryty format</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Wybrany format</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">Format nie znajduje się na liście</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Jeśli format pliku nie znajduje się na powyższej liście, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Inny format</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Nazwa aplikacji użytej przy tworzeniu pliku i numer wersji (na przykład „<i>ACMESoft SuperApp version 1.5</i>").</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Edycja uprawnień dostępu do plików</message>
 
 
-    <!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-    <message key="xmlui.Submission.submit.ReviewStep.head">Przeglądanie dodanych pozycji</message>
-    <message key="xmlui.Submission.submit.ReviewStep.yes">Tak</message>
-    <message key="xmlui.Submission.submit.ReviewStep.no">Nie</message>
-    <message key="xmlui.Submission.submit.ReviewStep.submit_jump">Popraw jedno z tych</message>
-    <message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Dodaj lub usuń plik</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head1">Pytania początkowe</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head2">Opisz stronę {0}</message>
-    <message key="xmlui.Submission.submit.ReviewStep.head3">Pliki wysłane</message>
-    <message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Wiele tytułów</message>
-    <message key="xmlui.Submission.submit.ReviewStep.published_before">Opublikowane wcześniej</message>
-    <message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-    <message key="xmlui.Submission.submit.ReviewStep.unknown">nieznany</message>
-    <message key="xmlui.Submission.submit.ReviewStep.known">znany</message>
-    <message key="xmlui.Submission.submit.ReviewStep.supported">obsługiwany</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">Przeglądanie dodanych pozycji</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Tak</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">Nie</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Popraw jedno z tych</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Dodaj lub usuń plik</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Pytania początkowe</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Opisz stronę {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Pliki wysłane</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Wiele tytułów</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Opublikowane wcześniej</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">nieznany</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">znany</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">obsługiwany</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-    <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Wystąpił błąd ... {0}</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.head">Udziel licencji do swojej pracy</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.info1">Jeśli chcesz, możesz dodać licencję <a href="http://creativecommons.org/">Creative Commons</a> do tej pozycji. <strong>Licencja Creative Commons określa, jak użytkownicy będą mogli korzystać z Twojego utworu.</strong></message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Wybierz licencję</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Przejdź do strony Creative Commons, aby wybrać licencję</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.license">Licencja</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Wybierz lub zmień udzieloną licencję ...</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.no_license">żadna licencja Creative Commons nie została wybrana</message>
-    <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Aby zapisać zmiany, musisz nacisnąć przycisk Dalej.</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Wystąpił błąd ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Udziel licencji do swojej pracy</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Jeśli chcesz, możesz dodać licencję <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Wybierz licencję</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Przejdź do strony Creative Commons, aby wybrać licencję</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Licencja</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Wybierz lub zmień udzieloną licencję ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">żadna licencja Creative Commons nie została wybrana</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Aby zapisać zmiany, musisz nacisnąć przycisk Dalej.</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-    <message key="xmlui.Submission.submit.LicenseStep.head">Licencja</message>
-    <message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Ostatni krok:</strong> aby system DSpace mógł prezentować Twoją pracę, musisz wybrać jedną z poniższych opcji.</message>
-    <message key="xmlui.Submission.submit.LicenseStep.info2">Aby udzielić licencji do utworu, zaznacz „Udzielam licencji” i naciśnij przycisk „Zakończ dodawanie”.</message>
-    <message key="xmlui.Submission.submit.LicenseStep.info3">Jeśli masz pytania dotyczące tej licencji, skontaktuj się z administratorem systemu.</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_label">Licencja</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Udzielam licencji</message>
-    <message key="xmlui.Submission.submit.LicenseStep.decision_error">Aby zakończyć dodawanie pozycji, musisz udzielić licencji. Jeśli nie możesz tego zrobić teraz, zapisz dane - będziesz mógł później do nich wrócić lub usunąć dodaną pozycję. Aby zapisać dane, wciśnij przycisk „Zapisz i wyjdź” widoczny poniżej.</message>
+	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
+	<message key="xmlui.Submission.submit.LicenseStep.head">Licencja</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Aby udzielić licencji do utworu, zaznacz „Udzielam licencji” i naciśnij przycisk „Zakończ dodawanie”.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Jeśli masz pytania dotyczące tej licencji, skontaktuj się z administratorem systemu.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licencja</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Udzielam licencji</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Aby zakończyć dodawanie pozycji, musisz udzielić licencji. Jeśli nie możesz tego zrobić teraz, zapisz dane - będziesz mógł później do nich wrócić lub usunąć dodaną pozycję. Aby zapisać dane, wciśnij przycisk „Zapisz i wyjdź” widoczny poniżej.</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-    <message key="xmlui.Submission.submit.RemovedStep.head">Pozycja usunięta</message>
-    <message key="xmlui.Submission.submit.RemovedStep.info1">Dodawanie pozycji zostało anulowane, a niedodana pozycja usunięta z systemu.</message>
-    <message key="xmlui.Submission.submit.RemovedStep.go_submission">Przejdź do strony dodawanych elementów</message>    
+	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
+	<message key="xmlui.Submission.submit.RemovedStep.head">Pozycja usunięta</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Dodawanie pozycji zostało anulowane, a niedodana pozycja usunięta z systemu.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Przejdź do strony dodawanych elementów</message>
 
-    <!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-    <message key="xmlui.Submission.submit.CompletedStep.head">Dodawanie zakończone</message>
-    <message key="xmlui.Submission.submit.CompletedStep.info1">Pozycja dodana przez Ciebie przejdzie teraz proces weryfikacji zdefiniowany dla wybranej kolekcji. Otrzymasz wiadomość e-mail, gdy pozycja zostanie dołączona do kolekcji lub gdy pojawi się jakaś wątpliwość. W każdej chwili możesz sprawdzić status tej pozycji, odwiedzając stronę z dodawanymi przez siebie pozycjami.</message>
-    <message key="xmlui.Submission.submit.CompletedStep.go_submission">Przejdź do strony dodawanych elementów</message>    
-    <message key="xmlui.Submission.submit.CompletedStep.submit_again">Dodaj następną pozycję</message>        
+	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
+	<message key="xmlui.Submission.submit.CompletedStep.head">Dodawanie zakończone</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Pozycja dodana przez Ciebie przejdzie teraz proces weryfikacji zdefiniowany dla wybranej kolekcji. Otrzymasz wiadomość e-mail, gdy pozycja zostanie dołączona do kolekcji lub gdy pojawi się jakaś wątpliwość. W każdej chwili możesz sprawdzić status tej pozycji, odwiedzając stronę z dodawanymi przez siebie pozycjami.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Przejdź do strony dodawanych elementów</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Dodaj następną pozycję</message>
 
-    <!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-    <message key="xmlui.Submission.workflow.PerformTaskStep.info1">Akcje jakie możesz podjąć w związku z tym zadaniem:</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Przypisz sobie to zadanie.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Przypisz sobie</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Pozostaw zadanie w puli dla kogoś innego.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Zostaw zadanie</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Jeśli przejrzałeś już element i uznałeś go za poprawny, dodaj go do kolejkcji wybierając przycisk „Zatwierdź”.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Zatwierdź pozycję</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Jeżeli edytowałeś pozycję, użyj tej opcji, aby zapisać w archiwum swoje modyfikacje.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Zapisz w archiwum</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Jeżeli po przejrzeniu pozycję uznałeś, że <strong>nie</strong>  można jej dodać do kolekcji, wybierz „Odrzuć”.     Zostaniesz wówczas poproszony o podanie powodu takiej decyzji oraz ewentualnej informacji dla dodającego, co może poprawić przed ponowieniem próby dodania pozycji.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Odrzuć pozycję</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Zaznacz tę opcję, aby zmienić metadane pozycji.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edytuj metadane</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Odłóż zadanie do puli, aby ktoś inny mógł je wykonać.</message>
-    <message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Odłóż zadanie do puli</message>
+	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Akcje jakie możesz podjąć w związku z tym zadaniem:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Przypisz sobie to zadanie.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Przypisz sobie</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Pozostaw zadanie w puli dla kogoś innego.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Zostaw zadanie</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Jeśli przejrzałeś już element i uznałeś go za poprawny, dodaj go do kolejkcji wybierając przycisk „Zatwierdź”.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Zatwierdź pozycję</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Jeżeli edytowałeś pozycję, użyj tej opcji, aby zapisać w archiwum swoje modyfikacje.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Zapisz w archiwum</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Jeżeli po przejrzeniu pozycję uznałeś, że <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Odrzuć pozycję</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Zaznacz tę opcję, aby zmienić metadane pozycji.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Edytuj metadane</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Odłóż zadanie do puli, aby ktoś inny mógł je wykonać.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Odłóż zadanie do puli</message>
 
-    <!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-    <message key="xmlui.Submission.workflow.RejectTaskStep.info1">Poniżej wpisz powód, dla którego odrzuciłeś dodawaną pozycję. Zaznacz, czy i w jaki sposób dodający może naprawić problem i dodać ponownie pozycję.</message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.reason">Powód</message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Powód, dla którego to pole jest wymagane</message>
-    <message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Odrzuć pozycję</message>
-
-
+	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Poniżej wpisz powód, dla którego odrzuciłeś dodawaną pozycję. Zaznacz, czy i w jaki sposób dodający może naprawić problem i dodać ponownie pozycję.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Powód</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Powód, dla którego to pole jest wymagane</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Odrzuć pozycję</message>
 
 
-    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-                     Administrative Aspect
 
-        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    <!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+		             Administrative Aspect
 
-    <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Zadanie zostało wykonane.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Zadanie zostało przerwane lub nie udało się go wykonać.    Skontaktuj się z administratorem.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Zadanie zostało dodane do kolejki.</message>
-    <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Zadanie nie może być dodane do kolejki.     Wystąpił błąd.     Skontaktuj się z administratorem.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Użytkownik został dodany.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Dane użytkownika zostały zmienione.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Do użytkownika została wysłana wiadomość e-mail zawierająca token, który może posłużyć do utworzenia nowego hasła.</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Udało się usunąć użytkownika(ów).</message>
-    <message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Konto użytkownika(ów) widoczne poniżej nie zostało usunięte, ponieważ jest zabezpieczone. Przejrzyj szczegóły konta na stronie e-osoby.</message>
-    <message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Udało się zmienić dane grupy.</message>
-    <message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Udało się usunąć zaznaczoną grupę.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Utworzono nowy schemat.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Usunięto schemat(y).</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Dodano nowe pole metadanych.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Zmieniono pole metadanych.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Przeniesiono pole(a).</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Usunięto pole(a).</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Zapisano format.</message>
-    <message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Format(y) został(y) usunięty(e).</message>
-    <message key="xmlui.administrative.FlowItemUtils.metadata_updated">Zaktualizowano metadane pozycji.</message>
-    <message key="xmlui.administrative.FlowItemUtils.metadata_added">Nowe metadane zostały dodane.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Pozycja została wycofana.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_reinstated">Pozycja została przywrócona.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_moved">Pozycja została przeniesiona.</message>
-    <message key="xmlui.administrative.FlowItemUtils.item_move_failed">Wybrana kolekcja docelowa nie została znaleziona.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_added">Wysłano nowe dane.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Błąd podczas wysyłania plików.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Zaktualizowano plik.</message>
-    <message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Wybrane pliki zostały skasowane.</message>
-    <message key="xmlui.administrative.FlowMapperUtils.map_items">Pozycje zostały zmapowane.</message>
-    <message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Pozycje zostały odmapowane.</message>
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
-    <!-- general items for all of the eperson classes -->
-    <message key="xmlui.administrative.eperson.general.epeople_trail">Zarządzaj e-osobami</message>
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
 
-    <!-- org.dspace.app.xmlui.administrative.Navigation -->
-    <!-- contextual menu items -->
-    <message key="xmlui.administrative.Navigation.context_head">Kontekst</message>
-    <message key="xmlui.administrative.Navigation.context_edit_item">Edytuj tę pozycję</message>
-    <message key="xmlui.administrative.Navigation.context_edit_collection">Edytuj tę kolekcję</message>
-    <message key="xmlui.administrative.Navigation.context_item_mapper">Odwzorowanie pozycji</message>
-    <message key="xmlui.administrative.Navigation.context_edit_community">Edytuj zbiór</message>
-    <message key="xmlui.administrative.Navigation.context_create_collection">Utwórz kolekcję</message>
-    <message key="xmlui.administrative.Navigation.context_create_subcommunity">Utwórz podzbiór</message>
-    <message key="xmlui.administrative.Navigation.context_create_community">Utwórz zbiór</message>
-    <message key="xmlui.administrative.Navigation.context_export_item">Eksport pozycji</message>
-    <message key="xmlui.administrative.Navigation.context_export_collection">Eksport kolekcji</message>
-    <message key="xmlui.administrative.Navigation.context_export_community">Eksport zbioru</message>
-    <message key="xmlui.administrative.Navigation.context_export_metadata">Eksport metadanych</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Zadanie zostało wykonane.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Zadanie zostało przerwane lub nie udało się go wykonać.    Skontaktuj się z administratorem.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Zadanie zostało dodane do kolejki.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Zadanie nie może być dodane do kolejki.     Wystąpił błąd.     Skontaktuj się z administratorem.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Użytkownik został dodany.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Dane użytkownika zostały zmienione.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Do użytkownika została wysłana wiadomość e-mail zawierająca token, który może posłużyć do utworzenia nowego hasła.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Udało się usunąć użytkownika(ów).</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Konto użytkownika(ów) widoczne poniżej nie zostało usunięte, ponieważ jest zabezpieczone. Przejrzyj szczegóły konta na stronie e-osoby.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Udało się zmienić dane grupy.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Udało się usunąć zaznaczoną grupę.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Utworzono nowy schemat.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Usunięto schemat(y).</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Dodano nowe pole metadanych.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Zmieniono pole metadanych.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Przeniesiono pole(a).</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Usunięto pole(a).</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Zapisano format.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Format(y) został(y) usunięty(e).</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Zaktualizowano metadane pozycji.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Nowe metadane zostały dodane.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Pozycja została wycofana.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Pozycja została przywrócona.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">Pozycja została przeniesiona.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">Wybrana kolekcja docelowa nie została znaleziona.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Wysłano nowe dane.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Błąd podczas wysyłania plików.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Zaktualizowano plik.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Wybrane pliki zostały skasowane.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Pozycje zostały zmapowane.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Pozycje zostały odmapowane.</message>
 
-    <!-- Site administrator options -->
-    <message key="xmlui.administrative.Navigation.administrative_head">Administracja</message>
-    <message key="xmlui.administrative.Navigation.administrative_access_control">Kontrola dostępu</message>
-    <message key="xmlui.administrative.Navigation.administrative_people">Osoby</message>
-    <message key="xmlui.administrative.Navigation.administrative_groups">Grupy</message>
-    <message key="xmlui.administrative.Navigation.administrative_authorizations">Ustawienia zabezpieczeń</message>
-    <message key="xmlui.administrative.Navigation.administrative_registries">Rejestry</message>
-    <message key="xmlui.administrative.Navigation.administrative_metadata">Metadane</message>
-    <message key="xmlui.administrative.Navigation.administrative_format">Formaty plików</message>
-    <message key="xmlui.administrative.Navigation.administrative_items">Pozycje</message>
+	<!-- general items for all of the eperson classes -->
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Zarządzaj e-osobami</message>
+
+	<!-- org.dspace.app.xmlui.administrative.Navigation -->
+	<!-- contextual menu items -->
+	<message key="xmlui.administrative.Navigation.context_head">Kontekst</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Edytuj tę pozycję</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Edytuj tę kolekcję</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Odwzorowanie pozycji</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Edytuj zbiór</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Utwórz kolekcję</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Utwórz podzbiór</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Utwórz zbiór</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Eksport pozycji</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Eksport kolekcji</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Eksport zbioru</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Eksport metadanych</message>
+
+	<!-- Site administrator options -->
+	<message key="xmlui.administrative.Navigation.administrative_head">Administracja</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Kontrola dostępu</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Osoby</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Grupy</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Ustawienia zabezpieczeń</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Rejestry</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadane</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Formaty plików</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Pozycje</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Pozycje wycofane</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Pozycje prywatne</message>
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Panel kontrolny</message>
     <message key="xmlui.administrative.Navigation.statistics">Statystyki</message>
-    <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importuj metadane</message>
-    <message key="xmlui.administrative.Navigation.administrative_curation">Zadania opiekuna</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importuj metadane</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Zadania opiekuna</message>
 
     <!-- my account items -->
-    <message key="xmlui.administrative.Navigation.account_export">Moje eksporty</message>
+	<message key="xmlui.administrative.Navigation.account_export">Moje eksporty</message>
 
 
-    <!-- export item -->
-    <message key="xmlui.administrative.ItemExport.head">Archiwum eksportów</message>
-    <message key="xmlui.administrative.ItemExport.item.id.error">Podany identyfikator pozycji jest nieprawidłowy.</message>
-    <message key="xmlui.administrative.ItemExport.collection.id.error">Podany identyfikator kolekcji jest nieprawidłowy.</message>
-    <message key="xmlui.administrative.ItemExport.community.id.error">Podany identyfikator zbioru jest nieprawidłowy.</message>
-    <message key="xmlui.administrative.ItemExport.item.not.found">Nie odnaleziono żadnej pozycji.</message>
-    <message key="xmlui.administrative.ItemExport.collection.not.found">Nie odnaleziono żadnej kolekcji.</message>
-    <message key="xmlui.administrative.ItemExport.community.not.found">Nie odnaleziono żadnego zbioru.</message>
-    <message key="xmlui.administrative.ItemExport.item.success">Wyeksportowano pozycję. Powinieneś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
-    <message key="xmlui.administrative.ItemExport.collection.success">Wyeksportowano kolekcję. Powinieneś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
-    <message key="xmlui.administrative.ItemExport.community.success">Wyesportowano zbiór. Powinienieś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
-    <message key="xmlui.administrative.ItemExport.available.head">Dostępne do pobrania archiwa eksportów:</message>
+	<!-- export item -->
+	<message key="xmlui.administrative.ItemExport.head">Archiwum eksportów</message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">Podany identyfikator pozycji jest nieprawidłowy.</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">Podany identyfikator kolekcji jest nieprawidłowy.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">Podany identyfikator zbioru jest nieprawidłowy.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">Nie odnaleziono żadnej pozycji.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">Nie odnaleziono żadnej kolekcji.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">Nie odnaleziono żadnego zbioru.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Wyeksportowano pozycję. Powinieneś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">Wyeksportowano kolekcję. Powinieneś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">Wyesportowano zbiór. Powinienieś otrzymać e-mail informujący, że archiwum jest gotowe do pobrania. Możesz również użyć linku „Moje eksporty”, aby zobaczyć listę dostępnych archiwów.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Dostępne do pobrania archiwa eksportów:</message>
 
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Zarządzanie e-osobami</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Zarządzanie e-osobami</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Zadania</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Utwórz nową e-osobę</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Kliknij tutaj, aby dodać nową e-osobę</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Przeglądaj e-osoby</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Kliknij tutaj, aby przeglądać wszystkie e-osoby.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Szukaj e-osoby</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-osoby są przeszukiwane na podstawie częściowej zgodności nazwy lub adresu email</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Poniżej znajdziesz listę e-osób, które spełniają kryteria wyszukiwania.  Wybierz e-osoby, które chcesz usunąć i naciśnij przycisk „Usuń”, aby kontynuować.  Możesz również kliknąć na nazwie lub emailu którejś z e-osób, aby edytować informację o niej.</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Wyniki wyszukiwania</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nazwa</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Skasuj e-osobę</message>
-    <message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Wyszukiwanie nie dało żadnych wyników...</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Zarządzanie e-osobami</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Zarządzanie e-osobami</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Zadania</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Utwórz nową e-osobę</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Kliknij tutaj, aby dodać nową e-osobę</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Przeglądaj e-osoby</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Kliknij tutaj, aby przeglądać wszystkie e-osoby.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Szukaj e-osoby</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-osoby są przeszukiwane na podstawie częściowej zgodności nazwy lub adresu email</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Poniżej znajdziesz listę e-osób, które spełniają kryteria wyszukiwania.  Wybierz e-osoby, które chcesz usunąć i naciśnij przycisk „Usuń”, aby kontynuować.  Możesz również kliknąć na nazwie lub emailu którejś z e-osób, aby edytować informację o niej.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Wyniki wyszukiwania</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nazwa</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Skasuj e-osobę</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Wyszukiwanie nie dało żadnych wyników...</message>
 
 
-    <!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-    <message key="xmlui.administrative.eperson.AddEPersonForm.title">Dodaj e-osobę</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.trail">Dodaj e-osobę</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.head1">Utwórz nowego użytkownika</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Ten adres email jest używany przez inną e-osobę. Adresy muszą być unikalne.</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informacje o nowej e-osobie:</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">Adres email musi być unikalny</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Adres email jest wymagany</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Imię jest wymagane</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Nazwisko jest wymagane</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Wymagaj certyfikatu</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Może się logować</message>
-    <message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Utwórz e-osobę</message>
+	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Dodaj e-osobę</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Dodaj e-osobę</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Utwórz nowego użytkownika</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Ten adres email jest używany przez inną e-osobę. Adresy muszą być unikalne.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Informacje o nowej e-osobie:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">Adres email musi być unikalny</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Adres email jest wymagany</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Imię jest wymagane</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Nazwisko jest wymagane</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Wymagaj certyfikatu</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Może się logować</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Utwórz e-osobę</message>
 
-    <!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-    <message key="xmlui.administrative.eperson.EditEPersonForm.title">Edytuj e-osobę</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edytuj e-osobę</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edytowanie e-osoby</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Ten adres email jest używany przez inną e-osobę. Adresy muszą być unikalne.</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informacje o {0}:</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">Adresy e-mail muszą być unikalne</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Adres e-mail jest wymagany</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Imię jest wymagane</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Nazwisko jest wymagane</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Wymaga certyfikatu</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Może się logować</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Reset hasła</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Możesz także bezpowrotnie usunąć tę e-osobę z systemu lub zresetować jej hasło. Podczas resetowania hasła, użytkownik otrzyma wiadomość e-mail zawierającą link do strony, na której może wybrać nowe hasło.</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Usuń e-osobę</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Zaloguj jako e-osoba</message>
+	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Edytuj e-osobę</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Edytuj e-osobę</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Edytowanie e-osoby</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Ten adres email jest używany przez inną e-osobę. Adresy muszą być unikalne.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Informacje o {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">Adresy e-mail muszą być unikalne</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Adres e-mail jest wymagany</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Imię jest wymagane</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Nazwisko jest wymagane</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Wymaga certyfikatu</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Może się logować</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Reset hasła</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Możesz także bezpowrotnie usunąć tę e-osobę z systemu lub zresetować jej hasło. Podczas resetowania hasła, użytkownik otrzyma wiadomość e-mail zawierającą link do strony, na której może wybrać nowe hasło.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Usuń e-osobę</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Zaloguj jako e-osoba</message>
 
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Nie można usunąć tej e-osoby ponieważ:</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">e-osoba dodała co najmniej jedną pozycję</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">e-osoba ma aktywny przepływ pracy związany z dodawaną pozycją</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">na uwagę e-osoby czeka proces przepływu pracy</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">w systemie są niezdefiniowane ograniczenia dla e-osoby</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Nie można usunąć tej e-osoby ponieważ:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">i</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">e-osoba dodała co najmniej jedną pozycję</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">e-osoba ma aktywny przepływ pracy związany z dodawaną pozycją</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">na uwagę e-osoby czeka proces przepływu pracy</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">w systemie są niezdefiniowane ograniczenia dla e-osoby</message>
 
-    <message key="xmlui.administrative.eperson.EditEPersonForm.member_head">grupy, których e-osoba jest członkiem:</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(za pośrednictwem grupy: {0})</message>
-    <message key="xmlui.administrative.eperson.EditEPersonForm.member_none">żadna</message>
-
-
-    <!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Potwierdzenie kasowania e-osoby</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Potwierdź kasowanie</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Potwierdź kasowanie</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Podane e-osoby będą skasowane: </message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Potwierdź kasowanie</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nazwa</message>
-    <message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Email</message>
-
-    <!-- general items for all of the group classes -->
-    <message key="xmlui.administrative.group.general.group_trail">Zarządzaj grupami</message>
-
-    <!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-    <message key="xmlui.administrative.group.ManageGroupsMain.title">Zarządzaj grupami</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.main_head">Zarządzanie grupami</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Zadania</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Utwórz nową grupę</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Kliknij tutaj, aby dodać nową grupę.</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Przeglądaj grupy</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Kliknij tu, aby przeglądać wszystkie grupy.</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Szukaj grupy</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_help">Wyszukiwanie dotyczy dowolnego fragmentu nazwy grupy</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_head">Wyniki wyszukiwania</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nazwa</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Członkowie</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Zbiór / Kolekcja</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Zobacz</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Usuń grupy</message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.no_results">Twoje wyszukiwanie nie zwróciło żadnych wyników...</message>
-
-    <!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-    <message key="xmlui.administrative.group.EditGroupForm.title">Edytor grupy</message>
-    <message key="xmlui.administrative.group.EditGroupForm.trail">Edytuj grupę</message>
-    <message key="xmlui.administrative.group.EditGroupForm.main_head">Edycja grupy: {0} (id: {1})</message>
-    <message key="xmlui.administrative.group.EditGroupForm.main_head_new">Edytor grupowy: nowa grupa</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_clear">Wyczyść wyszukiwanie</message>
-    <message key="xmlui.administrative.group.EditGroupForm.member">Członek</message>
-    <message key="xmlui.administrative.group.EditGroupForm.cycle">Cykl</message>
-    <message key="xmlui.administrative.group.EditGroupForm.pending">Oczekujące</message>
-    <message key="xmlui.administrative.group.EditGroupForm.pending_warn">Zauważ, że zmiany oczekujące nie zostaną zapisane, dopóki nie naciśniesz przycisku „Zapisz”.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_add">Dodaj</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_remove">Usuń</message>
-    <message key="xmlui.administrative.group.EditGroupForm.collection_para">Ta grupa jest powiązana z kolekcją: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.community_para">Ta grupa jest powiązana ze zbiorem: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_name">Zmień nazwę grupy: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_instructions">Ta grupa jest powiązana z konkretną kolekcją lub zbiorem i jej nazwa nie może zostać zmodyfikowana.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.label_search">Szukaj członków do dodania: </message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_search_people">E-osoby...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupy...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.no_results">Twoje wyszukiwanie nie zwróciło żadnych wyników...</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nazwa</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Email</message>
-    <message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nazwa</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column3">Członkowie</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column4">Kolekcja</message>
-    <message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-    <message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">zobacz</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_head">Członkowie</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column2">Nazwa</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupa: {0}</message>    
-    <message key="xmlui.administrative.group.EditGroupForm.members_none">Ta grupa nie ma członków.</message>
-    <message key="xmlui.administrative.group.EditGroupForm.members_pending">[oczekujące]</message>
-    <message key="xmlui.administrative.group.EditGroupForm.instructions_para">Usuń członków</message>
-    <message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Usuń członków</message>
-
-    <!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Potwierdzenie Kasowania grupy</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Potwierdzenie kasowania</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Potwierdź skasowanie</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Podane grupy zostaną skasowane:</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nazwa</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">e-osoby</message>
-    <message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupy</message>
-
-    <!-- general items for all of the registries classes -->
-    <message key="xmlui.administrative.registries.general.format_registry_trail">Rejestr formatów</message>
-    <message key="xmlui.administrative.registries.general.metadata_registry_trail">Rejestr metadanych</message>    
-
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Kasowanie formatów plików</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Kasowanie formatów plików</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Potwierdź skasowanie</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Czy jesteś pewien, że format powinien zostać skasowany? Format wszystkich istniejących plików w tym formacie zostanie uznany za nieznany.</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Typ MIME</message>
-    <message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nazwa</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Usuń pola</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Usuń pola</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Potwierdź usunięcie</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Czy jesteś <b>całkowicie</b>     pewien, że chcesz usunąć te pola?  Jeśli którekolwiek pozycje zawierają metadane dla tych pól, nie mogą być one skasowane. Upewnij się, czy żadne pozycje nie używają tych pól.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">UWAGA: </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Jeśli którakolwiek pozycja posiada metadane dla tych pól, wystąpi błąd.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nazwa</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Zakres</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Skasuj schemat</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Skasuj schemat</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Potwierdź usunięcie</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Czy jesteś <b>całkowicie</b> pewien, że chcesz skasować ten schemat? Jeśli którakolwiek pozycja zawiera metadane dla pól zawierających się w tym schemacie, nie może ona być skasowana. Upewnij się najpierw, że nie ma żadnych takich pozycji.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">UWAGA: </message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Jeśli którakolwiek pozycja posiada metadane dla tego schematu, wystąpi błąd.</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Przestrzeń nazw</message>
-    <message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nazwa</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format danych</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format danych</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nowy format danych</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format danych: {0}</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Opisz jak najdokładniej metadane dla formatu plików określonego poniżej. Nazwy formatów muszą być unikalne, typy MIME – nie. Możesz zdefiniować różne formaty dla różnych wersji plików Microsoft Word, nawet jeśli typ MIME dla nich będzie taki sam.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nazwa</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Unikalna nazwa dla tego formatu, (np. Microsoft Word 97 lub Microsoft Word 2003)</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Nazwa pola jest wymagana.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Typ MIME</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Typ mime połączony z formatem wcale nie musi być unikalny.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.description">Opis</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support">Poziom wsparcia</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Poziom wsparcia, do którego zobowiązuje Twoja instytucja.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Nieznany</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Znany</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Obsługiwany</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Wewnętrzny</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Formaty „wewnętrzne” są niewidoczne dla użytkowników, mają zastosowanie tylko do zadań administracyjnych.</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Rozszerzenia plików</message>
-    <message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Rozszerzenia są rozszerzeniami plików, które są używane do automatycznej identyfikacji formatu wysyłanych plików. Możesz wpisać kilkanaście rozszerzeń dla każdego formatu.</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-    <message key="xmlui.administrative.registries.EditMetadataSchema.title">Schemat metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.trail">Schemat metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head1">Schemat metadanych: "{0}"</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.para1">To schemat metadanych dla "{0}". Możesz dodać nowe lub zmienić istniejące pola metadanych. Możesz także usunąć wybrane pola lub przenieść je do definicji innego schematu.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head2">Pola schematu metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column3">Pole</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.column4">Zakres</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.empty">Brak pól metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Usuń pole</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Przenieś pola do innego schematu</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head3">Dodaj nowe pole metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.name">Nazwa pola</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.note">Zakres</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Dodatkowe informacje o polu metadanych.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Dodaj nowe pole metadanych</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aktualizuj pole: {0}</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aktualizuj pole</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error">Błąd</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Nazwa pola jest już używana, wszystkie elementy i kwalifikatory muszą być unikalne.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">„Element” jest wymagany dla definicji pola.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Element w polu zawiera niepoprawny znak.  Element <strong>NIE</strong> może zawierać: kropek, podkreśleń ani spacji.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">„Element” jest za długi w definicji pola, powinien być krótszy niż 32 znaki.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Kwalifikator pola jest zbyt długi, powinien być krótszy niż 32 znaki.</message>
-    <message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Kwalifikator pola zawiera niepoprawny znak. Kwalifikator <strong>NIE</strong> może zawierać: kropek, podkreśleń ani spacji.</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
-    <message key="xmlui.administrative.registries.FormatRegistryMain.title">Rejestr formatów</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.head">Rejestr formatów plików</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.para1">Oto lista formatów plików, zawierająca informację o znanych formatach i poziomie ich wsparcia. Za pomocą tego narzędzia możesz edytować lub dodawać nowe formaty plików. Formaty oznaczone jako „wewnętrzne” są ukryte przed użytkownikami i służą wyłącznie celom administracyjnym.</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Dodaj nowy format danych</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nazwa</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column4">Typ MIME</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.column5">Poziom obsługi</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>wewnętrzny</i>)</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Nieznany</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Znany</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Obsługiwany</message>
-    <message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Usuń definicje formatów</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.title">Rejestr metadanych</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Rejestr metadanych</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Rejestr metadanych przechowuje listę wszystkich pól metadanych dostępnych dla repozytorium. Pola mogą być podzielone pomiędzy różne schematy. DSpace wymaga jednak, aby zdefiniowany był co najmniej jeden schemat – Dublin Core. Można go rozszerzać, a także dodawać do rejestru nowe schematy.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Przestrzeń nazw</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nazwa</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Usuń schemat</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Dodaj schemat</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Przestrzeń nazw</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">Definicją przestrzeni nazw powinien być poprawny adres URI nowego schematu.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">To pole jest wymagane.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nazwa</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Skrót nazwy schematu. Pole będzie użyte jako prefiks nazw pól (np. dc.element.qualifier). Skrót musi być krótszy niż 32 znaki i nie może zawierać spacji, kropek i podkreśleń.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">To pole jest wymagane. Musi zawierać mniej niż 32 znaku i nie może zawierać spacji, kropek, podkreśleń.</message>
-    <message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Dodaj schemat</message>
-
-    <!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
-    <message key="xmlui.administrative.registries.MoveMetadataField.title">Przenieś pola</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.trail">Przenieś pola</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.head1">Przenieś pola metadanych</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.para1">Wybierz docelowy schemat, do którego zostaną przeniesione te pola. Jeśli docelowy schemat ma pola nazywające się tak samo, wówczas pola nie zostaną przeniesione.</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column2">Nazwa</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.column3">Zakres</message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.para2">Przenieś do schatu: </message>
-    <message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Przenieś pola</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">grupy, których e-osoba jest członkiem:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(za pośrednictwem grupy: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">żadna</message>
 
 
+	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Potwierdzenie kasowania e-osoby</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Potwierdź kasowanie</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Potwierdź kasowanie</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Podane e-osoby będą skasowane: </message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Potwierdź kasowanie</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Nazwa</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Email</message>
 
+	<!-- general items for all of the group classes -->
+	<message key="xmlui.administrative.group.general.group_trail">Zarządzaj grupami</message>
 
-    <!-- general authorization keywords -->
-    <message key="xmlui.administrative.authorization.general.authorize_trail">Autoryzacja</message>
-    <message key="xmlui.administrative.authorization.general.policyList_trail">Lista uprawnień i zabezpieczeń</message>
+	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Zarządzaj grupami</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Zarządzanie grupami</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Zadania</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Utwórz nową grupę</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Kliknij tutaj, aby dodać nową grupę.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Przeglądaj grupy</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Kliknij tu, aby przeglądać wszystkie grupy.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Szukaj grupy</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Wyszukiwanie dotyczy dowolnego fragmentu nazwy grupy</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Wyniki wyszukiwania</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nazwa</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Członkowie</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Zbiór / Kolekcja</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Zobacz</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Usuń grupy</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Twoje wyszukiwanie nie zwróciło żadnych wyników...</message>
 
-    <!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
-    <message key="xmlui.administrative.authorization.AuthorizationMain.title">Zarządzanie ustawieniami autoryzacji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Zarządzanie ustawieniami autoryzacji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoryzacje pozycji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Podany identyfikator nie określa żadnej pozycji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Poszukaj pozycji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Pozycji można szukać używając wskaźnika lub identyfikatora</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Znajdź</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Zaawansowane narzędzie autoryzacji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Kliknij tu, aby przejść do narzędzia zarządzania uprawnieniami pozycji</message> <!-- TODO dottem "wildcard item policy" -->
-    <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoryzacja zbioru/kolekcji</message>
-    <message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Kliknij zbiór lub kolekcję, aby edytować ustawienia zabezpieczeń.</message>
+	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
+	<message key="xmlui.administrative.group.EditGroupForm.title">Edytor grupy</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Edytuj grupę</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Edycja grupy: {0} (id: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Edytor grupowy: nowa grupa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Wyczyść wyszukiwanie</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Członek</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Cykl</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">Oczekujące</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Zauważ, że zmiany oczekujące nie zostaną zapisane, dopóki nie naciśniesz przycisku „Zapisz”.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Dodaj</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Usuń</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Ta grupa jest powiązana z kolekcją: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Ta grupa jest powiązana ze zbiorem: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Zmień nazwę grupy: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Ta grupa jest powiązana z konkretną kolekcją lub zbiorem i jej nazwa nie może zostać zmodyfikowana.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">Szukaj członków do dodania: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">E-osoby...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Grupy...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">Twoje wyszukiwanie nie zwróciło żadnych wyników...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nazwa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Email</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nazwa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Członkowie</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Kolekcja</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">zobacz</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Członkowie</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nazwa</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupa: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">Ta grupa nie ma członków.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[oczekujące]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Usuń członków</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Usuń członków</message>
+
+	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Potwierdzenie Kasowania grupy</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Potwierdzenie kasowania</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Potwierdź skasowanie</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Podane grupy zostaną skasowane:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Nazwa</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">e-osoby</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Grupy</message>
+
+	<!-- general items for all of the registries classes -->
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Rejestr formatów</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Rejestr metadanych</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Kasowanie formatów plików</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Kasowanie formatów plików</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Potwierdź skasowanie</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Czy jesteś pewien, że format powinien zostać skasowany? Format wszystkich istniejących plików w tym formacie zostanie uznany za nieznany.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Typ MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Nazwa</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Usuń pola</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Usuń pola</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Potwierdź usunięcie</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Czy jesteś <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">UWAGA: </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Jeśli którakolwiek pozycja posiada metadane dla tych pól, wystąpi błąd.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Nazwa</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Zakres</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Skasuj schemat</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Skasuj schemat</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Potwierdź usunięcie</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Czy jesteś <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">UWAGA: </message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Jeśli którakolwiek pozycja posiada metadane dla tego schematu, wystąpi błąd.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Przestrzeń nazw</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Nazwa</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Format danych</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Format danych</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Nowy format danych</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Format danych: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Opisz jak najdokładniej metadane dla formatu plików określonego poniżej. Nazwy formatów muszą być unikalne, typy MIME – nie. Możesz zdefiniować różne formaty dla różnych wersji plików Microsoft Word, nawet jeśli typ MIME dla nich będzie taki sam.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Nazwa</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Unikalna nazwa dla tego formatu, (np. Microsoft Word 97 lub Microsoft Word 2003)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Nazwa pola jest wymagana.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Typ MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">Typ mime połączony z formatem wcale nie musi być unikalny.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Opis</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Poziom wsparcia</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Poziom wsparcia, do którego zobowiązuje Twoja instytucja.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Nieznany</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Znany</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Obsługiwany</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Wewnętrzny</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Formaty „wewnętrzne” są niewidoczne dla użytkowników, mają zastosowanie tylko do zadań administracyjnych.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Rozszerzenia plików</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Rozszerzenia są rozszerzeniami plików, które są używane do automatycznej identyfikacji formatu wysyłanych plików. Możesz wpisać kilkanaście rozszerzeń dla każdego formatu.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Schemat metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Schemat metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Schemat metadanych: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">To schemat metadanych dla "{0}". Możesz dodać nowe lub zmienić istniejące pola metadanych. Możesz także usunąć wybrane pola lub przenieść je do definicji innego schematu.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Pola schematu metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Pole</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Zakres</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Brak pól metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Usuń pole</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Przenieś pola do innego schematu</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Dodaj nowe pole metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Nazwa pola</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Zakres</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Dodatkowe informacje o polu metadanych.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Dodaj nowe pole metadanych</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Aktualizuj pole: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Aktualizuj pole</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Błąd</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Nazwa pola jest już używana, wszystkie elementy i kwalifikatory muszą być unikalne.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">„Element” jest wymagany dla definicji pola.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Element w polu zawiera niepoprawny znak.  Element </message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">„Element” jest za długi w definicji pola, powinien być krótszy niż 32 znaki.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Kwalifikator pola jest zbyt długi, powinien być krótszy niż 32 znaki.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Kwalifikator pola zawiera niepoprawny znak. Kwalifikator </message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Rejestr formatów</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Rejestr formatów plików</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Oto lista formatów plików, zawierająca informację o znanych formatach i poziomie ich wsparcia. Za pomocą tego narzędzia możesz edytować lub dodawać nowe formaty plików. Formaty oznaczone jako „wewnętrzne” są ukryte przed użytkownikami i służą wyłącznie celom administracyjnym.</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Dodaj nowy format danych</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nazwa</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Typ MIME</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Poziom obsługi</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Nieznany</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Znany</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Obsługiwany</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.submit_delete">Usuń definicje formatów</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MetadatRegistryMain.java -->
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Rejestr metadanych</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Rejestr metadanych</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Rejestr metadanych przechowuje listę wszystkich pól metadanych dostępnych dla repozytorium. Pola mogą być podzielone pomiędzy różne schematy. DSpace wymaga jednak, aby zdefiniowany był co najmniej jeden schemat – Dublin Core. Można go rozszerzać, a także dodawać do rejestru nowe schematy.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Przestrzeń nazw</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nazwa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_delete">Usuń schemat</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.head2">Dodaj schemat</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace">Przestrzeń nazw</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_help">Definicją przestrzeni nazw powinien być poprawny adres URI nowego schematu.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.namespace_error">To pole jest wymagane.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name">Nazwa</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_help">Skrót nazwy schematu. Pole będzie użyte jako prefiks nazw pól (np. dc.element.qualifier). Skrót musi być krótszy niż 32 znaki i nie może zawierać spacji, kropek i podkreśleń.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.name_error">To pole jest wymagane. Musi zawierać mniej niż 32 znaku i nie może zawierać spacji, kropek, podkreśleń.</message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.submit_add">Dodaj schemat</message>
+
+	<!-- org.dspace.app.xmlui.administrative.registries.MoveMetadataField.java -->
+	<message key="xmlui.administrative.registries.MoveMetadataField.title">Przenieś pola</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.trail">Przenieś pola</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.head1">Przenieś pola metadanych</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para1">Wybierz docelowy schemat, do którego zostaną przeniesione te pola. Jeśli docelowy schemat ma pola nazywające się tak samo, wówczas pola nie zostaną przeniesione.</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column1">ID</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column2">Nazwa</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.column3">Zakres</message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Przenieś do schatu: </message>
+	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Przenieś pola</message>
 
 
 
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edytuj ustawienia zabezpieczeń</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Lista ustawień zabezpieczeń</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Ustawienia zabezpieczeń dla kolekcji "{0}" ({1},ID: {2})</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Ustawienia zabezpieczeń dla zbioru "{0}" ({1},ID: {2})</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Kliknij tu, aby dodać nowe ustawienia zabezpieczeń. </message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Dodaj</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+
+	<!-- general authorization keywords -->
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Autoryzacja</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Lista uprawnień i zabezpieczeń</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
+	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Zarządzanie ustawieniami autoryzacji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Zarządzanie ustawieniami autoryzacji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_head">Autoryzacje pozycji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.bad_name">Podany identyfikator nie określa żadnej pozycji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_item_lookup">Poszukaj pozycji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.search_help">Pozycji można szukać używając wskaźnika lub identyfikatora</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.submit_find">Znajdź</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced">Zaawansowane narzędzie autoryzacji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Kliknij tu, aby przejść do narzędzia zarządzania uprawnieniami pozycji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Autoryzacja zbioru/kolekcji</message>
+	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Kliknij zbiór lub kolekcję, aby edytować ustawienia zabezpieczeń.</message>
+
+
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Edytuj ustawienia zabezpieczeń</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Lista ustawień zabezpieczeń</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_collection">Ustawienia zabezpieczeń dla kolekcji "{0}" ({1},ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_head_community">Ustawienia zabezpieczeń dla zbioru "{0}" ({1},ID: {2})</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Kliknij tu, aby dodać nowe ustawienia zabezpieczeń. </message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Dodaj</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Nazwa</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Działanie</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupa</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Działanie</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Grupa</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Data początkowa</message>
     <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">Data końcowa</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Usuń zaznaczone</message>
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edytuj</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Usuń zaznaczone</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Edytuj</message>
 
 
 
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
-    <message key="xmlui.administrative.authorization.EditItemPolicies.title">Edytuj ustawienia zabezpieczeń pozycji</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.trail">Lista ustawień zabezpieczeń</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Ustawienia zabezpieczeń dla pozycji {0} (ID={1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Za pomocą tego edytora można przeglądać i zmieniać ustawienia zabezpieczeń dla pozycji oraz zmieniać ustawienia zabezpieczeń poszczególnych składników pozycji: pakietów i plików. Pozycja jest "pojemnikiem" dla pakietów, a te z kolei są "pojemnikami" dla plików. Pojemniki zwykle mogą posiadać szczegółowe ustawienia zabezpieczeń dla operacji DODAWANIA/USUWANIA/ODCZYTU/ZAPISU, pliki tymczasem posiadają ustawienia dla operacji ODCZYTU/ZAPISU.</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Dla każdej pozycji zauważysz dodatkowy pakiet i plik zawierający licencję dla pozycji.</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Reguły pozycji</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Reguły dla pakietu {0} ({1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Plik {0} ({1})</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Dodaj nową regułę dla pozycji</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Dodaj nową regułę dla pakietu</message>
-    <message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Dodaj nową regułę dla pliku</message>
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
+	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Edytuj ustawienia zabezpieczeń pozycji</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Lista ustawień zabezpieczeń</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Ustawienia zabezpieczeń dla pozycji {0} (ID={1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Za pomocą tego edytora można przeglądać i zmieniać ustawienia zabezpieczeń dla pozycji oraz zmieniać ustawienia zabezpieczeń poszczególnych składników pozycji: pakietów i plików. Pozycja jest "pojemnikiem" dla pakietów, a te z kolei są "pojemnikami" dla plików. Pojemniki zwykle mogą posiadać szczegółowe ustawienia zabezpieczeń dla operacji DODAWANIA/USUWANIA/ODCZYTU/ZAPISU, pliki tymczasem posiadają ustawienia dla operacji ODCZYTU/ZAPISU.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Dla każdej pozycji zauważysz dodatkowy pakiet i plik zawierający licencję dla pozycji.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Reguły pozycji</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">Reguły dla pakietu {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bitstream">Plik {0} ({1})</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Dodaj nową regułę dla pozycji</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Dodaj nową regułę dla pakietu</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Dodaj nową regułę dla pliku</message>
 
-    <message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Nie znaleziono reguł dla tego obiektu.</message>
+	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Nie znaleziono reguł dla tego obiektu.</message>
 
 
-    <!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
-    <message key="xmlui.administrative.authorization.EditPolicyForm.title">Edytor reguł</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edytor reguł</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Utwórz nową regułę dla {0} {1}</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edycja reguły {0} dla {1} {2}</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Żadna grupa nie jest zaznaczona</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Żadne działanie nie jest zaznaczone</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nazwa</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Akcje dla tego zasobu</message>
+	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
+	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Edytor reguł</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Edytor reguł</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_new">Utwórz nową regułę dla {0} {1}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edycja reguły {0} dla {1} {2}</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Żadna grupa nie jest zaznaczona</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Żadne działanie nie jest zaznaczone</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nazwa</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Akcje dla tego zasobu</message>
 
-    <message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Ustaw</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.current_group">obecna</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Wyniki wyszukania</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Wybierz grupę</message>
-    <message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Szukaj dla grupy</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Ustaw</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">obecna</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Wyniki wyszukania</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.policy_currentGroup">Wybierz grupę</message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Szukaj dla grupy</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Szukaj</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Wybierz działanie</message>
-    
+
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Nazwa</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Opis</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Data początkowa</message>
@@ -1289,20 +1416,20 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Akceptowane formaty: rrrr, rrrr-mm, rrrr-mm-dd</message>
 
     <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Zaawansowany menedżer reguł</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Zaawansowana autoryzacja</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Zaawansowany menedżer reguł</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Możesz dodawać i usuwać ustawienia zabezpieczeń dla różnych rodzajów zawartości w ramach kolekcji.    UWAGA - usunięcie uprawnień ODCZYTU (READ) zablokuje moliwość przeglądania tej pozycji!</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Dla wszystkich zaznaczonych grup...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Zaawansowany menedżer reguł</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Zaawansowana autoryzacja</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Zaawansowany menedżer reguł</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_para">Możesz dodawać i usuwać ustawienia zabezpieczeń dla różnych rodzajów zawartości w ramach kolekcji.    UWAGA - usunięcie uprawnień ODCZYTU (READ) zablokuje moliwość przeglądania tej pozycji!</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_groupSentence">Dla wszystkich zaznaczonych grup...</message>
     <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_actionSentence">...przyznaj uprawnienia wykonywania następujących zadań...</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...dla wszystkich poniższych rodzajów obiektów...</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_resourceSentence">...dla wszystkich poniższych rodzajów obiektów...</message>
     <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_collectionSentence">...w następujących kolekcjach.</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupa</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Działanie</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Typ zawartości</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Kolekcja</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Dodaj reguły</message>
-    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Wyczyść reguły</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyGroup">Grupa</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyAction">Działanie</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyResource">Typ zawartości</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Kolekcja</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Dodaj reguły</message>
+	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Wyczyść reguły</message>
     <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Akceptowane formaty: rrrr, rrrr-mm, rrrr-mm-dd</message>
 
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nazwa</message>
@@ -1314,578 +1441,615 @@
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Wybierz conajmniej grupę</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Wybierz conajmniej kolekcję</message>
 
-    <!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Potwierdzenie kasowania reguły.</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Potwierdź kasowanie</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Potwierdź kasowanie</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Podane reguły zostaną usunięte: </message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Działanie</message>
-    <message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupa</message>
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Potwierdzenie kasowania reguły.</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Potwierdź kasowanie</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Potwierdź kasowanie</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">Podane reguły zostaną usunięte: </message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Działanie</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupa</message>
 
-    <!-- general edit item messages -->
-    <message key="xmlui.administrative.item.general.item_trail">Pozycje</message>
-    <message key="xmlui.administrative.item.general.template_head">Edytuj szablon pozycji dla kolekcji: {0}</message>
-    <message key="xmlui.administrative.item.general.option_head">Edytuj pozycję</message>
-    <message key="xmlui.administrative.item.general.option_status">Status pozycji</message>
-    <message key="xmlui.administrative.item.general.option_bitstreams">Dane pozycji</message>
-    <message key="xmlui.administrative.item.general.option_metadata">Metadane pozycji</message>
-    <message key="xmlui.administrative.item.general.option_view">Oglądaj pozycję</message>
-    <message key="xmlui.administrative.item.general.option_curate">Zadania opiekuna</message>
-    <message key="xmlui.administrative.item.general.option_queue">Kolejka</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-    <message key="xmlui.administrative.item.AddBitstreamForm.title">Wysyłanie danych</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.trail">Wysyłanie danych</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.head1">Wyślij nowe dane</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Pakiet</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Plik z zawartością (domyślne)</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadane plików</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturki</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licencje</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licencje Creative Commons</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.file_label">Plik</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.file_help">Podaj nazwę pliku znajdującego się na Twoim komputerze. Jeżeli naciśniesz przycisk „Przeglądaj”, będziesz mógł skorzystać z okienka wyboru pliku.</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.description_label">Opis</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.description_help">Krótki opis pliku, np. „<i>Główna część artykułu</i>” lub „<i>Wyniki doświadczeń</i>”.(Pole nieobowiązkowe).</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Wyślij</message>
-    <message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Musisz mieć uprawnienia DODAWANIA i ZAPISU co najmniej do jednego pakietu, aby móc dodawać nowe pliki.</message>
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Potwierdź usunięcie</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Potwierdź usunięcie</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Potwierdź usunięcie(a)</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Czy jesteś pewien, że chcesz usunąć te pliki:</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nazwa</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Opis</message>
-    <message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-    <message key="xmlui.administrative.item.ConfirmItemForm.title">Potwierdź</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.trail">Potwierdź</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.head1">Modyfikuj pozycje: {0}</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Czy jesteś pewien, że ta pozycja powinna zostać całkowicie skasowana? Ostrożnie: po skasowanej pozycji nie pozostanie żaden ślad.</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Czy jesteś pewien, że ta pozycja powinna zostać wycofana z archiwum?</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Czy jesteś pewien, że ta pozycja powinna zostać przywrócona do archiwum?</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column1">Pole</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column2">Wartość</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.column3">Język</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Wycofaj</message>
-    <message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Przywróć</message>
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
+	<!-- general edit item messages -->
+	<message key="xmlui.administrative.item.general.item_trail">Pozycje</message>
+	<message key="xmlui.administrative.item.general.template_head">Edytuj szablon pozycji dla kolekcji: {0}</message>
+	<message key="xmlui.administrative.item.general.option_head">Edytuj pozycję</message>
+	<message key="xmlui.administrative.item.general.option_status">Status pozycji</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Dane pozycji</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Metadane pozycji</message>
+	<message key="xmlui.administrative.item.general.option_view">Oglądaj pozycję</message>
+        <message key="xmlui.administrative.item.general.option_curate">Zadania opiekuna</message>
+        <message key="xmlui.administrative.item.general.option_queue">Kolejka</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Wysyłanie danych</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Wysyłanie danych</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Wyślij nowe dane</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Pakiet</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Plik z zawartością (domyślne)</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadane plików</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Miniaturki</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Licencje</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Licencje Creative Commons</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Plik</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Podaj nazwę pliku znajdującego się na Twoim komputerze. Jeżeli naciśniesz przycisk „Przeglądaj”, będziesz mógł skorzystać z okienka wyboru pliku.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Opis</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Krótki opis pliku, np. „<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Wyślij</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Musisz mieć uprawnienia DODAWANIA i ZAPISU co najmniej do jednego pakietu, aby móc dodawać nowe pliki.</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Potwierdź usunięcie</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Potwierdź usunięcie</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Potwierdź usunięcie(a)</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Czy jesteś pewien, że chcesz usunąć te pliki:</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Nazwa</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Opis</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Format</message>
+
+	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Potwierdź</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Potwierdź</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modyfikuj pozycje: {0}</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Czy jesteś pewien, że ta pozycja powinna zostać całkowicie skasowana? Ostrożnie: po skasowanej pozycji nie pozostanie żaden ślad.</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Czy jesteś pewien, że ta pozycja powinna zostać wycofana z archiwum?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Czy jesteś pewien, że ta pozycja powinna zostać przywrócona do archiwum?</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Pole</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Wartość</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Język</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Wycofaj</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Przywróć</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Ukryj (uczyń prywatną)</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Upublicznij</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-    <message key="xmlui.administrative.item.MoveItemForm.title">Przenieś</message>
-    <message key="xmlui.administrative.item.MoveItemForm.trail">Przenieś</message>
-    <message key="xmlui.administrative.item.MoveItemForm.head1">Przenieś pozycję: {0}</message>
-    <message key="xmlui.administrative.item.MoveItemForm.collection">Kolekcja</message>
-    <message key="xmlui.administrative.item.MoveItemForm.collection_help">Wybierz kolekcję, do której chciałbyś przenieść tę pozycję.</message>
-    <message key="xmlui.administrative.item.MoveItemForm.collection_default">Wybierz kolekcję...</message>
-    <message key="xmlui.administrative.item.MoveItemForm.submit_move">Przenieś</message>
+	<message key="xmlui.administrative.item.MoveItemForm.title">Przenieś</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Przenieś</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Przenieś pozycję: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Kolekcja</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Wybierz kolekcję, do której chciałbyś przenieść tę pozycję.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Wybierz kolekcję...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Przenieś</message>
     <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Dziedziczenie uprawnień</message>
     <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Dziedziczenie domyślnych uprawnień dostępu docelowej kolekcji</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-    <message key="xmlui.administrative.item.EditBitstreamForm.title">Edycja danych</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.trail">Edycja danych</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.head1">Edycja danych</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.file_label">Plik</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Podstawowe dane</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">tak</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">nie</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.description_label">Opis</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.description_help">Krótki opis pliku, np. „<i>Główna część artykułu</i>” lub „<i>Wyniki doświadczeń</i>”.(Pole nieobowiązkowe).</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.para1">Wybierz format pliku z listy poniżej, na przykład „<i>Adobe PDF</i>” lub „<i>Microsoft Word</i>”. <strong>Jeśli format nie znajduje się na poniższej liście</strong>, opisz go w polu poniżej.</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.format_label">Wybrany format</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format nie znajduje się na liście</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.para2">Jeśeli format pliku nie znajduje się na powyższej liście, <strong>wybierz opcję „format nie znajduje się na liście” powyżej</strong> i opisz format pliku poniżej.</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.user_label">Inny format</message>
-    <message key="xmlui.administrative.item.EditBitstreamForm.user_help">Nazwa aplikacji użytej przy tworzeniu pliku i numer wersji (na przykład „<i>ACMESoft SuperApp werjsa 1.5</i>”).</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Edycja danych</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Edycja danych</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Edycja danych</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">Plik</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Podstawowe dane</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">tak</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">nie</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Opis</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Krótki opis pliku, np. „<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Wybierz format pliku z listy poniżej, na przykład „<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Wybrany format</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Format nie znajduje się na liście</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Jeśeli format pliku nie znajduje się na powyższej liście, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Inny format</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Nazwa aplikacji użytej przy tworzeniu pliku i numer wersji (na przykład „<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nazwa pliku</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Zmiana nazwy pliku.  Zmieni się URL tego pliku, ale stare odnośniki będą działały.</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Dane pozycji</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Dane pozycji</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Dane</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nazwa</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Opis</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Zobacz</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Kolejność</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Pakiet: {0}</strong></message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (podstawowe) </message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">zobacz</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Wyślij nowe dane</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Usuń dane</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Zmień kolejność plików</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Potrzebujesz uprawnienia DODAWANIA i ZAPISU dla pozycji i pakietów aby móc wysyłać nowe dane.</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Tylko administratorzy systemu mogą usunąć dane / pliki.</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Poprzedni:</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Przesuń do góry</message>
-    <message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Przesuń w dół</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Dane pozycji</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Dane pozycji</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Dane</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nazwa</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Opis</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Zobacz</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Kolejność</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (podstawowe) </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">zobacz</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Wyślij nowe dane</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Usuń dane</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Zmień kolejność plików</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Potrzebujesz uprawnienia DODAWANIA i ZAPISU dla pozycji i pakietów aby móc wysyłać nowe dane.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Tylko administratorzy systemu mogą usunąć dane / pliki.</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Poprzedni:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Przesuń do góry</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Przesuń w dół</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-    <message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadane pozycji</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadane pozycji</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.head1">Dodaj nowe metadane</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nazwa</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Wartość</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Język</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Dodaj nowe metadane</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.para1">ZAUWAŻ, że te zmiany nie są w żaden sposób weryfikowane. Jesteś całkowicie odpowiedzialny za wprowadzenie danych w poprawnym formacie. Jeśli nie jesteś go pewien, NIE wprowadzaj zmian.</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadane</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column1">Usuń</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nazwa</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column3">Wartość</message>
-    <message key="xmlui.administrative.item.EditItemMetadataForm.column4">Język</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Metadane pozycji</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Metadane pozycji</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Dodaj nowe metadane</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Nazwa</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Wartość</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Język</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Dodaj nowe metadane</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">ZAUWAŻ, że te zmiany nie są w żaden sposób weryfikowane. Jesteś całkowicie odpowiedzialny za wprowadzenie danych w poprawnym formacie. Jeśli nie jesteś go pewien, NIE wprowadzaj zmian.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadane</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Usuń</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Nazwa</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column3">Wartość</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.column4">Język</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
-    <message key="xmlui.administrative.item.EditItemStatusForm.title">Status pozycji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.trail">Status pozycji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.para1">Witaj na stronie zarządzania pozycjami. Tutaj możesz wycofać, przywrócić, przenieść lub usunąć pozycję. Możesz także zakutalizować lub dodać metadane lub dane na innych zakładkach.</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_id">Wewnętrzny identyfikator pozycji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Wskaźnik</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Ostatnio modyfikowane</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_in">W kolekcji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_page">Strona pozycji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Modyfikuj ustawienia autoryzacji dla pozycji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Wycofaj pozycję z repozytorium</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Przywróć pozycję do tego repozytorium</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_move">Przenieś pozycję do innej kolekcji</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Całkowicie usuń pozycję</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autoryzacje...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Wycofanie...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Przywrócenie...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Przeniesienie...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Usuń całkowicie</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.na">nd.</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(tylko administratorzy systemu)</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(tylko administratorzy kolekcji)</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(nie masz wystarczających uprawnień dla tego zadania)</message>
+	<!-- org.dspace.app.xmlui.administrative.item.EditItemStatusForm -->
+	<message key="xmlui.administrative.item.EditItemStatusForm.title">Status pozycji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.trail">Status pozycji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.para1">Witaj na stronie zarządzania pozycjami. Tutaj możesz wycofać, przywrócić, przenieść lub usunąć pozycję. Możesz także zakutalizować lub dodać metadane lub dane na innych zakładkach.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_id">Wewnętrzny identyfikator pozycji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_handle">Wskaźnik</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_modified">Ostatnio modyfikowane</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_in">W kolekcji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_page">Strona pozycji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_auth">Modyfikuj ustawienia autoryzacji dla pozycji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_withdraw">Wycofaj pozycję z repozytorium</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_reinstate">Przywróć pozycję do tego repozytorium</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Przenieś pozycję do innej kolekcji</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Całkowicie usuń pozycję</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Autoryzacje...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Wycofanie...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Przywrócenie...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Przeniesienie...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Usuń całkowicie</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.na">nd.</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(tylko administratorzy systemu)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(tylko administratorzy kolekcji)</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(nie masz wystarczających uprawnień dla tego zadania)</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Ukryj pozycję (uczyń prywatną)</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Upublicznij pozycję</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Ukryj...</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Upublicznij...</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
-    <message key="xmlui.administrative.item.ViewItem.title">Przeglądaj pozycję</message>
-    <message key="xmlui.administrative.item.ViewItem.trail">Przeglądaj pozycję</message>
-    <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
-    <message key="xmlui.administrative.item.CurateItemForm.main_head">Sprawdź pozycję: {0}</message>
-    <message key="xmlui.administrative.item.CurateItemForm.title">Sprawdź pozycję</message>
-    <message key="xmlui.administrative.item.CurateItemForm.trail">Zadanie opiekuna</message>
-    <message key="xmlui.administrative.item.CurateItemForm.label_name">Zadanie</message>
 
-    <!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
-    <message key="xmlui.administrative.item.FindItemForm.title">Znajdź pozycję</message>
-    <message key="xmlui.administrative.item.FindItemForm.head1">Znajdź pozycję</message>
-    <message key="xmlui.administrative.item.FindItemForm.identifier_label">Wewnętrzny identyfikator pozycji/wskaźnik pozycji</message>
-    <message key="xmlui.administrative.item.FindItemForm.identifier_error">Nie rozpoznany identyfikator.</message>
-    <message key="xmlui.administrative.item.FindItemForm.find">Znajdź</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport -->
-    <message key="xmlui.administrative.metadataimport.general.title">Importuj metadane</message>
-    <message key="xmlui.administrative.metadataimport.general.head1">Importuj metadane</message>
-    <message key="xmlui.administrative.metadataimport.general.trail">Importuj metadane</message>
-    <message key="xmlui.administrative.metadataimport.general.changes">zmiany</message>
-    <message key="xmlui.administrative.metadataimport.general.no_changes">Żadne zmiany nie zostały wykryte</message>
-    <message key="xmlui.administrative.metadataimport.general.new_item">Nowa pozycja</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_successful">Wysyłanie udane</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_failed">Wysyłanie nieudane</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Nieznana schema metadanych w nagłówku</message>
-    <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Nieznany element metadanych w nagłówku</message>
-    <message key="xmlui.administrative.metadataimport.flow.import_successful">Import udany</message>
-    <message key="xmlui.administrative.metadataimport.flow.import_failed">Import nieudany</message>
-    <message key="xmlui.administrative.metadataimport.flow.over_limit">Ilość zmian przekroczył maksymalną dopuszczalną ilość. Ogranicz ilość zmian lub zmień wartość pola bulkedit.gui-item-limit w pliku dspace.cfg</message>
+	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
+	<message key="xmlui.administrative.item.ViewItem.title">Przeglądaj pozycję</message>
+	<message key="xmlui.administrative.item.ViewItem.trail">Przeglądaj pozycję</message>
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Sprawdź pozycję: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Sprawdź pozycję</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Zadanie opiekuna</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Zadanie</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Wyślij CSV</message>
+	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
+	<message key="xmlui.administrative.item.FindItemForm.title">Znajdź pozycję</message>
+	<message key="xmlui.administrative.item.FindItemForm.head1">Znajdź pozycję</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_label">Wewnętrzny identyfikator pozycji/wskaźnik pozycji</message>
+	<message key="xmlui.administrative.item.FindItemForm.identifier_error">Nie rozpoznany identyfikator.</message>
+	<message key="xmlui.administrative.item.FindItemForm.find">Znajdź</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Poprawnie przetworzone</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Zmiany pozycji wprowadzone</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Dodane: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Usunięte: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Dodany do nowej kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Usunięty z kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Przypisany do kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Usunięte przypisanie do kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Pozycja usunięta</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Pozycja wycofana</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Pozycja przywrócona</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport -->
+        <message key="xmlui.administrative.metadataimport.general.title">Importuj metadane</message>
+        <message key="xmlui.administrative.metadataimport.general.head1">Importuj metadane</message>
+        <message key="xmlui.administrative.metadataimport.general.trail">Importuj metadane</message>
+        <message key="xmlui.administrative.metadataimport.general.changes">zmiany</message>
+        <message key="xmlui.administrative.metadataimport.general.no_changes">Żadne zmiany nie zostały wykryte</message>
+        <message key="xmlui.administrative.metadataimport.general.new_item">Nowa pozycja</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_successful">Wysyłanie udane</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_failed">Wysyłanie nieudane</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Nieznana schema metadanych w nagłówku</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Nieznany element metadanych w nagłówku</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_successful">Import udany</message>
+        <message key="xmlui.administrative.metadataimport.flow.import_failed">Import nieudany</message>
+        <message key="xmlui.administrative.metadataimport.flow.over_limit">Ilość zmian przekroczył maksymalną dopuszczalną ilość. Ogranicz ilość zmian lub zmień wartość pola bulkedit.gui-item-limit w pliku dspace.cfg</message>
 
-    <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Dodaj: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Usuń: </message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Dodany do nowej kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Usunięty z kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Przypisany do kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Usunięte przypisanie do kolekcji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Oczekujące zmiany pozycji</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Zastosuj zmiany</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Zmiany oczekujące na przejrzenie znajdują się na poniższej liście</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Usuń pozycję</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Wycofaj pozycję</message>
-    <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Przywróć pozycję</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportMain.submit_upload">Wyślij CSV</message>
 
-    <!-- general mapper messages -->
-    <message key="xmlui.administrative.mapper.general.mapper_trail">Przyporządkowanie pozycji</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportConfirm -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.success">Poprawnie przetworzone</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.changes_committed">Zmiany pozycji wprowadzone</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_added">Dodane: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_removed">Usunięte: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_newowner">Dodany do nowej kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Usunięty z kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Przypisany do kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Usunięte przypisanie do kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Pozycja usunięta</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Pozycja wycofana</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Pozycja przywrócona</message>
 
-    <!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
-    <message key="xmlui.administrative.mapper.MapperMain.title">Przyporządkowanie pozycji</message>
-    <message key="xmlui.administrative.mapper.MapperMain.head1">Przyporządkowanie pozycji - przyporządkuj pozycje z innych kolekcji</message>
-    <message key="xmlui.administrative.mapper.MapperMain.para1">Kolekcja: "<strong>{0}</strong>"</message>
-    <message key="xmlui.administrative.mapper.MapperMain.para2">To narzędzie mapowania pozycji daje administratorom kolekcji możliwość przyporządkowania pozycji z innych kolekcji tej kolekcji. Możesz wyszukać pozycje, aby je dodać lub przejrzeć pozycje już przyporządkowane.</message>
-    <message key="xmlui.administrative.mapper.MapperMain.stat_label">Statystyki</message>
-    <message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} z {1}</strong> pozycji w tej kolekcji jest przyporządkowanych do innych kolekcji.</message>
-    <message key="xmlui.administrative.mapper.MapperMain.search_label">Szukaj</message>
-    <message key="xmlui.administrative.mapper.MapperMain.submit_search">Szukaj pozycji</message>
-    <message key="xmlui.administrative.mapper.MapperMain.submit_browse">Przeglądaj przyporządkowane pozycje</message>
-    <message key="xmlui.administrative.mapper.MapperMain.no_add">(Wymaga uprawnień DODAWANIA do kolekcji)</message>
+        <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Dodaj: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Usuń: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Dodany do nowej kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Usunięty z kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Przypisany do kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_unmapped">Usunięte przypisanie do kolekcji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Oczekujące zmiany pozycji</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Zastosuj zmiany</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Zmiany oczekujące na przejrzenie znajdują się na poniższej liście</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Usuń pozycję</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Wycofaj pozycję</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Przywróć pozycję</message>
 
-    <!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
-    <message key="xmlui.administrative.mapper.SearchItemForm.title">Szukanie pozycji</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.trail">Szukanie pozycji</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.head1">Szukanie pozycji spełniających kryteria: "{0}"</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Mapuje zaznaczone pozycje</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column2">Kolekcja</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
-    <message key="xmlui.administrative.mapper.SearchItemForm.column4">Tytuł</message>
+	<!-- general mapper messages -->
+	<message key="xmlui.administrative.mapper.general.mapper_trail">Przyporządkowanie pozycji</message>
 
-    <!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
-    <message key="xmlui.administrative.mapper.BrowseItemForm.title">Przeglądanie przyporządkowanych pozycji</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.trail">Przeglądanie przyporządkowanych pozycji</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.head1">Przeglądanie przyporządkowanych pozycji</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Usuń mapowanie wybranych pozycji</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column2">Kolekcja</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.column4">Tytuł</message>
-    <message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Musisz mieć uprawnienie USUWANIA z tej kolekcji, aby móc usunąć mapowanie pozycji.</message>
+	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
+	<message key="xmlui.administrative.mapper.MapperMain.title">Przyporządkowanie pozycji</message>
+	<message key="xmlui.administrative.mapper.MapperMain.head1">Przyporządkowanie pozycji - przyporządkuj pozycje z innych kolekcji</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para1">Kolekcja: "<strong>{0}</strong>"</message>
+	<message key="xmlui.administrative.mapper.MapperMain.para2">To narzędzie mapowania pozycji daje administratorom kolekcji możliwość przyporządkowania pozycji z innych kolekcji tej kolekcji. Możesz wyszukać pozycje, aby je dodać lub przejrzeć pozycje już przyporządkowane.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Statystyki</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
+	<message key="xmlui.administrative.mapper.MapperMain.search_label">Szukaj</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Szukaj pozycji</message>
+	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Przeglądaj przyporządkowane pozycje</message>
+	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Wymaga uprawnień DODAWANIA do kolekcji)</message>
 
-    <!-- General tags for collection management -->
-    <message key="xmlui.administrative.collection.general.collection_trail">Kolekcje</message>    
-    <message key="xmlui.administrative.collection.general.options_metadata">Edytuj metadane</message>    
-    <message key="xmlui.administrative.collection.general.options_roles">Przypisz role</message>    
+	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
+	<message key="xmlui.administrative.mapper.SearchItemForm.title">Szukanie pozycji</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Szukanie pozycji</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Szukanie pozycji spełniających kryteria: "{0}"</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Mapuje zaznaczone pozycje</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Kolekcja</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Tytuł</message>
+
+	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
+	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Przeglądanie przyporządkowanych pozycji</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Przeglądanie przyporządkowanych pozycji</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Przeglądanie przyporządkowanych pozycji</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Usuń mapowanie wybranych pozycji</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Kolekcja</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Tytuł</message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Musisz mieć uprawnienie USUWANIA z tej kolekcji, aby móc usunąć mapowanie pozycji.</message>
+
+	<!-- General tags for collection management -->
+	<message key="xmlui.administrative.collection.general.collection_trail">Kolekcje</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Edytuj metadane</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Przypisz role</message>
         <message key="xmlui.administrative.collection.general.options_curate">Zadania opiekuna</message>
         <message key="xmlui.administrative.collection.general.options_queue">Kolejka</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edycja ról dla kolekcji</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Role</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edycja kolekcji: {0}</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">brak</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.create">Utwórz...</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Ogranicz...</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Administratorzy kolekcji decydują, kto może dodawać pozycje do kolekcji, edytować metadane (po dodaniu pozycji), a także dodawać (przyporządkować) istniejące pozycje z innych kolekcji do tej kolekcji (w zależności od ustawień autoryzacji kolekcji).</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Osoby odpowiedzialne za ten krok mogą zaakceptować lub odrzucić dodawane pozycje, nie mogą jednak edytować metadanych w nowododanych pozycjach.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Osoby odpowiedzialne za ten krok mogą modyfikować metadane nowych pozycji oraz akceptować lub odrzucać te pozycje.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Osoby odpowiedzialne za ten krok mogą modyfikować metadane, ale nie są uprawnione do akceptacji lub odrzucenia dodanych pozycji.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">E-osoby i grupy, które mają uprawnienia dodawania nowych pozycji do tej kolekcji.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">E-osoby i grupy, które mają uprawnienia odczytu nowych pozycji w tej kolekcji. Zmiany tej roli nie działają wstecz. Istniejące elementy systemu będą nadal widoczne dla tych, którzy mieli dostęp do odczytu w momencie ich dodawania.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Ta kolekcja ma własne domyślne ustawienia zabezpieczeń dostępu.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Domyślne uprawnienia odczytu dla nowych pozycji są ustawione dla użytkownika anonimowego.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Bezpośrednia edycja ustawień autoryzacji.</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Role</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Powiązania grupy</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">    </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administratorzy</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Kroki przepływu pracy</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Krok akceptuj/odrzuć </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Krok akceptuj/odrzuć/edytuj metadane </message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Krok edytuj metadane</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Dodający pozycje</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Domyślnie dostęp czytaj</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(wyłącznie administratorzy)</nobr></message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(wyłącznie administratorzy repozytorium)</message>
-    <message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(nie masz uprawnień do konfiguracji)</nobr></message>
+	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edycja ról dla kolekcji</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">Role</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.main_head">Edycja kolekcji: {0}</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.no_role">brak</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.create">Utwórz...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.restrict">Ogranicz...</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_admins">Administratorzy kolekcji decydują, kto może dodawać pozycje do kolekcji, edytować metadane (po dodaniu pozycji), a także dodawać (przyporządkować) istniejące pozycje z innych kolekcji do tej kolekcji (w zależności od ustawień autoryzacji kolekcji).</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step1">Osoby odpowiedzialne za ten krok mogą zaakceptować lub odrzucić dodawane pozycje, nie mogą jednak edytować metadanych w nowododanych pozycjach.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step2">Osoby odpowiedzialne za ten krok mogą modyfikować metadane nowych pozycji oraz akceptować lub odrzucać te pozycje.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_wf_step3">Osoby odpowiedzialne za ten krok mogą modyfikować metadane, ale nie są uprawnione do akceptacji lub odrzucenia dodanych pozycji.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_submitters">E-osoby i grupy, które mają uprawnienia dodawania nowych pozycji do tej kolekcji.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.help_default_read">E-osoby i grupy, które mają uprawnienia odczytu nowych pozycji w tej kolekcji. Zmiany tej roli nie działają wstecz. Istniejące elementy systemu będą nadal widoczne dla tych, którzy mieli dostęp do odczytu w momencie ich dodawania.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_custom">Ta kolekcja ma własne domyślne ustawienia zabezpieczeń dostępu.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.default_read_anonymous">Domyślne uprawnienia odczytu dla nowych pozycji są ustawione dla użytkownika anonimowego.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.edit_authorization">Bezpośrednia edycja ustawień autoryzacji.</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_name">Role</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_group">Powiązania grupy</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.role_buttons">    </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_admins">Administratorzy</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf">Kroki przepływu pracy</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step1">Krok akceptuj/odrzuć </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step2">Krok akceptuj/odrzuć/edytuj metadane </message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Krok edytuj metadane</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Dodający pozycje</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Domyślnie dostęp czytaj</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-    <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Sprawdź kolekcję: {0}</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.title">Sprawdź kolekcję</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Zadanie opiekuna</message>
-    <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Zadanie</message>
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Sprawdź kolekcję: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Sprawdź kolekcję</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Zadanie opiekuna</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Zadanie</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Potwierdzenie usunięcia</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Potwierdź</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Potwierdź usunięcie kolekcji {0}</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Czy jesteś pewien, że kolekcja {0} powinna być skasowana? To spowoduje skasowanie:</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Pozycje (również te, których proces dodawania nie został ukończony) w tej kolekcji, które nie są zawarte w żadnej innej</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Zawartość tych pozycji</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Wszystkie powiązane uprawnienia autoryzacji</message>
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Potwierdzenie usunięcia</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Potwierdź</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">Potwierdź usunięcie kolekcji {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">Czy jesteś pewien, że kolekcja {0} powinna być skasowana? To spowoduje skasowanie:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Pozycje (również te, których proces dodawania nie został ukończony) w tej kolekcji, które nie są zawarte w żadnej innej</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Zawartość tych pozycji</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Wszystkie powiązane uprawnienia autoryzacji</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Potwierdź usunięcie roli</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Potwierdź</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Potwierdź usunięcie roli {0}</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Czy jesteś pewien, że chcesz usunąć tę rolę? Usunięcie tej grupy spowoduje dodanie uprawnień ODCZYTU dla wszystkich nowododawanych pozycji wszystkim użytkownikom. Zauważ, że te zmiany nie działają wstecz. Istniejące w systemie pozycje wciąż będą mogły być odczytane jedynie przez osoby przypisane do roli, którą kasujesz.</message>
-    <message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Czy jesteś pewien, że chcesz skasować tę rolę? Wszystkie zmiany i dostosowania grupy {0} zostaną utracone, będzie trzeba je utworzyć na nowo.</message>
+	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Potwierdź usunięcie roli</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Potwierdź</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Potwierdź usunięcie roli {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Czy jesteś pewien, że chcesz usunąć tę rolę? Usunięcie tej grupy spowoduje dodanie uprawnień ODCZYTU dla wszystkich nowododawanych pozycji wszystkim użytkownikom. Zauważ, że te zmiany nie działają wstecz. Istniejące w systemie pozycje wciąż będą mogły być odczytane jedynie przez osoby przypisane do roli, którą kasujesz.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Czy jesteś pewien, że chcesz skasować tę rolę? Wszystkie zmiany i dostosowania grupy {0} zostaną utracone, będzie trzeba je utworzyć na nowo.</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edytuj metadane kolekcji</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadane</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edytuj kolekcję: {0}</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nazwa</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Krótki opis</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Wprowadzenie (HTML)</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Tekst praw autorskich (HTML)</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Nowości (HTML)</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licencja</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Pochodzenie</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Wyślij nowe logo</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Obecne logo</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Szablon pozycji</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Utwórz...</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edycja...</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Usuń logo</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Skasuj kolekcję</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Zapisz aktualizację</message>
-    <message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(tylko administratorzy)</nobr></message>
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Edytuj metadane kolekcji</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Metadane</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Edytuj kolekcję: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Nazwa</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Krótki opis</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Wprowadzenie (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Tekst praw autorskich (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Nowości (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Licencja</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Pochodzenie</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Wyślij nowe logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Obecne logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Szablon pozycji</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Utwórz...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Edycja...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Usuń logo</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Skasuj kolekcję</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Zapisz aktualizację</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-    <message key="xmlui.administrative.collection.CreateCollectionForm.title">Utwórz kolekcję</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.trail">Utwórz kolekcję</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Wpisz metadane dla nowej kolekcji z {0}</message>
-    <message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Utwórz</message>
+	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Utwórz kolekcję</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Utwórz kolekcję</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Wpisz metadane dla nowej kolekcji z {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Utwórz</message>
 
-    <!-- General to the harvesting options under collection -->
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Ustawienia zbierania kolekcji</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Zbieranie</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Źródło zawartości</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Źródło zawartości</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">To jest standardowa kolekcja DSpace</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Ta kolekcja zbiera zawartość z zewnętrznego źródła</message>
-    <message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Zapisz</message>
+	<!-- General to the harvesting options under collection -->
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Ustawienia zbierania kolekcji</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Zbieranie</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Źródło zawartości</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Źródło zawartości</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">To jest standardowa kolekcja DSpace</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Ta kolekcja zbiera zawartość z zewnętrznego źródła</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Zapisz</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Lokalizacja zebranej kolekcji</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opcje zbierania</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Dostawca OAI</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">Ustaw identyfikator OAI</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Format metadanych</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">URL docelowego repozytorium serwisu dostawcy OAI</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Musisz podać identyfikator kolekcji docelowej.</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Trwały identyfikator używany przez dostawcę OAI do wyznaczenia docelowej kolekcji</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Musisz podać identyfikator docelowej kolekcji.</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Zbierana zawartość</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Zbierz wyłącznie metadane.</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Zbierze metadane i odwołania do plików (wymaga obsługi ORE).</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Zbierze metadane i pliki (wymaga obsługi ORE).</message>
-    <message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Testuj ustawienia</message>
+	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Lokalizacja zebranej kolekcji</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Opcje zbierania</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Dostawca OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">Ustaw identyfikator OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Format metadanych</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">URL docelowego repozytorium serwisu dostawcy OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Musisz podać identyfikator kolekcji docelowej.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Trwały identyfikator używany przez dostawcę OAI do wyznaczenia docelowej kolekcji</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Musisz podać identyfikator docelowej kolekcji.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Zbierana zawartość</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Zbierz wyłącznie metadane.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Zbierze metadane i odwołania do plików (wymaga obsługi ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Zbierze metadane i pliki (wymaga obsługi ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Testuj ustawienia</message>
 
-    <!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Lokalizacja zebranej kolekcji</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Dostawca OAI</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">Identyfikator zbioru OAI</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Format metadanych</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Zbierana zawartość</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Wynik ostatniego zbierania</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Ta kolekcja jeszcze nie była zbierana.</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Obecny status zbierania</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Kolekcja gotowa do zbierania</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Kolekcja jest obecnie zbierana</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Kolekcja oczekuje w kolejce na zbieranie</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Błąd OAI pojawił się podczas ostatniego zbierania</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Nieoczekiwany błąd wystąpił podczas ostatniego zbierania</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Zbierz wyłącznie metadane.</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Zbierz metadane i odwołania do plików.</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Zbierz metadane i pliki (pełna replikacja).</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Zmień ustawienia</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importuj teraz</message>
-    <message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Zresetuj i zaimportuj kolekcję ponownie</message>
+	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Lokalizacja zebranej kolekcji</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Dostawca OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">Identyfikator zbioru OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Format metadanych</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Zbierana zawartość</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Wynik ostatniego zbierania</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Ta kolekcja jeszcze nie była zbierana.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Obecny status zbierania</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Kolekcja gotowa do zbierania</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Kolekcja jest obecnie zbierana</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Kolekcja oczekuje w kolejce na zbieranie</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">Błąd OAI pojawił się podczas ostatniego zbierania</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">Nieoczekiwany błąd wystąpił podczas ostatniego zbierania</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Zbierz wyłącznie metadane.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Zbierz metadane i odwołania do plików.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Zbierz metadane i pliki (pełna replikacja).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Zmień ustawienia</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Importuj teraz</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Zresetuj i zaimportuj kolekcję ponownie</message>
 
-    <message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Kontrola harmonogramów zbiorów</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_actions">Działania</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_submit_start">Uruchom proces zbierania</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Zresetuj status procesu zbierania</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Kontynuuj</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pauza</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_collections">Kolekcja skonfigurowana do zbierania</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_active">Aktywne procesy zbierające</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_queued">Procesy zbierania oczekujące w kolejce</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Błędy OAI</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Wewnętrzne błędy</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Ustawienia generatora</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Źródło ORE</message>
-    <message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Ustawienia procesów zbierania</message>    
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Harvesting</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Kontrola harmonogramów zbiorów</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Status</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Działania</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Uruchom proces zbierania</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Zresetuj status procesu zbierania</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Kontynuuj</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Pauza</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Stop</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Kolekcja skonfigurowana do zbierania</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Aktywne procesy zbierające</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Procesy zbierania oczekujące w kolejce</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Błędy OAI</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Wewnętrzne błędy</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Ustawienia generatora</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Źródło ORE</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Ustawienia procesów zbierania</message>
 
-    <!-- General tags for community management -->
-    <message key="xmlui.administrative.community.general.community_trail">Zbiory</message>
-    <message key="xmlui.administrative.community.general.options_metadata">Edytuj metadane</message>
-    <message key="xmlui.administrative.community.general.options_roles">Przypisz role</message>
-    <message key="xmlui.administrative.community.general.options_curate">Zadania opiekuna</message>
-    <message key="xmlui.administrative.community.general.options_queue">Kolejka</message>
+	<!-- General tags for community management -->
+	<message key="xmlui.administrative.community.general.community_trail">Zbiory</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Edytuj metadane</message>
+	<message key="xmlui.administrative.community.general.options_roles">Przypisz role</message>
+        <message key="xmlui.administrative.community.general.options_curate">Zadania opiekuna</message>
+        <message key="xmlui.administrative.community.general.options_queue">Kolejka</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-    <message key="xmlui.administrative.community.AssignCommunityRoles.title">Edytuj role dla zbiorów</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.trail">Role</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edytuj zbiór: {0}</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.no_role">brak</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.create">Utwórz...</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Administratorzy zbiorów mogą tworzyć podzbiory lub kolekcje. Mogą także zarządzać i przypisywać uprawnienia zarządzania tymi podzbiorami lub kolekcjami. Ponadto administratorzy decydują o tym, kto ma prawo dodawać nowe pozycje do podzbiorów, edytować metadane pozycji (po dodaniu) i dodawać mapowanie istniejących pozycji z innych kolekcji (w zależności od autoryzacji).</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Ten zbiór ma własne domyślne ustawienia zabezpieczeń dostępu.</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Domyślne uprawnienia odczytu dla nowych pozycji i plików są ustawione dla użytkownika anonimowego.</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Bezpośrednia edycja ustawień autoryzacji.</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Powiązane grupy</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administratorzy</message>
-    <message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(tylko administratorzy)</nobr></message>
+	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Edytuj role dla zbiorów</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Edytuj zbiór: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">brak</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Utwórz...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Administratorzy zbiorów mogą tworzyć podzbiory lub kolekcje. Mogą także zarządzać i przypisywać uprawnienia zarządzania tymi podzbiorami lub kolekcjami. Ponadto administratorzy decydują o tym, kto ma prawo dodawać nowe pozycje do podzbiorów, edytować metadane pozycji (po dodaniu) i dodawać mapowanie istniejących pozycji z innych kolekcji (w zależności od autoryzacji).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Ten zbiór ma własne domyślne ustawienia zabezpieczeń dostępu.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">Domyślne uprawnienia odczytu dla nowych pozycji i plików są ustawione dla użytkownika anonimowego.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Bezpośrednia edycja ustawień autoryzacji.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Role</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Powiązane grupy</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administratorzy</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-    <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Sprawdź zbiór: {0}</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.title">Sprawdzanie zbioru</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.trail">Zadanie opiekuna</message>
-    <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Zadanie</message>
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Sprawdź zbiór: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Sprawdzanie zbioru</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Zadanie opiekuna</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Zadanie</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Potwierdź skasowanie</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Potwierdź</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Potwierdź skasowanie zbioru {0}</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Czy jesteś pewien, że zbiór {0} powinien być usunięty? To skasuje:</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Wszystkie kolekcje w tym zbiorze, które nie są zawarte w innych zbiorach</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Wszystkie pozycje (w tym będące w trakcie dodawnia) w tym zbiorze, które nie są zawarte w innych zbiorach</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Zawartość tych pozycji</message>
-    <message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Wszystkie powiązane ustawienia autoryzacji</message>
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Potwierdź skasowanie</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Potwierdź</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Potwierdź skasowanie zbioru {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Czy jesteś pewien, że zbiór {0} powinien być usunięty? To skasuje:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Wszystkie kolekcje w tym zbiorze, które nie są zawarte w innych zbiorach</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Wszystkie pozycje (w tym będące w trakcie dodawnia) w tym zbiorze, które nie są zawarte w innych zbiorach</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Zawartość tych pozycji</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Wszystkie powiązane ustawienia autoryzacji</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-    <message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Potwierdź usunięcie roli</message>
-    <message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Potwierdzenie</message>
-    <message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Potwierdź usunięcie roli {0}</message>
-    <message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Czy na pewno chcesz usunąć tę rolę? Stracisz wszystkie zmiany i ustawienia dla grupy {0} i będziesz musiał wprowadzać je od początku.</message>
+	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Potwierdź usunięcie roli</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Potwierdzenie</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Potwierdź usunięcie roli {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Czy na pewno chcesz usunąć tę rolę? Stracisz wszystkie zmiany i ustawienia dla grupy {0} i będziesz musiał wprowadzać je od początku.</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edycja metadanych zbioru</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadane</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edytuj metadane dla zbioru {0}</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edycja ustawień autoryzacji</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nazwa</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Krótki opis</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Wprowadzenie (HTML)</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Tekst praw autorskich (HTML)</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Nowości (HTML)</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Wgraj nowe logo</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Obecne logo</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Usuń logo</message>
-    <message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Usuń zbiór</message>
+	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Edycja metadanych zbioru</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Metadane</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Edytuj metadane dla zbioru {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Edycja ustawień autoryzacji</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Nazwa</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Krótki opis</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Wprowadzenie (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Tekst praw autorskich (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Nowości (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Wgraj nowe logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Obecne logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Usuń logo</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Usuń zbiór</message>
 
-    <!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-    <message key="xmlui.administrative.community.CreateCommunityForm.title">Utwórz zbiór</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.trail">Utwórz zbiór</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Wprowadź metadane dla nowego podzbioru {0}</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Wprowadź metadane dla zbioru na najwyższym poziomie</message>
-    <message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Utwórz</message>
+	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Utwórz zbiór</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Utwórz zbiór</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Wprowadź metadane dla nowego podzbioru {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Wprowadź metadane dla zbioru na najwyższym poziomie</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Utwórz</message>
 
 
-    <!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-    <message key="xmlui.administrative.ControlPanel.title">Panel sterowania</message>
-    <message key="xmlui.administrative.ControlPanel.trail">Panel sterowania</message>
-    <message key="xmlui.administrative.ControlPanel.head">Panel sterowania</message>
-    <message key="xmlui.administrative.ControlPanel.option_java">Informacje Java</message>
-    <message key="xmlui.administrative.ControlPanel.option_dspace">Konfiguracja DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.option_alerts">Alerty systemowe</message>
-    <message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
-    <message key="xmlui.administrative.ControlPanel.minutes">{0} m</message>
-    <message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
-    <message key="xmlui.administrative.ControlPanel.java_head">Java i system operacyjny</message>
-    <message key="xmlui.administrative.ControlPanel.java_version">Wersja JRE</message>
-    <message key="xmlui.administrative.ControlPanel.java_vendor">Dostawca JRE</message>
-    <message key="xmlui.administrative.ControlPanel.os_name">Nazwa systemu operacyjnego</message>
-    <message key="xmlui.administrative.ControlPanel.os_arch">Architektura systemu operacyjnego</message>
-    <message key="xmlui.administrative.ControlPanel.os_version">Wersja systemu operacyjnego</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_head">Statystyki działania</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_processors">Dostępnych procesorów</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_max">Maksymalna pamięć</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_total">Zaalokowana pamięć</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_used">Użyta pamięć</message>
-    <message key="xmlui.administrative.ControlPanel.runtime_free">Wolna pamięc</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_head">Informacja o Cocoon</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_version">Wersja Cocoon</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Katalog podręczny Cocoon</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Katalog roboczy Cocoon</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Rozmiar głównej pamięci podręcznej ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Rozmiar stałej pamięci podręcznej ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Rozmiar tymczasowej pamięci podręcznej ({0})</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_head">Ustawienia DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_version">Wersja DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_dir">Katalog instalacyjny DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_url">Podstawowy URL DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_hostname">Nazwa serwera DSpace</message>
-    <message key="xmlui.administrative.ControlPanel.dspace_name">Nazwa repozytorium</message>
-    <message key="xmlui.administrative.ControlPanel.db_name">Nazwa bazy danych</message>
-    <message key="xmlui.administrative.ControlPanel.db_url">URL bazy danych</message>
-    <message key="xmlui.administrative.ControlPanel.db_driver">Sterownik JDBC</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxconnections">Maksymalna ilość połączeń z bazą danych</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxwait">Maksymalny czas oczekiwania bazy danych</message>
-    <message key="xmlui.administrative.ControlPanel.db_maxidle">Maksymalna ilość oczekujących połączeń</message>
-    <message key="xmlui.administrative.ControlPanel.mail_server">Serwer pocztowy SMTP</message>
-    <message key="xmlui.administrative.ControlPanel.mail_from_address">Z adresu e-mail</message>
-    <message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Adres e-mail, na który wysyłane są uwagi</message>
-    <message key="xmlui.administrative.ControlPanel.mail_admin">Adres e-mail administratora strony</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_head">Alarmy systemowe</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Ostrzeżenie dla systemów z równoważeniem obciążenia (load balanced systems)</strong>: Alarmy systemowe działają tylko w ramach aktywnego węzła. Musisz upewnić się, że każdy węzeł otrzymuje polecenie uaktywniające alarmy.</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_message_label">Wiadomość ostrzegawcza</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_message_default">System zostanie wyłączony do regularnej konserwacji. Zapisz swoją pracę i wyloguj się.</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Odliczanie</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Brak zegara odliczającego</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minut</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minut</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minut</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 godzina</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Zachowaj bieżący zegar odliczający czas</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_session_label">Zarządzaj sesjami</message>    
-    <message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Kontynuuj, aby umożliwić uwierzytelnianie sesji</message>    
-    <message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Ogranicz uwierzytelnianie, ale zachowaj już istniejące sesje</message>    
-    <message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Ogranicz uwierzytelnianie i zakończ istniejące sesje</message>    
-    <message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Informacja:</strong>Administratorzy strony nie podlegają zarządzaniu sesjami.</message>    
-    <message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktywuj</message>
-    <message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Dezaktywuj</message>
-    <message key="xmlui.administrative.ControlPanel.activity_head">Bieżąca aktywność (maksymalnie {0} stron)</message>
-    <message key="xmlui.administrative.ControlPanel.stop_anonymous">ZATRZYMAJ zapisywanie działań anonimowych.</message>
-    <message key="xmlui.administrative.ControlPanel.start_anonymous">ROZPOCZNIJ zapisywanie działań anonimowych.</message>
-    <message key="xmlui.administrative.ControlPanel.stop_bot">ZATRZYMAJ zapisywanie działań botów.</message>
-    <message key="xmlui.administrative.ControlPanel.start_bot">ROZPOCZNIJ zapisywanie działań botów.</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_time">Czas</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_user">Użytkownik</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adres IP</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_url">URL strony</message>
-    <message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Program kliencki</message>
-    <message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonim {0}</message>    
-    <message key="xmlui.administrative.ControlPanel.activity_none">Nie zapisano żadnych informacji o odsłonach stron.</message>
+	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
+	<message key="xmlui.administrative.ControlPanel.title">Panel sterowania</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Panel sterowania</message>
+	<message key="xmlui.administrative.ControlPanel.head">Panel sterowania</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Informacje Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Konfiguracja DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Alerty systemowe</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} h</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} m</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} s</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java i system operacyjny</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Wersja JRE</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Dostawca JRE</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Nazwa systemu operacyjnego</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Architektura systemu operacyjnego</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Wersja systemu operacyjnego</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Statystyki działania</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Dostępnych procesorów</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Maksymalna pamięć</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Zaalokowana pamięć</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Użyta pamięć</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Wolna pamięc</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Informacja o Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Wersja Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Katalog podręczny Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Katalog roboczy Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Rozmiar głównej pamięci podręcznej ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Rozmiar stałej pamięci podręcznej ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Rozmiar tymczasowej pamięci podręcznej ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Ustawienia DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Wersja DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Katalog instalacyjny DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">Podstawowy URL DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Nazwa serwera DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Nazwa repozytorium</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Nazwa bazy danych</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL bazy danych</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Sterownik JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Maksymalna ilość połączeń z bazą danych</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Maksymalny czas oczekiwania bazy danych</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Maksymalna ilość oczekujących połączeń</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Serwer pocztowy SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Z adresu e-mail</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Adres e-mail, na który wysyłane są uwagi</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">Adres e-mail administratora strony</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Alarmy systemowe</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Wiadomość ostrzegawcza</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">System zostanie wyłączony do regularnej konserwacji. Zapisz swoją pracę i wyloguj się.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Odliczanie</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Brak zegara odliczającego</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 minut</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 minut</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 minut</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 godzina</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Zachowaj bieżący zegar odliczający czas</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Zarządzaj sesjami</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Kontynuuj, aby umożliwić uwierzytelnianie sesji</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Ogranicz uwierzytelnianie, ale zachowaj już istniejące sesje</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Ogranicz uwierzytelnianie i zakończ istniejące sesje</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktywuj</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Dezaktywuj</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Bieżąca aktywność (maksymalnie {0} stron)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ZATRZYMAJ zapisywanie działań anonimowych.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">ROZPOCZNIJ zapisywanie działań anonimowych.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">ZATRZYMAJ zapisywanie działań botów.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">ROZPOCZNIJ zapisywanie działań botów.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Czas</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Użytkownik</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">Adres IP</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL strony</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">Program kliencki</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Anonim {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Nie zapisano żadnych informacji o odsłonach stron.</message>
 
-    <message key="xmlui.administrative.ControlPanel.select_panel">Skorzystaj z powyższych zakładek, aby wybrać interesującą Cię informację</message>
+	<message key="xmlui.administrative.ControlPanel.select_panel">Skorzystaj z powyższych zakładek, aby wybrać interesującą Cię informację</message>
 
-    <!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-    <message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Za {0} minut</strong>: </message>
+	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
-    <!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-    <message key="xmlui.administrative.NotAuthorized.title">Nieautoryzowany</message>
-    <message key="xmlui.administrative.NotAuthorized.trail">Nieautoryzowany</message>
-    <message key="xmlui.administrative.NotAuthorized.head">Niewystarczające uprawnienia</message>
-    <message key="xmlui.administrative.NotAuthorized.para1a">Konto, z którego korzystasz, nie ma wystarczających uprawnień, aby wykonać żądane zadanie. Jeśli sądzisz, że może to być efekt błędu lub masz pytania związane z uprawnieniami, skontaktuj się z administratorem strony </message>
-    <message key="xmlui.administrative.NotAuthorized.para1b">administratorzy systemu</message>
-    <message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-    <message key="xmlui.administrative.NotAuthorized.para2">Zaloguj jako inny użytkownik</message>
-
-    <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-    <message key="xmlui.administrative.CurateForm.title">Systemowe zadania opiekuna</message>
-    <message key="xmlui.administrative.CurateForm.trail">Zadania opiekuna</message>
-    <message key="xmlui.administrative.CurateForm.object_label_name">Obiekt w DSpace</message>
-    <message key="xmlui.administrative.CurateForm.object_hint">Wskazówka: podaj [prefiks]/0 aby uruchomić zadanie dla całego repozytorium (nie wszystkie zadania muszą obsługiwać takie rozwiązanie)</message>
-    <message key="xmlui.administrative.CurateForm.task_label_name">Zadanie</message>
+	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
+	<message key="xmlui.administrative.NotAuthorized.title">Nieautoryzowany</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">Nieautoryzowany</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Niewystarczające uprawnienia</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">Konto, z którego korzystasz, nie ma wystarczających uprawnień, aby wykonać żądane zadanie. Jeśli sądzisz, że może to być efekt błędu lub masz pytania związane z uprawnieniami, skontaktuj się z administratorem strony </message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">administratorzy systemu</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Zaloguj jako inny użytkownik</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">Systemowe zadania opiekuna</message>
+        <message key="xmlui.administrative.CurateForm.trail">Zadania opiekuna</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Obiekt w DSpace</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Wskazówka: podaj [prefiks]/0 aby uruchomić zadanie dla całego repozytorium (nie wszystkie zadania muszą obsługiwać takie rozwiązanie)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Zadanie</message>
     <!-- Used by Curate<DSO>Form classes also -->
-    <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Wybierz z następujących grup</message>
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Wybierz z następujących grup</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1908,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Odwiedziny plików</message>
     <message key="xmlui.statistics.Navigation.title">Statystyki</message>
     <message key="xmlui.statistics.Navigation.usage.view">Przejrzyj statystyki użycia</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Przejrzyj statystyki wyszukiwania</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Przejrzyj statystyki przepływu pracy</message>
     <message key="xmlui.statistics.trail">Statystyki</message>
@@ -1952,265 +2117,281 @@
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Konfiguracja ewaluacji przeglądania punktacji</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Pula przeglądania pojedynczego użytkownika</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Zdarzenie automatycznego przypisywania pojedynczemu użytkownikowi</message>
-    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Zdarzenie przeglądania pojedynczego użytkownika</message>z
-
-
-
-
-
-
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Zdarzenie przeglądania pojedynczego użytkownika</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-                          dri2xhtml
+                     Google Analytics Statistics Aspect
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
+	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+		                  dri2xhtml
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
 
 
-    <!-- structural.xsl -->
-    <message key="xmlui.dri2xhtml.structural.footer-promotional">
+
+	<!-- structural.xsl -->
+	<message key="xmlui.dri2xhtml.structural.footer-promotional">
         <a href="http://di.tamu.edu" id="ds-logo-link">
-            <span id="ds-footer-logo">&#160;</span>
-        </a>
-        <p> 
-            Ta strona używa Manakina, nowego interfejsu dla DSpace stworzonego przez Texas A&amp;M University 
-            Libraries. Interfejs może być zmodyfikowany przez Aspekty Manakina i Tematy bazujące na XSL. 
-            Więcej informacji <a href="http://di.tamu.edu">http://di.tamu.edu</a> i
-            <a href="http://dspace.org">http://dspace.org</a>.    Modyfikacje wprowadzone przez zespół
-            <a href="http://www.ceon.pl/">CeON</a> <a href="http://www.icm.edu.pl/">ICM UW</a>
-        </p>
-    </message>
-    <message key="xmlui.dri2xhtml.structural.contact-link">Kontakt z nami</message>
-    <message key="xmlui.dri2xhtml.structural.feedback-link">Wyślij uwagi</message>
+			<span id="ds-footer-logo"> </span>
+		</a>
+		<p>
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
+		</p>
+	</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Kontakt z nami</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Wyślij uwagi</message>
 
-    <message key="xmlui.dri2xhtml.structural.head-subtitle">Repozytorium Centrum Otwartej Nauki</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Repozytorium Centrum Otwartej Nauki</message>
 
-    <message key="xmlui.dri2xhtml.structural.profile">Profil: </message>
-    <message key="xmlui.dri2xhtml.structural.logout">Wyloguj</message>
-    <message key="xmlui.dri2xhtml.structural.login">Zaloguj</message>
+	<message key="xmlui.dri2xhtml.structural.profile">Profil: </message>
+	<message key="xmlui.dri2xhtml.structural.logout">Wyloguj</message>
+	<message key="xmlui.dri2xhtml.structural.login">Zaloguj</message>
 
-    <message key="xmlui.dri2xhtml.structural.search">Szukaj w DSpace</message>
-    <message key="xmlui.dri2xhtml.structural.search-advanced">Szukanie zaawansowane</message>
-    <message key="xmlui.dri2xhtml.structural.search-in-community">W tym zbiorze</message>
-    <message key="xmlui.dri2xhtml.structural.search-in-collection">W tej kolekcji</message>
+	<message key="xmlui.dri2xhtml.structural.search">Szukaj w DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Szukanie zaawansowane</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">W tym zbiorze</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">W tej kolekcji</message>
 
-    <message key="xmlui.dri2xhtml.structural.pagination-previous">Poprzednia strona</message>
-    <message key="xmlui.dri2xhtml.structural.pagination-info">Wyświetlanie pozycji {0}-{1} z {2}</message>
-    <message key="xmlui.dri2xhtml.structural.pagination-next">Następna strona</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Poprzednia strona</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Wyświetlanie pozycji {0}-{1} z {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Następna strona</message>
 
-    <message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-    <message key="xmlui.dri2xhtml.structural.link_original_license">Oryginalna licencja</message>
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Oryginalna licencja</message>
 
 
-    <!-- DS-METS-1.0-MODS.xsl -->
-    <!-- DS-METS-1.0-DIM.xsl -->
-    <!-- DS-METS-1.0-QDC.xsl -->
-    <message key="xmlui.dri2xhtml.METS-1.0.no-preview">Podgląd niedostępny</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-title">Bez tytułu</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-author">Nieznany autor</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
+	<!-- DS-METS-1.0-MODS.xsl -->
+	<!-- DS-METS-1.0-DIM.xsl -->
+	<!-- DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Podgląd niedostępny</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Bez tytułu</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Nieznany autor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
         To nie jest obiekt DSpace zgodny z profilem METS 1.0 i jako taki nie
         może zostać prawidłowo wyświetlony. Możesz zmienić albo podstawowy
         szablon (dri2xhtml), albo utworzyć własny szablon obsługujący żądany
         profil.
     </message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.item-preview">Podgląd</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-title">Tytuł</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Streszczenie</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-description">Opis</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Publikujący</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-subject">Temat</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Podgląd</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Tytuł</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Autor</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Streszczenie</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Opis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Data</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Publikujący</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Temat</message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Pliki tej pozycji</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Plik</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nazwa</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Rozmiar</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Przeglądanie</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Opis</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Oglądaj/<wbr/>Otwórz</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Nie ma plików powiązanych z tą pozycją.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Pliki tej pozycji</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Plik</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Nazwa</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Rozmiar</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Format</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Przeglądanie</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Opis</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Oglądaj/<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Nie ma plików powiązanych z tą pozycją.</message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bajtów</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">KB</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">MB</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">GB</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bajtów</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">KB</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">MB</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">GB</message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.license-text">Z tą pozycją powiązane są następujące pliki licencyjne:</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Z tą pozycją powiązane są następujące pliki licencyjne:</message>
     <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Poza zaznaczonymi wyjątkami, licencja tej pozycji opisana jest jako </message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
         Widok „summaryView” dla kolekcji nie jest obecnie używany
         ani implementowany. Można to zmienić modyfikując w dri2xhtml szablon o
         nazwie „collectionSummaryView”.
     </message>
-    <message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
+	<message key="xmlui.dri2xhtml.METS-1.0.community-not-implemented">
         Widok „summaryView” dla zbioru nie jest obecnie ani
         używany, ani implementowany. Można to zmienić modyfikując w dri2xhtml
         szablon o nazwie „communitySummaryView”.
     </message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo kolekcji</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo zbioru</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Brak logo</message>        
-    <message key="xmlui.dri2xhtml.METS-1.0.news">Nowości</message>    
+	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Logo kolekcji</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Logo zbioru</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Brak logo</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Nowości</message>
 
-    <!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
-        DS-METS-1.0-QDC.xsl -->
-    <message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
+	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
+		DS-METS-1.0-QDC.xsl -->
+	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
         Qualified Dublin Core (QDC) nie ma obecnie zastosowania do zbiorów
         i kolekcji DSpace. Jeśli używasz QDC, skorzystaj z narzędzia
         „QDC crosswalk dla pozycji DSpace” i DIM lub MODS dla
         przetworzenia zbiorów i kolekcji.
     </message>
 
-    <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementy Dublin Core</message>
-    <message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Warunki Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementy Dublin Core</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Warunki Dublin Core</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
 
 
-    <!-- Special pioneer model related text, wherever it might end up -->
-    <message key="xmlui.dri2xhtml.pioneer.preview">Podgląd</message>
-    <message key="xmlui.dri2xhtml.pioneer.date">Data</message>
-    <message key="xmlui.dri2xhtml.pioneer.title">Tytuł</message>
-    <message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
+	<!-- Special pioneer model related text, wherever it might end up -->
+	<message key="xmlui.dri2xhtml.pioneer.preview">Podgląd</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Tytuł</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
 
-    <!-- tag used to handle the empty textarea tag added 09/28/2006 -->
-    <message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
-    <!--###### File Format MIME Type Mappings ######-->
+  <!--###### File Format MIME Type Mappings ######-->
 
-    <!-- Application-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.application/marc">Rekord MARC</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Nieznany</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Aplet Java</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-    <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+  <!-- Application-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">Rekord MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Nieznany</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Aplet Java</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
-    <!-- Audio-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.audio/basic">Dźwięk</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/flac">Dźwięk FLAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/m4a">Dźwięk AAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">Dźwięk AAC</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">Dźwięk mp3</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">Dźwięk AIFF</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">Dźwięk MPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">Dźwięk WMA</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">Dźwięk WMV</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-    <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">Dźwięk WAV</message>
+  <!-- Audio-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Dźwięk</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">Dźwięk FLAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">Dźwięk AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">Dźwięk AAC</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">Dźwięk mp3</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">Dźwięk AIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">Dźwięk MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">Dźwięk WMA</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">Dźwięk WMV</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">Dźwięk WAV</message>
 
-    <!-- Image-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.image/gif">Obraz GIF</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/jp2">Obraz JPEG 2000</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/jpeg">Obraz JPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/png">Obraz PNG</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/tiff">Obraz TIFF</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Obraz BMP</message>
-    <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
+  <!-- Image-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">Obraz GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">Obraz JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">Obraz JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">Obraz PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">Obraz TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">Obraz BMP</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
 
-    <!-- Text-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.text/css">Plik CSS</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/csv">Plik CSV</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/plain">Plik tekstowy</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/richtext">Plik RTF</message>
-    <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
+  <!-- Text-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.text/css">Plik CSS</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/csv">Plik CSV</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/javascript">Javascript</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/plain">Plik tekstowy</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/richtext">Plik RTF</message>
+  <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
-    <!-- Video-based formats -->
-    <message key="xmlui.dri2xhtml.mimetype.video/avi">Wideo AVI</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mpeg">Wideo MPEG</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Wideo MPEG-2</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/mp4">Wideo MPEG-4</message>
-    <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Wideo QuickTime</message>
+  <!-- Video-based formats -->
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">Wideo AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">Wideo MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">Wideo MPEG-2</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">Wideo MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Wideo QuickTime</message>
 
-    <!-- explanatory messages for choice authority confidence values -->
-    <message key="xmlui.authority.confidence.description.cf_unset">Poziom zaufania nie został przypisany tej wartości</message>
-    <message key="xmlui.authority.confidence.description.cf_novalue">Serwis nadrzędny nie zwrócił żadnej rozsądnej wartości poziomu zaufania</message>
-    <message key="xmlui.authority.confidence.description.cf_rejected">Serwis nadrzędny zaleca odrzucenie tej dodawanej pozycji</message>
-    <message key="xmlui.authority.confidence.description.cf_failed">W serwisie nadrzędnym wystąpił wewnętrzny błąd</message>
-    <message key="xmlui.authority.confidence.description.cf_notfound">Brak pasującej odpowiedzi od serwisu nadrzędnego</message>
-    <message key="xmlui.authority.confidence.description.cf_ambiguous">Serwis nadrzędny zwrócił kilka tak samo poprawnych wartości</message>
-    <message key="xmlui.authority.confidence.description.cf_uncertain">Wartość wydaje się poprawna, ale nie została zaakceptowana przez człowieka, więc wciąż budzi wątpliwości</message>
-    <message key="xmlui.authority.confidence.description.cf_accepted">Ta wartość zwracana przez serwis nadrzędny została potwierdzona przez człowieka</message>
-    <!-- help message on "unlock" button in EditItemMetadata display -->
-    <message key="xmlui.authority.confidence.unlock.help">Odblokuj wartość klucza serwisu nadrzędnego, aby móc go modyfikować, lub zablokuj go z powrotem</message>
+  <!-- explanatory messages for choice authority confidence values -->
+  <message key="xmlui.authority.confidence.description.cf_unset">Poziom zaufania nie został przypisany tej wartości</message>
+  <message key="xmlui.authority.confidence.description.cf_novalue">Serwis nadrzędny nie zwrócił żadnej rozsądnej wartości poziomu zaufania</message>
+  <message key="xmlui.authority.confidence.description.cf_rejected">Serwis nadrzędny zaleca odrzucenie tej dodawanej pozycji</message>
+  <message key="xmlui.authority.confidence.description.cf_failed">W serwisie nadrzędnym wystąpił wewnętrzny błąd</message>
+  <message key="xmlui.authority.confidence.description.cf_notfound">Brak pasującej odpowiedzi od serwisu nadrzędnego</message>
+  <message key="xmlui.authority.confidence.description.cf_ambiguous">Serwis nadrzędny zwrócił kilka tak samo poprawnych wartości</message>
+  <message key="xmlui.authority.confidence.description.cf_uncertain">Wartość wydaje się poprawna, ale nie została zaakceptowana przez człowieka, więc wciąż budzi wątpliwości</message>
+  <message key="xmlui.authority.confidence.description.cf_accepted">Ta wartość zwracana przez serwis nadrzędny została potwierdzona przez człowieka</message>
+  <!-- help message on "unlock" button in EditItemMetadata display -->
+  <message key="xmlui.authority.confidence.unlock.help">Odblokuj wartość klucza serwisu nadrzędnego, aby móc go modyfikować, lub zablokuj go z powrotem</message>
 
-    <!-- Choice Lookup popup window -->
-    <!-- NOTE: These messages necessarily use a *different* format for
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
      - parameters, unfortunately, since substitution happens in the
      - JavaScript (AJAX) that completes the lookup popup window.
      - So, positional parameters are @1@, @2@, etc.
     -->
-    <message key="xmlui.ChoiceLookupTransformer.title">Wyszukiwanie wartości repozytorium</message>
-    <message key="xmlui.ChoiceLookupTransformer.accept">Akceptuj</message>
-    <message key="xmlui.ChoiceLookupTransformer.add">Dodaj</message>
-    <message key="xmlui.ChoiceLookupTransformer.cancel">Anuluj</message>
-    <message key="xmlui.ChoiceLookupTransformer.more">Zobacz więcej wyników</message>
-    <!-- params are: start, end, total-count, search-value -->
-    <message key="xmlui.ChoiceLookupTransformer.results">Wyniki @1@ do @2@ z @3@ dla "@4@"</message>
-    <message key="xmlui.ChoiceLookupTransformer.fail">Nie udało się załadować danych dla wyboru: </message>
+  <message key="xmlui.ChoiceLookupTransformer.title">Wyszukiwanie wartości repozytorium</message>
+  <message key="xmlui.ChoiceLookupTransformer.accept">Akceptuj</message>
+  <message key="xmlui.ChoiceLookupTransformer.add">Dodaj</message>
+  <message key="xmlui.ChoiceLookupTransformer.cancel">Anuluj</message>
+  <message key="xmlui.ChoiceLookupTransformer.more">Zobacz więcej wyników</message>
+  <!-- params are: start, end, total-count, search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.results">Wyniki @1@ do @2@ z @3@ dla "@4@"</message>
+  <message key="xmlui.ChoiceLookupTransformer.fail">Nie udało się załadować danych dla wyboru: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
-    <!-- Choice Lookup - sample config for dc.publisher field -->
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nazwa wydawcy</message>
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up dla wydawcy</message>
-    <!-- Params are: search-value -->
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Niepoprawna wartość: @1@</message>
+  <!-- Choice Lookup - sample config for dc.publisher field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nazwa wydawcy</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Look up dla wydawcy</message>
+  <!-- Params are: search-value -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Niepoprawna wartość: @1@</message>
 
-    <!-- Choice Lookup - sample config for dc.contributor.author field -->
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Imię i nazwisko w formacie "Imię, Nazwisko"</message>
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Nazwisko np. "Kowalski"</message>
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Imię np. "Joanna"</message>
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Look up dla autora</message>
-    <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Wartość wprowadzona "@1@" (nie pochodząca z serwisu nadrzędnego)</message>
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">Imię i nazwisko w formacie "Imię, Nazwisko"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Nazwisko np. "Kowalski"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Imię np. "Joanna"</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">Look up dla autora</message>
+  <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Wartość wprowadzona "@1@" (nie pochodząca z serwisu nadrzędnego)</message>
 
-    <!-- mobile theme -->
-    <message key="xmlui.mobile.home_mobile">Repozytorium dla urządzeń mobilnych</message>
-    <message key="xmlui.mobile.search_all">Szukaj wrzędzie</message>
-    <message key="xmlui.mobile.browse_all">Przeglądaj wszystko według</message>
-    <message key="xmlui.mobile.browse_date">Data</message>
-    <message key="xmlui.mobile.browse_author">Autor</message>
-    <message key="xmlui.mobile.browse_title">Tytuł</message>
-    <message key="xmlui.mobile.browse_subject">Temat</message>
-    <message key="xmlui.mobile.related_google_scholar">Powiązane</message>
-    <message key="xmlui.mobile.items_in_google_scholar">Pozycje w Google Scholar</message>
-    <message key="xmlui.mobile.download">Pobierz</message>
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">Repozytorium dla urządzeń mobilnych</message>
+  <message key="xmlui.mobile.search_all">Szukaj wrzędzie</message>
+  <message key="xmlui.mobile.browse_all">Przeglądaj wszystko według</message>
+  <message key="xmlui.mobile.browse_date">Data</message>
+  <message key="xmlui.mobile.browse_author">Autor</message>
+  <message key="xmlui.mobile.browse_title">Tytuł</message>
+  <message key="xmlui.mobile.browse_subject">Temat</message>
+  <message key="xmlui.mobile.related_google_scholar">Powiązane</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Pozycje w Google Scholar</message>
+  <message key="xmlui.mobile.download">Pobierz</message>
 
 
     <!-- Versioning -->
@@ -2273,266 +2454,45 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Uwaga</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Nowsza wersja tej pozycji jest przetwarzana w zadaniach przepływu pracy.</message>
 
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
 
-<!-- Discovery -->
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message>
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Temat</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Rodzaj zawartości</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Data wydania</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Data wydania</message>
 
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
 
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Ostatnio dodane</message>
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Rodzaj</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Wydawca</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
 
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Rodzic</message>
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Grupuj wyniki według</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Brak</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publikacje</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Zbiór</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Kolekcja</message>
-
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Seria</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Przeglądanie według: autora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Przeglądanie według: tytułu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Przeglądanie według: tematu</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Przeglądanie według: streszczenia</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Przeglądanie według: serii</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Przeglądanie według: sponsora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Przeglądanie według: identyfikatora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Przeglądanie według: języka (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Przeglądanie według: słowa kluczowego</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Przeglądanie według: nazwy naukowej</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Przeglądanie według: współautora (jakiegokolwiek)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Przeglądanie według: twórcy</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Przeglądanie według: tematu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Przeglądanie według: opisu</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Przeglądanie według: relacji</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Przeglądanie według: typu MIME</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Przeglądanie według: innego współautora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Przeglądanie według: promotora</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Przeglądanie według: wydziału</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Przeglądanie według: daty wydania</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Tytuł</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Temat</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Data wydania</message>
-
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Wyświetlanie pozycji {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Filtruj według: autora</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Filtruj według: tematu</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Temat</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Temat</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Data wydania</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Zaczynające się od</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Lub wpisz pierwszych kilka liter:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Opcje sortowania:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Znaczenie</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Tytuł (malejąco)</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Data wydania (malejąco)</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Tytuł (rosnąco)</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Data wydania (rosnąco)</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Wyników na stronę:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Dodaj filtr</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Zastosuj</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Usuń</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Nowe filtry:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Bieżące filtry:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Dodaj filtry</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">Nie znaleziono żadnych wyników dla użytych filtrów</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Odkryj</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... zobacz więcej</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Szukaj</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Szukaj</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Filtry</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Użyj filtrów by uściślić zapytanie.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">Zawiera</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">Jest równe</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">Nie zawiera</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">Nie jest równe</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">Nie ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Powiązane pozycje</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Wyświetlanie pozycji powiązanych tytułem, autorstwem i tematem.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Wyświetlanie {0} z wszystkich {1} wyników dla zbioru: {2}. <span class="searchTime">({3} sekund)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_collection">Wyświetlanie {0} z wszystkich {1} wyników dla kolekcji: {2}. <span class="searchTime">({3} sekund)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Wyświetlanie {0} z wszystkich {1} wyników. <span class="searchTime">({2} sekund)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Zbiory lub kolekcje odpowiadające Twojemu zapytaniu</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Pozycje odpowiadające Twojemu zapytaniu</message>
-
-
-<!-- SwordClient -->
-
-    <!--   Sword Client  -->
-    <message key="xmlui.swordclient.Navigation.context_head">Sword - Kopiowanie</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">Skopiuj pozycję do innego repozytorium</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">Sword - kopiowanie</message>
-    <message key="xmlui.swordclient.general.main_head">Kopiuj pozycję: {0}</message>
-
-
-    <message key="xmlui.swordclient.SelectTarget.title">Docelowe repozytorium kopiowanie Sword</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">Wybierz docelowe repozytorium</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">Alternatywny URL</message>
-    <message key="xmlui.swordclient.SelectTarget.username">Nazwa użytkownika</message>
-    <message key="xmlui.swordclient.SelectTarget.password">Hasło</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">W imieniu</message>
-
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">Błędny URL</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">Błędna nazwa użytkownika</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">Błędne hasło</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Błąd podczas pobierania dokumentu serwisu Sword: {0}</message>
-
-    <message key="xmlui.swordclient.SelectCollection.title">Docelowa kolekcja Sword</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">Wybierz docelową kolekcję</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">Kolekcja: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">Tytuł: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">Ustawienia zabezpieczeń dostępu: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">Mediacja: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">Rodzaje plików: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Formaty pakietów: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Zdeponuj w tej lokalizacji</message>
-
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">Docelowy serwis podrzędny</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Pobierz dokument serwisu podrzędnego</message>
-
-    <message key="xmlui.swordclient.SelectPackagingAction.head">Kolekcja:{0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">Tytył: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">Ustawienia zabezpieczeń dostępu: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">Mediacja:{0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">Rodzaj pliku</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Format pakietu</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Wybrano nieobsługiwany format pakietu</message>
-
-    <message key="xmlui.swordclient.DepositAction.success">Pozycja została poprawnie skopiowana</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Błąd formatu pakietu</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">Niepoprawny wskaźnik</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Podczas tworzenia pakietu wystąpił błąd</message>
-    <message key="xmlui.swordclient.DepositAction.error">Podczas deponowania wystąpił błąd: {0}</message>
-
-    <message key="xmlui.swordclient.SwordResponse.title">Odpowiedź Sword</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">Odpowiedź Sword</message>
-
-
-<!-- XMLWorkflow -->
-
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Działania, które możesz podjąć w związku z tym zadaniem:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Przypisz to zadanie sobie.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Przypisz sobie</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Pozostaw to zadanie w puli, aby mógł je przypisać ktoś sobie inny.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Zostaw</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Wróć do przeglądu</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Zaakceptuj/Odrzuć zadanie</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Działanie: Akceptacja/odrzucenie pozycji</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Działania, które możesz podjąć w związku z tym zadaniem:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Jeśli przejrzawszy tę pozycję jesteś przekonany, że <strong>nie</strong> jest ona nadaje się ona do kolekcji, wybierz "Odrzuć".  Będziesz mógł wypełnić formularz z informacją o tym dlaczego pozycja nie jest odpowiednia oraz wiadomością dla dodającego, w której poinformujesz go czy powinien coś zmienić i ponownie zdeponować pracę.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Orzuć pozycję</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Jeśli przejrzałeś tę pozycję i zdecydowałeś, że można ją dołączyć do kolekcji, wybierz "Zaakceptuj".</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Zaakceptuj pozycję</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Działanie: Akceptacja/ordzucenie/edycja pozycji</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Działania, które możesz podjąć w związku z tym zadaniem:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Jeśli przejrzawszy tę pozycję jesteś przekonany, że <strong>nie</strong> jest ona nadaje się ona do kolekcji, wybierz "Odrzuć".  Będziesz mógł wypełnić formularz z informacją o tym dlaczego pozycja nie jest odpowiednia oraz wiadomością dla dodającego, w której poinformujesz go czy powinien coś zmienić i ponownie zdeponować pracę.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Odrzuć pozycję</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Jeśli przejrzałeś tę pozycję i zdecydowałeś, że można ją dołączyć do kolekcji, wybierz "Zaakceptuj".</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Zaakceptuj pozycję</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Wybierz tę opcję jeśli chcesz zmienić metadane pozycji.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Edytuj metadane</message>
-
-    <message key="xmlui.XMLWorkflow.step.unknown">Nieznany stan</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Działanie: przypisz recenzenta</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Użyj poniższego pola aby znaleźć i przypisać recenzenta.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Szukanie recenzenta</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Szukaj e-osoby</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Przypisz jako recenzenta</message>
-
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Jeśli nie jesteś odpowiednią osobą, która mogłaby zrecenzować tę pracę, możesz nie przyjąć tego zadania wybierając przycisk "Nie przyjmuj".</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Nie przyjmuj zadania</message>
-
-
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Recenzja dodanej pozycji</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Recenzuj dodaną pozycję</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Podaj punktację dla tej pozycji</message>
-
-
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Przegląd przepływu pracy</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Przegląd przepływu pracy</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Przegląd przepływu pracy</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Krok</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Pozycja</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Kolekcja</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Osoba dodająca</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Przekaż pozycje z powrotem autorowi</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Usuń pozycje</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Brak</message>
-
-
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Wyświetlanie pozycji przepływu pracy: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Wyświetlanie pozycji przepływu pracy</message>
-
-    <message key="xmlui.XMLWorkflow.default.reviewstep">Krok akceptacji/odrzucenia</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Zaakceptuj/odrzuć</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Zaakceptuj/odrzuć</message>
-
-    <message key="xmlui.XMLWorkflow.default.editstep">Krok akceptacji/edycji/odrzucenia</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Zaakceptuj/edytuj/odrzuć</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">Zaakceptuj/edytuj/odrzuć</message>
-
-    <message key="xmlui.XMLWorkflow.default.finaleditstep">Krok końcowej akceptacji/edycji</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Końcowa akceptacja/edycja</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Końcowa akceptacja/edycja</message>
-
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Krok przypisania recenzenta</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Przypisz recenzenta</message>
-
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Krok recenzji pojedynczego użytkownika</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Recenzuj pozycję</message>
-
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Oceń recenzję</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Ocena recenzji</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Ocena recenzji</message>
-
-
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_pl.xml
+++ b/src/main/webapp/i18n/messages_pl.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="pl">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/src/main/webapp/i18n/messages_pt_BR.xml
@@ -1,14 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="pt-BR" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -23,19 +13,6 @@
 		   particular java class.
 		-->
 
-	<!-- TRADUÇÃO IBICT 
-		O formato usado para todas as chave é como se segue 
-		
-		xmlui.<Aspect>.<Java Class>.<name> 
-		
-		Existem poucas exceções para este formato de nomeação, 
-		1) Algumas chaves gerais estão em xmlui.general namespace 
-		   porque são usadas muito frequentemente. 
-		2) Algumas chaves gerais que são específicas para um aspecto particular 
-		   podem ser encontradas em xmlui.	<Aspect> sem especificar uma 
-		   classe java particular. 
-		-->
-
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">Página inicial</message>
 	<message key="xmlui.general.search">Pesquisar</message>
@@ -48,8 +25,13 @@
 	<message key="xmlui.general.delete">Excluir</message>
 	<message key="xmlui.general.next">Próximo</message>
 	<message key="xmlui.general.untitled">Sem título</message>
-    <message key="xmlui.general.perform">Executar</message>
-    <message key="xmlui.general.queue">Fila</message>
+        <message key="xmlui.general.perform">Executar</message>
+        <message key="xmlui.general.queue">Fila</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
 		Page not found keys
@@ -76,7 +58,7 @@
 	<message key="xmlui.feed.general_description">O Repositório captura, armazena, indexa, preserva e distibui material de pesquisa em formato digital.</message>
     <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">O canal de imagem</message>
-	<message key="xmlui.feed.untitled">Sem Título</message>	
+	<message key="xmlui.feed.untitled">Sem Título</message>
 
 	<!--
 		Default notice header
@@ -106,10 +88,10 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Resultados para a sua consulta</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">A busca não retornou resultados.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tudo sobre o DSpace</message>
-	
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Título</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data do documento</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data de submissão</message>
+
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">Título</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">data do documento</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">data de submissão</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">Relevância</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Ordenar registros por</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">Ordem</message>
@@ -149,7 +131,8 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Texto completo</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">AND (e)</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">OR (ou)</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT (não)</message>      
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">NOT (não)</message>
+
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Ou digite as primeiras letras:</message>
@@ -159,8 +142,8 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Escolha o ano)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Ou digite um ano: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Navegue pelos itens de um determinado ano.</message>
-    <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Desculpe, não há nenhum resultado para essa busca.</message>
- 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Classificar por: </message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Desculpe, não há nenhum resultado para essa busca.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by"> Classificar por: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order"> Ordenar: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp"> Resultados: </message><!-- /Page -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal"> Autores/Item: </message>
@@ -192,6 +175,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Navegação {0} por data de submissão {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Navegação {0} por data de submissão</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Escopo da busca</message>
@@ -249,16 +252,13 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Opinião enviada</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Seus comentários foram recebidos.</message>
 
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Buscar no DSpace</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Digite algum texto na caixa abaixo para buscar no DSpace.</message>
-
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Ver item</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Este item aparece na(s) seguinte(s) coleção(s)</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Mostrar registro simples</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Mostrar registro completo</message>
-    <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este item foi removido e não está disponível.</message>
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Este item foi removido e não está disponível.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Navegar</message>
@@ -298,12 +298,12 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">item</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">recurso</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">desconhecido</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Ir para a tela de login</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Ir para a tela de login</message>
 
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este item foi removido</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">O item selecionado foi removido e não está mais disponível.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">O item selecionado é restrito e requer permissão para ser visto. Por favor, faça o login para acessar o item.</message>
-    <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Você não possui direitos de acesso para visualizar este item. Por favor contate o administrador do sistema.</message>	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Este item foi removido</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">O item selecionado foi removido e não está mais disponível.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">O item selecionado é restrito e requer permissão para ser visto. Por favor, faça o login para acessar o item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Você não possui direitos de acesso para visualizar este item. Por favor contate o administrador do sistema.</message>
         
 	<!-- Authentication messages used at the top of the login page:  -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Este item é restrito</message>
@@ -323,9 +323,112 @@
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Este arquivo exportado é restrito.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">O arquivo exportado que você está tentando acessar é de acesso restrito e requer permissão para ser visto. Por favor, faça o login abaixo para acessar o arquivo exportado. </message>
 
-    <!-- Recent submission to Discovery -->
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Ver mais</message>
 
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 		                EPerson Aspect
@@ -345,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Cadastro indisponível</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Cadastro indisponível</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">A configuração deste repositório não permite o registo neste contexto. Por favor, entre em contato com o <a href="../contact">administrador do site</a> para questões e comentários.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">A configuração deste repositório não permite o registo neste contexto. Por favor, entre em contato com o <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Atualizar perfil</message>
@@ -538,18 +641,18 @@
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Submissões</message>
 
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Submissões e Fluxo de submissões</message>
 	<message key="xmlui.Submission.Submissions.trail">Submissões</message>
 	<message key="xmlui.Submission.Submissions.head">Submissões e Tarefas do fluxo de submissões</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Sem título</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">e-mail: </message>
-	
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Tarefas do fluxo de submissões</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Estas tarefas são itens que estão aguardando aprovação antes de serem adicionados ao repositório. Existem duas listas de tarefas, uma com as tarefas que você escolheu para fazer e outra para as tarefas que ainda ninguém está trabalhando.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Tarefas que você possui</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Tarefa</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Item</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Coleção</message>
@@ -568,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Estes são itens submetidos incompletos. Você também pode </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">iniciar outra submissão</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Título</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Coleção</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Submetedor</message>
@@ -592,14 +695,14 @@
 	<message key="xmlui.Submission.Submissions.status_6">Submissão sendo editada</message>
 	<message key="xmlui.Submission.Submissions.status_7">Submissão foi arquivada</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Status desconhecido</message>
-    <!-- Same transformer, completed submissions section -->
-    <message key="xmlui.Submission.Submissions.completed.head">Submissões arquivadas</message>
-    <message key="xmlui.Submission.Submissions.completed.info">Estas são as submissões completas que foram aceitas para o DSpace.</message>
-    <message key="xmlui.Submission.Submissions.completed.column1">Data de aceitação</message>
-    <message key="xmlui.Submission.Submissions.completed.column2">Título</message>
-    <message key="xmlui.Submission.Submissions.completed.column3">Coleção</message>
-    <message key="xmlui.Submission.Submissions.completed.limit">Nós temos listadas acima apenas 50 das suas submissões arquivadas. </message>
-    <message key="xmlui.Submission.Submissions.completed.displayall">Exibir todas as minhas submissões arquivadas.</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Submissões arquivadas</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Estas são as submissões completas que foram aceitas para o DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Data de aceitação</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Título</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Coleção</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Nós temos listadas acima apenas 50 das suas submissões arquivadas. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Exibir todas as minhas submissões arquivadas.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Questões iniciais</message>
@@ -637,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Vários títulos</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">O item tem mais de um título, <i>isto é, um item traduzido</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">O item tem mais de um título, <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Se a caixa acima for inválida, em seguida, o seguinte título será removido do item: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Publicado</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">O item foi publicado ou distribuído publicamente antes</message>
@@ -650,8 +753,8 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Descrever o item</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Erro: tipo de campo desconhecido</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Este campo é necessário</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">último nome, <i>por exemplo, Silva</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Primeiro nome(s) + "Jr", <i>por exemplo, João</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">último nome, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Primeiro nome(s) + "Jr", <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Ano</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Mês</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Dia</message>
@@ -672,16 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Acesso embargado até uma data específica</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Visível/Embargado</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Nome</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Descriçãon</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Razão</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirmar política &amp; adicionar outra</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Grupos</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Erro no formato da data</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Quando a opção de embargo é selecionada, a data torna-se obrigatória</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Uma política identica ao grupo e essa ação está vigente.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Lista de políticas</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Itens restritos</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Se selecionado, as informações do item não serão indexados para busca</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Nome</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Ação</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Grupo</message>
@@ -690,9 +799,13 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Editar</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remover</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Formatos de data aceitável: yyyy (ano), yyyy-mm (ano e mês), yyyy-mm-dd (ano, mês e dia)</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
 
-    
-	<!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Editar política</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
@@ -704,7 +817,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">O arquivo não foi carregado, pois parece conter um vírus. Entre em contato com o administrador do sistema.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Um problema técnico foi encontrado enquanto tentava verificar a existência de vírus no arquivo. Por favor, entre em contato com o administrador do sistema.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Descrição do arquivo</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Opcionalmente, poderá fornecer uma breve descrição do arquivo, por exemplo "<i>Artigo principal</i>", ou "<i>Leitura de dados da experiência</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Opcionalmente, poderá fornecer uma breve descrição do arquivo, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Upload do arquivo e Adicionar outro</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Arquivos enviados</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Primário</message>
@@ -713,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Tamanho</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Descrição</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Formato</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Desconhecido</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">Formato desconhecido</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Válido)</message>
@@ -733,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">O arquivo não foi carregado e, aparentemente, contem vírus. Por favor, contate o administrado do sistema.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Um problema técnico foi encontrado enquanto tentava verificar se o arquivo contem vírus. Por favor, contate o administrado do sistema.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Descrição do arquivo</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, forneça uma breve descrição do arquivo, pro exemplo "<i>Artigo principal</i>", ou "<i>Relatório de pesquisa</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Opcionalmente, forneça uma breve descrição do arquivo, pro exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Carregar arquivo &amp; adicionar outro</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Arquivo carregado</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primário</message>
@@ -742,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Tamanho</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Descrição</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Formato</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Desconhecido</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">Formato desconhecido</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Suportado)</message>
@@ -758,12 +871,12 @@
 	<message key="xmlui.Submission.submit.EditFileStep.head">Editar arquivo</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Arquivo</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Descrição do arquivo</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Opcionalmente, poderá fornecer uma breve descrição do arquivo, por exemplo  "<i>Artigo principal</i>", ou "<i>Leitura de dados da experiência</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Selecione o formato do arquivo a partir da lista abaixo, por exemplo, "<i>Adobe PDF</i>" ou "<i>Microsoft Word</i>." <strong>Se o formato não está na lista </strong>, por favor descreva-o na caixa de entrada abaixo da lista.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Opcionalmente, poderá fornecer uma breve descrição do arquivo, por exemplo  "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Selecione o formato do arquivo a partir da lista abaixo, por exemplo, "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Formato identificado</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Selecionar formato</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Formato não consta na lista</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Se o formato não está na lista acima, <strong>selecione "Formato não consta na lista" acima</strong> e descreva o formato do arquivo na caixa abaixo.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Se o formato não está na lista acima, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Outro formato</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">O número do aplicativo que você usou para criar o arquivo e o número da versão (por exemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
@@ -790,7 +903,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Ocorreu um erro ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Licenciar seu trabalho</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Se você desejar, você pode adicionar um <a href="http://creativecommons.org/">Creative Commons</a> Licença para o seu item. <strong>As licenças Creative Commons determinam o que as pessoas que lêem o seu trabalho poderá fazer com ele.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Se você desejar, você pode adicionar um <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Escolha uma licença</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Ir para o site do Creative Commons para selecionar uma licença</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Tipo de licença</message>
@@ -800,7 +913,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Licença distribuída</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Há um último passo:</strong> No DSpace, para reproduzir, traduzir e distribuir sua submissão em todo o mundo, você deve concordar com os termos a seguir.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Conceder a licença de distribuição padrão, selecionando "Eu concedo a Licença" e clique em "Finalizar submissão".</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Se você tiver dúvidas sobre esta licença, por favor entre em contato com os administradores do sistema.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Licença distribuída</message>
@@ -828,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Aprovar item</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Uma vez editado o item, utilize esta opção para publicá-lo.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Publicar</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se você revisou o item e não estiver <strong>not</strong> adequado para a inclusão na Coleção, selecione "Rejeitar". Em seguida, será solicitado que digite uma mensagem indicando o motivo do item não ser adequado, e se o solicitante deve mudar alguma coisa e que reenvie.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Se você revisou o item e não estiver <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Rejeitar o item</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Selecione esta opção para alterar os metadados do item.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Editar metadado</message>
@@ -911,11 +1024,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Registros</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadado</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Formato</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Itens</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Itens removidos</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Itens restritos</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Painel de controle</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Painel de controle</message>
     <message key="xmlui.administrative.Navigation.statistics">Estatísticas</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Importar metadado</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">Tarefas do revisor</message>
 
@@ -950,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-people são pesquisados por qualquer correspondência parcial no e-mail ou nome</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Abaixo segue a lista de e-people correspondente à sua pesquisa. Selecione a e-people que deseja excluir e clique no botão Excluir para continuar ou clique no e-mail ou nome da e-person para editá-los.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Resultados da busca</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Nome</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">E-mail</message>
@@ -1025,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Buscar por grupos</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Os grupos são pesquisados por qualquer correspondência parcial em seu nome</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Resultados da busca</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Nome</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Membros</message>
@@ -1057,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">E-mail</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Membros</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Coleção</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">ver</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Membros</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Nome</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">E-mail</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">grupo: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Este grupo não tem membros.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pendente]</message>
@@ -1102,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Excluir campos</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Excluir campos</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Confirmar exclusão</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Você tem <b>absoluta</b> certeza que deseja excluir estes campos? Se algum desses itens contém metadados para esses campos, o(s) campo(s) não poderá ser excluído. Você deve ter certeza que nenhum desses itens utiliza esses campos.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Você tem <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ATENçãO: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Isto causará um erro se qualquer item tiver metadados para esses campos.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1113,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Excluir esquema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Excluir esquema</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Confirmar exclusão</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Você tem <b>absoluta</b> certeza que deseja excluir este esquema? Se algum desses itens contém metadados para esses campos deste esquema, este não pode ser excluído. Você deve ter certeza que nenhum desses itens contém metadados neste esquema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Você tem <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ATENÇãO: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Isto causará um erro se qualquer item tiver metadados para esse esquema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1148,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Esquema de metadados: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Este é o esquema de metadados para "{0}". Você pode adicionar novos ou atualizar os campos de metadados existentes para esse esquema. Os campos podem também ser seleccionadas para exclusão ou ser movido para um outro esquema. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Esquema de campo de metadado</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Campo</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Nota de escopo</message>
@@ -1175,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Registro de formato Bitstream</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Esta lista de formatos de bitstream fornece informações sobre os formatos conhecidos e seu nível de apoio. Você pode editar ou adicionar novos formatos de bitstream com esta ferramenta. Formatos marcados como 'interno' são inivisíveis ao usuário e são utilizados para fins administrativos.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Adicionar um novo formato bitstream</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Nome</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">Tipo MIME</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Nível de suporte</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>interno</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Desconhecido</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Conhecido</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Suporte</message>
@@ -1190,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Registro de metadado</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Registro de metadado</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">O registro de metadados mantém uma lista de todos os campos de metadados disponíveis no repositório. Estes campos podem ser divididos entre vários esquemas. No entanto, o DSpace requer esquema do Dubli Core qualificado. Você pode estender o esquema Dublin Core com campos adicionais ou adicionar novos esquemas para o registro.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namespace</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Nome</message>
@@ -1278,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Editar política {0} para {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Grupo não selecionado</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Ação não selecionada</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Nome</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Ações para este recurso</message>
@@ -1299,7 +1414,7 @@
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">Uma política identica ao grupo e essa ação está vigente.</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Data inicial maior que a data final</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Formato de data aceitável: yyyy (ano), yyyy-mm (ano e mês), yyyy-mm-dd (ano, mês e dia)</message>
-	
+
     <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Gestão avançada da política</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Autorizações avançadas</message>
@@ -1315,7 +1430,7 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Coleção</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Adicionar política</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Excluir política</message>
-	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Formato de data aceitável: yyyy (ano), yyyy-mm (ano e mês), yyyy-mm-dd (ano, mês e dia)</message>
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Formato de data aceitável: yyyy (ano), yyyy-mm (ano e mês), yyyy-mm-dd (ano, mês e dia)</message>
 
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Nome</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Descrição</message>
@@ -1325,7 +1440,7 @@
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Data inicial maior que a data final</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Selecione pelo menos um grupo</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Selecione pelo menos uma coleção</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Confirmar exclusão da política</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Confirmar exclusão</message>
@@ -1334,6 +1449,41 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Ação</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grupo</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
 
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Itens</message>
@@ -1359,7 +1509,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Arquivo</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Por favor, insira o nome do arquivo no seu computador correspondente ao seu item. Se você clicar em "Buscar ...", uma nova janela aparecerá na qual você poderá localizar e selecionar o arquivo do seu computador.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Descrição</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Opcionalmente, fornecer uma breve descrição do arquivo, por exemplo "<i>Artigo principal</i>", or "<i>Leitura de metadados</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Opcionalmente, fornecer uma breve descrição do arquivo, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Upload</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Você precisa adicionar e ESCREVA privilégio em pelo menos um bundle de ser capaz de carregar bitstreams novos.</message>
 
@@ -1407,11 +1557,11 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">sim</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">não</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Descrição</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Opcionalmente, fornecer uma breve descrição do arquivo, por exemplo "<i>Artigo principal</i>", ou "<i>Leitura de dados</i>"."</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Selecione o formato do arquivo a partir da lista abaixo, por exemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>ou</b> se o formato não está na lista, por favor descreva-o na caixa abaixo.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Opcionalmente, fornecer uma breve descrição do arquivo, por exemplo "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Selecione o formato do arquivo a partir da lista abaixo, por exemplo "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Formato selecionado</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Formato não listado</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se o formato não está na lista acima, <strong>selecione "Formato não consta na lista" acima</strong> e descreva-o no campo abaixo.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Se o formato não está na lista acima, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Outro formato</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">O aplicativo usado para criar o arquivo, e o número da versão (por exemplo, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Nome do arquivo</message>
@@ -1421,7 +1571,7 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Nome</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Descrição</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Formato</message>
@@ -1478,7 +1628,7 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(só para administradores do sistema)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(só para administradores da coleção)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(você não tem permissão para executar esta ação)</message>
-	<message key="xmlui.administrative.item.EditItemStatusForm.label_private">Tornar restrito</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Tornar restrito</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Tornar público</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Tornar restrito...</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Tornar público...</message>
@@ -1555,7 +1705,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Coleção: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Esta é a ferramenta para mapear item que permite aos administradores de coleta mapear itens de outras coleções para esta coleção. Você pode buscar por itens de outras coleções e mapeá-los, ou navegar na lista de itens atualmente mapeados.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Estatísiticas</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} de {1}</strong> itens desta coleção são mapeados a partir de outras coleções</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Buscar</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Buscar itens</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Buscar itens mapeados</message>
@@ -1566,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Buscar itens</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">SBuscar itens relacionados: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Mapear itens selecionados</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Coleção</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Título</message>
@@ -1576,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Buscar itens mapeados</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Buscar itens mapeados</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Itens selecionados não mapeados</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Coleção</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Autor</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Título</message>
@@ -1615,9 +1765,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Etapa Editar Metadados</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Submetedores</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Padrão de acesso de leitura</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(sópara adminstradores do sistema)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Nível de grupo do repositório, somente para administradores)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(você não tem permissão para esta configuração)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Atualização da coleção: {0}</message>
@@ -1660,7 +1810,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Excluir imagem</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Excluir coleção</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Salvar atualizações</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(só para adminstradores do sistema)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Criação de coleção</message>
@@ -1754,7 +1904,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Grupo associado</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Administradores</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(sópara adminstradores do sistema)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Revisor da comunidade: {0}</message>
@@ -1848,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Comentários do destinatário</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Administração geral da página e-mail</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Sistema de alerta</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Aviso para o sistema de balanceamento de capacidade</strong>: Sistema de alerta são efetivos para o nóque é ativado. Você precisa garantir que cada nóno conjunto recebe o comando de alerta para ativação.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Mensagem de alerta</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">O sistema irá para a manutenção regular. Por favor, salve o seu trabalho e desconecte sua conta.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Contagem regressiva</message>
@@ -1862,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Continuar para sessões autenticadas</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Restringir a autenticação, mas manter as sessões atuais</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Restringir a autenticação e excluir as sessões atuais</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Nota:</strong> Os administradores do site estão isentos de gerenciamento de sessão.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Ativar</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Desativar</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Atividade atual ({0} máximo de páginas)</message>
@@ -1881,7 +2031,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">Use as guias acima para selecionar as informações a seguir</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Em {0} minutos</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Não autorizado</message>
@@ -1892,13 +2042,13 @@
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Entrar como outro usuário</message>
         
-        <!-- Tarefas de curadoria de todo o sistema (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
         <message key="xmlui.administrative.CurateForm.title">Tarefas de curadoria do sistema</message>
         <message key="xmlui.administrative.CurateForm.trail">Tarefas de curadoria</message>
         <message key="xmlui.administrative.CurateForm.object_label_name">Identificador de objetos do DSpace</message>
         <message key="xmlui.administrative.CurateForm.object_hint">Sugestão: Entre [seu-prefixo-identificador]/0 para executar uma tarefa dentro do site (nem todas as tarefas podem suportar esta capacidade)</message>
         <message key="xmlui.administrative.CurateForm.task_label_name">Tarefa</message>
-    <!-- Usado por classes do formulário <DSO>-->
+    <!-- Used by Curate<DSO>Form classes also -->
         <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Escolha entre os seguintes grupos</message>
 
 
@@ -1922,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Arquivos visitados</message>
     <message key="xmlui.statistics.Navigation.title">Estatística</message>
     <message key="xmlui.statistics.Navigation.usage.view">Ver as estatísticas de uso</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Ver as estatísticas de busca</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Ver as estatísticas de fluxo de submissão</message>
     <message key="xmlui.statistics.trail">Estatística</message>
@@ -1960,7 +2111,6 @@
     <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Metadados de etapas aceitas/rejeitadas/editadas</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Editar conjunto de metadados de etapas</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Editar metadados de etapas </message>
-
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Conjunto de revisão de classificação</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Revisão de classificação</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Avaliação de revisão de classificação</message>
@@ -1969,11 +2119,24 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Atribuir ação para um usuário único</message>
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">revisão de um único usuário</message>
 
-	
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1989,13 +2152,13 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo"></span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Este site está usando Manakin, uma nova versão para o DSpace criado por Texas AeM University
-			Libraries. A interface pode ser consideravelmente modificada por meio de Manakin Aspects e XSL baseado em Themes.
-			Para mais informações visite
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> e
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
@@ -2050,8 +2213,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Formato</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Visualização</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Descrição</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualizar/<wbr/>Abrir</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Acesso de leitura liberado para</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Visualizar/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Não existem arquivos associados a este item.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
@@ -2076,7 +2238,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Sem imagem</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.news">Notícias</message>
 
-	<!-- Elementos específicos para a internacionalização do qualificador de metadado Dublin Core.
+	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
 		Qualificador Dublin Core (QDC) não é aplicável agora para as comunidades e coleções do DSpace.
@@ -2087,14 +2249,16 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Elementos Dublin Core</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Termos Dublin Core</message>
 
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
 
-	<!-- Primeiro texto modelo especial que indica onde o texto deve acabar -->
+
+	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Visualização</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Data</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Titulo</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Autor</message>
 
-	<!-- tag usada para manipular the o texto da área vazia e adicionar tag 09/28/2006 -->
+	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
   <!--###### File Format MIME Type Mappings ######-->
@@ -2132,7 +2296,7 @@
   <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
   <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
-  <!-- AFormatos baseados em áudio -->
+  <!-- Audio-based formats -->
   <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
   <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
   <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
@@ -2155,7 +2319,7 @@
   <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">BMP image</message>
   <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Photo CD</message>
 
-  <!-- Formatos baseados em texto -->
+  <!-- Text-based formats -->
   <message key="xmlui.dri2xhtml.mimetype.text/css">CSS file</message>
   <message key="xmlui.dri2xhtml.mimetype.text/csv">CSV file</message>
   <message key="xmlui.dri2xhtml.mimetype.text/html">HTML</message>
@@ -2172,7 +2336,7 @@
   <message key="xmlui.dri2xhtml.mimetype.video/mp4">MPEG-4 video</message>
   <message key="xmlui.dri2xhtml.mimetype.video/quicktime">QuickTime video</message>
 
-  <!-- mensagens explicativas para a escloha dos valores confiáveis de autoridade -->
+  <!-- explanatory messages for choice authority confidence values -->
   <message key="xmlui.authority.confidence.description.cf_unset">Os valores confiáveis nunca foram gravados</message>
   <message key="xmlui.authority.confidence.description.cf_novalue">Nenhum valor razoável de confiança foi desenvolvido para autoridade</message>
   <message key="xmlui.authority.confidence.description.cf_rejected">Recomenda-se que esta submissão seja rejeitada</message>
@@ -2181,31 +2345,32 @@
   <message key="xmlui.authority.confidence.description.cf_ambiguous">Existem vários valores de autoridade correspondentes de igual validade</message>
   <message key="xmlui.authority.confidence.description.cf_uncertain">o valor é singular e válido, mas nã foi visto e aceito, por isso ainda é incerto</message>
   <message key="xmlui.authority.confidence.description.cf_accepted">Este valor precisa ser confirmado por um usuário interativo</message>
-  <!-- mensagem de ajuda em "unlock" no butão Edição de metadado -->
+  <!-- help message on "unlock" button in EditItemMetadata display -->
   <message key="xmlui.authority.confidence.unlock.help">Desative a chave do valor de autoridade para a edição manual ou mantenha bloqueada </message>
 
-  <!-- Opção de busca na janela popup  -->
-  <!-- NOTA: Estas mensagens necessariamente usam um formato diferente para
-     - parâmetros, infelizmente, desde a substituição ocorre no
-     - JavaScript (AJAX) que completa a busca na janela popup.
-     - Então, a posição dos parâmetros são @1@, @2@, etc.
+  <!-- Choice Lookup popup window -->
+  <!-- NOTE: These messages necessarily use a *different* format for
+     - parameters, unfortunately, since substitution happens in the
+     - JavaScript (AJAX) that completes the lookup popup window.
+     - So, positional parameters are @1@, @2@, etc.
     -->
   <message key="xmlui.ChoiceLookupTransformer.title">Valor de busca DSpace</message>
   <message key="xmlui.ChoiceLookupTransformer.accept">Aceito</message>
   <message key="xmlui.ChoiceLookupTransformer.add">Adicionar</message>
   <message key="xmlui.ChoiceLookupTransformer.cancel">Cancelar</message>
   <message key="xmlui.ChoiceLookupTransformer.more">Veja mais resultados</message>
-  <!-- params são: início, fim, total de contas, valor da busca -->
+  <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Resultados @1@ a @2@ de @3@ para "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Falha ao carregar os dados selecionados: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
-  <!-- Escolha para a pesquisa - exemplo de configuração para o campo dc.publisher -->
+  <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Nome do editor</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.title">Buscar editor</message>
-  <!-- Params são: valor da busca -->
+  <!-- Params are: search-value -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.nonauthority">Valor de não-autoridade: @1@</message>
 
-  <!-- Escolha para a pesquisa - exemplo de configuração o campo para dc.contributor.author -->
+  <!-- Choice Lookup - sample config for dc.contributor.author field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help">O nome deve ser informado como "último, Primeiro" </message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.last">Útimo nome, ex. "Silva"</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.help.first">Primeiro nome(s) ex. "João"</message>
@@ -2284,264 +2449,46 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Esta não é a última versão do item. A versão mais nova pode ser encontrada em: </message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notificar</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">Uma versão mais recente deste item está em processo de submissão.</message>
-	
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
 
-    <!-- Discovery -->
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Autor</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Assunto</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Tipo de conteúdo</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Data de publicação</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Data de publicação</message>
-
-
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Submissões recentes</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Tipo</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Editora</message>
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
 
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Relação</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Resultados agrupados por</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Nenhum</message>
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Publicação</message>
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Comunidade</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Coleção</message>
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
 
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Séries</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Navegar por: Autor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Navegar por: Título</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Navegar por: Assunto</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Navegar por: Resumo</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Navegar por: Séries</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Navegar por: Patrocinador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Navegar por: Identificador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Navegar por: Idioma (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Navegar por: Palavra-chave</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Navegar por: Nome científico</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Navegar por: Contribuidor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Navegar por: Autor</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Navegar por: Assunto</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Navegar por: Descrição</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Navegar por: Relação</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Navegar por: Mime-Type</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Navegar por: Outros contribuidores</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Navegar por: Orientador</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Navegar por: Departamento</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Navegar por: Data de publicação</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Título</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Assunto</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Data de publicação</message>
-
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Agora, apresentando os itens {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Filtrador por: Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Autor</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Autor</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Filtrador por: Assunto</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Assunto</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Assunto</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Data de publicação</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Iniciar com</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Ou entre com as primeiras letras:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Opção de ordenação:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Relevância</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Título - decrescente</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Data de publicação - decrescente</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Título - crescente</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Data de publicação - crescente</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Resultados por página:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Adicionar filtro</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Aplicar</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Remover</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Novo Filtro:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Filtros correntes:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Adicionar filtros</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">Nenhum valor para o filtro encontrado</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Discover</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... Ver mais</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Buscar</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Buscar</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Filtros</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Utilize filtros para refinar o resultado de busca.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">Contém</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">Igual</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">Não contém</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">Diferentes</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">sem ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Itens relacionados</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Apresentado os itens relacionados pelo título, autor e assunto.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Apresentado {0} de um total de {1} resultados para a comunidade: {2}. <span class="searchTime">({3} seconds)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_collection">Apresentando {0} de um total de {1} resultados para a coleção: {2}. <span class="searchTime">({3} seconds)</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Apresentando  {0} de um total de {1} resultados. <span class="searchTime">({2} seconds)</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Comunidades ou coleções que correspondem a requisição</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Itens que correspondem a requisição</message>
-
-
-    <!-- SwordClient -->
-
-    <message key="xmlui.swordclient.Navigation.context_head">Copiar pelo protocolo SWORD</message>
-    <message key="xmlui.swordclient.Navigation.context_copy">Copiar item para outro repositório</message>
-    <message key="xmlui.swordclient.general.SwordCopy_trail">Copiar pelo protocolo SWORD</message>
-    <message key="xmlui.swordclient.general.main_head">Copoiar item: {0}</message>
-    
-    
-    <message key="xmlui.swordclient.SelectTarget.title">Destino da cópia SWORD</message>
-    <message key="xmlui.swordclient.SelectTarget.trail">Selecionar destino</message>
-    <message key="xmlui.swordclient.SelectTarget.url">URL</message>
-    <message key="xmlui.swordclient.SelectTarget.other_url">URL alternativa</message>
-    <message key="xmlui.swordclient.SelectTarget.username">Identificação</message>
-    <message key="xmlui.swordclient.SelectTarget.password">Senha</message>
-    <message key="xmlui.swordclient.SelectTarget.on_behalf_of">Em nome de</message>
-    
-    <message key="xmlui.swordclient.SelectTargetAction.url_error">URL inválida</message>
-    <message key="xmlui.swordclient.SelectTargetAction.username_error">Identificação inválida</message>
-    <message key="xmlui.swordclient.SelectTargetAction.password_error">Senha inválida</message>
-    <message key="xmlui.swordclient.SelectTargetAction.serviceDoc_error">Erro buscando documento SWORD: {0}</message>
-    
-    <message key="xmlui.swordclient.SelectCollection.title">Coleção destino para o SWORD</message>
-    <message key="xmlui.swordclient.SelectCollection.trail">Selecionar coleção</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_head">Coleção: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_title">Título: {0} </message>
-    <message key="xmlui.swordclient.SelectCollection.collection policy">Política: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_mediation">Mediação: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_file_types">Tipos de arquivos: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_package_formats">Formato de pacote: {0}</message>
-    <message key="xmlui.swordclient.SelectCollection.collection_deposit_button">Depositar nesta localização</message>
-    
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target">Destuno do sub-serviço</message>
-    <message key="xmlui.swordclient.SelectCollection.sub_service_target_button">Obter documento de sub-serviço</message>
-    
-    <message key="xmlui.swordclient.SelectPackagingAction.head">Coleção:{0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.title">Título: {0}</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.policy">Política: {0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.mediation">Mediação:{0} </message>
-    <message key="xmlui.swordclient.SelectPackagingAction.file_types">Tipos de arquivos</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.package_formats">Formato de pacote</message>
-    <message key="xmlui.swordclient.SelectPackagingAction.packageFormat_error">Formato de pacote selecionado nao suportado</message>
-    
-    <message key="xmlui.swordclient.DepositAction.success">Cópia do item realizada com sucesso</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Erro no formato do pacote</message>
-    <message key="xmlui.swordclient.DepositAction.invalid_handle">Indentificador persistente inválido</message>
-    <message key="xmlui.swordclient.DepositAction.package_error">Um erro ocorreu na criação do pacote do objeto</message>
-    <message key="xmlui.swordclient.DepositAction.error">Erro encontrado durate o processo de depósito: {0}</message>
-    
-    <message key="xmlui.swordclient.SwordResponse.title">Resultado SWORD</message>
-    <message key="xmlui.swordclient.SwordResponse.trail">Resultado SWORD</message>
-    
-    
-    <!-- XMLWorkflow -->
-    
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.info1">Ações que podem ser executadas nesta tarefa:</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_help">Assumir esta tarefa.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.take_submit">Pegar tarefa</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_help">Deixar a tarefa para outro pegar.</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.leave_submit">Deixar tarefa</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.back">Retornar à visão geral</message>
-    <message key="xmlui.XMLWorkflow.workflow.ClaimAction.title">Aceitar/Rejeitar tarefa</message>
-    
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.head">Executar tarefa: Aceitar/Rejeitar item</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.info1">Ações que podem ser executadas nesta tarefa:</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_help">Caso tenha avaliado o item e concluído como <strong>não</strong> indicado para inclusão na coleção, selecione "Rejeitar".  Será pedido que entre com uma mensagem, indicando a razão da rejeição e se é possível ressubmeter o item com alterações.</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.reject_submit">Rejeitar item</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_help">Caso tenha avaliado o item e concluído pela inclusão na coleção, selecione "Aprovar".</message>
-    <message key="xmlui.XMLWorkflow.workflow.AcceptAction.approve_submit">Aprovar item</message>
-    
-    
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.head">Executar tarefa: Aceitar/Rejeitar/Editar item</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.info1">Ações que podem ser executadas nesta tarefa:</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_help">Caso tenha avaliado o item e concluído como <strong>não</strong> indicado para inclusão na coleção, selecione "Rejeitar".  Será pedido que entre com uma mensagem, indicando a razão da rejeição e se é possível ressubmeter o item com alterações.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.reject_submit">Rejeitar item</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_help">Caso tenha avaliado o item e concluído pela inclusão na coleção, selecione "Aprovar".</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.approve_submit">Rejeitar item</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_help">Selecione esta opção para alterar os metadados do item.</message>
-    <message key="xmlui.XMLWorkflow.workflow.EditMetadataAction.edit_submit">Editar metadado</message>
-    
-    <message key="xmlui.XMLWorkflow.step.unknown">Estado desconhecido</message>
-    
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.head">Executar tarefa: atribuir avaliador</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.help">Utilize a caixa abaixo para buscar por um usuário a ser indicador como revisor da tarefa.</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.label">Buscar por avaliador</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.search.button">Buscar por usuário</message>
-    <message key="xmlui.XMLWorkflow.workflow.SelectReviewerAction.select-reviewer.button">Selecionar como avaliador</message>
-    
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.help">Caso não seja a pessoa apropriada para avaliar o item, pode-se declinar da tarefa, selecionado o botão de "Declinar tarefa" .</message>
-    <message key="xmlui.XMLWorkflow.workflow.SingleUserReviewAction.decline.button">Declinar tarefa</message>
-    
-    
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.head">Avaliar submissão</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.score.button">Avaliar submissão</message>
-    <message key="xmlui.XMLWorkflow.workflow.ScoreReviewAction.help">Entre com a pontuação para esta submissão</message>
-    
-    
-    <message key="xmlui.XMLWorkflow.Navigation.xmlworkflow_overview">Visão geral do fluxo de trabalho</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.trail">Visão geral do fluxo de trabalho</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.title">Visão geral do fluxo de trabalho</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column1"> </message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column2">Passo</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column3">Item</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column4">Coleção</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.search_column5">Depositante</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_submitter">Enviar itens de volta ao depositante</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.submit_delete">Deletar itens</message>
-    <message key="xmlui.XMLWorkflow.WorkflowOverviewTransformer.button.no_results">Sem resultados</message>
-    
-    
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.title">Apresentar item no fluxo de trabalho: {0}</message>
-    <message key="xmlui.XMLWorkflow.WorkflowItemTransformer.trail">Apresentar item no fluxo de trabalho</message>
-    
-    <message key="xmlui.XMLWorkflow.default.reviewstep">Aceitar/Rejeitar</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.claimaction">Aceitar/Rejeitar</message>
-    <message key="xmlui.XMLWorkflow.default.reviewstep.reviewaction">Aceitar/Rejeitar</message>
-    
-    <message key="xmlui.XMLWorkflow.default.editstep">Aceitar/Rejeitar/Editar passo</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.claimaction">Aceitar/Rejeitar/Editar</message>
-    <message key="xmlui.XMLWorkflow.default.editstep.editaction">Aceitar/Rejeitar/Editar</message>
-    
-    <message key="xmlui.XMLWorkflow.default.finaleditstep">Aceitar/Editar passo final</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.claimaction">Aceitar/Editar passo final</message>
-    <message key="xmlui.XMLWorkflow.default.finaleditstep.finaleditaction">Aceitar/Editar passo final</message>
-    
-    
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.claimaction">Passo de atribuir avaliador</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.selectReviewerStep.selectrevieweraction">Atribuir avaliador</message>
-    
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep">Passo de avaliador único</message>
-    <message key="xmlui.XMLWorkflow.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Avaliar submissão</message>
-    
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.claimaction">Pontuação de avaliação</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep.scorereviewaction">Pontuação de avaliação</message>
-    <message key="xmlui.XMLWorkflow.scoreReview.scoreReviewStep">Pontuação de avaliação</message>
-
-
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_pt_BR.xml
+++ b/src/main/webapp/i18n/messages_pt_BR.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="pt-BR">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_ru.xml
+++ b/src/main/webapp/i18n/messages_ru.xml
@@ -1,43 +1,37 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
-
--->
-<catalogue xml:lang="ru" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
-		The format used by all keys is as follows xmlui.<Aspect>.<Java Class>.<name>
+		The format used by all keys is as follows
+
+		xmlui.<Aspect>.<Java Class>.<name>
+
 		There are a few exceptions to this naming format,
 		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
 		2) Some general keys which are specific to a particular aspect
 		   may be found at xmlui.<Aspect> without specifying a
-		   particular java class.    		-->
-<!--
-messages_ru.xml copied from messages_es.xml on 2014-12-21
+		   particular java class.
+		-->
 
-Translated by Ekaterina Chubich
--->
 	<!-- General keys -->
-<message key="xmlui.general.dspace_home">Главная</message>
-<message key="xmlui.general.search">Поиск</message>
-<message key="xmlui.general.go">Ok</message>
-<message key="xmlui.general.go_home">На главную страницу DSpace</message>
-<message key="xmlui.general.save">Сохранить</message>
-<message key="xmlui.general.cancel">Отмена</message>
-<message key="xmlui.general.return">Назад</message>
-<message key="xmlui.general.update">Изменить</message>
-<message key="xmlui.general.delete">Удалить</message>
-<message key="xmlui.general.next">Далее</message>
-<message key="xmlui.general.untitled">Без имени</message>
-<message key="xmlui.general.perform">Выполнить</message>
-<message key="xmlui.general.queue">Добавить в очередь</message>
+	<message key="xmlui.general.dspace_home">Главная</message>
+	<message key="xmlui.general.search">Поиск</message>
+	<message key="xmlui.general.go">Ok</message>
+	<message key="xmlui.general.go_home">На главную страницу DSpace</message>
+	<message key="xmlui.general.save">Сохранить</message>
+	<message key="xmlui.general.cancel">Отмена</message>
+	<message key="xmlui.general.return">Назад</message>
+	<message key="xmlui.general.update">Изменить</message>
+	<message key="xmlui.general.delete">Удалить</message>
+	<message key="xmlui.general.next">Далее</message>
+	<message key="xmlui.general.untitled">Без имени</message>
+        <message key="xmlui.general.perform">Выполнить</message>
+        <message key="xmlui.general.queue">Добавить в очередь</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
 		Page not found keys
@@ -45,9 +39,9 @@ Translated by Ekaterina Chubich
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
-<message key="xmlui.PageNotFound.title">Страница не найдена</message>
-<message key="xmlui.PageNotFound.head">Страница не найдена</message>
-<message key="xmlui.PageNotFound.para1">Запрашиваемая страница не найдена на этом сервере</message>
+	<message key="xmlui.PageNotFound.title">Страница не найдена</message>
+	<message key="xmlui.PageNotFound.head">Страница не найдена</message>
+	<message key="xmlui.PageNotFound.para1">Запрашиваемая страница не найдена на этом сервере</message>
 
 
 	<!--
@@ -61,10 +55,10 @@ Translated by Ekaterina Chubich
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
 	-->
-<message key="xmlui.feed.general_description">Цифровое хранилище DSpace регистрирует, хранит, индексирует, защищает и распространяет исследовательские материалы в цифровом формате.</message>
-<message key="xmlui.feed.header">Потоки RSS</message>
-<message key="xmlui.feed.logo_title">Изображение</message>
-<message key="xmlui.feed.untitled">Без имени</message>
+	<message key="xmlui.feed.general_description">Цифровое хранилище DSpace регистрирует, хранит, индексирует, защищает и распространяет исследовательские материалы в цифровом формате.</message>
+    <message key="xmlui.feed.header">Потоки RSS</message>
+	<message key="xmlui.feed.logo_title">Изображение</message>
+	<message key="xmlui.feed.untitled">Без имени</message>
 
 	<!--
 		Default notice header
@@ -86,228 +80,248 @@ Translated by Ekaterina Chubich
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Результаты поиска для сообщества: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Результаты поиска для коллекции: {0}</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Результаты поиска</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Ваш запрос "{0}" дал {1} результатов</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Сообщества и коллекции, отвечающие Вашему запросу</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Элементы отвечающие Вашему запросу</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Поиск не дал результатов</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Весь DSpace</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Результаты поиска для сообщества: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Результаты поиска для коллекции: {0}</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_none">Результаты поиска</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.result_query">Ваш запрос "{0}" дал {1} результатов</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head2">Сообщества и коллекции, отвечающие Вашему запросу</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.head3">Элементы отвечающие Вашему запросу</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Поиск не дал результатов</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Весь DSpace</message>
 
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">название</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">дата публикации</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">дата утверждения</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">релевантность</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Сортировать элементы по</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order">в порядке</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">возрастающем</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">убывающем</message>
-<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Результаты/страница</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">название</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">дата публикации</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">дата утверждения</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">релевантность</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Сортировать элементы по</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">в порядке</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.asc">возрастающем</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.order.desc">убывающем</message>
+	<message key="xmlui.ArtifactBrowser.AbstractSearch.rpp">Результаты/страница</message>
 
     <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Расширенный поиск</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Расширенный поиск</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Расширенный поиск</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Поле поиска</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Поиск в пределах одного сообщества или коллекции.</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Соединение</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Тип поиска</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Искать по</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Автору</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Названию</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Теме</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Аннотации</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Серии</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Спонсору</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Идентификатору</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Языку (ISO)</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Ключевым словам</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.title">Расширенный поиск</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.trail">Расширенный поиск</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.head">Расширенный поиск</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope">Поле поиска</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_scope_help">Поиск в пределах одного сообщества или коллекции.</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.conjunction">Соединение</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_type">Тип поиска</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.search_for">Искать по</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_author">Автору</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_title">Названию</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Теме</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_abstract">Аннотации</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_series">Серии</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_sponsor">Спонсору</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Идентификатору</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Языку (ISO)</message>
+	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Ключевым словам</message>
 
    <!--  some common other possibilities for Advanced Search Fields -->
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Спонсору</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Автору</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Описанию</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Отсылкам</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Типу MIME</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Другим участникам</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Консультанту</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Отделению</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Спонсору</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Автору</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Описанию</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Отсылкам</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Типу MIME</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_other">Другим участникам</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_advisor">Консультанту</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_department">Отделению</message>
 
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Полный текст</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.and">И</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.or">ИЛИ</message>
-<message key="xmlui.ArtifactBrowser.AdvancedSearch.not">НЕ</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_ANY">Полный текст</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">И</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">ИЛИ</message>
+   <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">НЕ</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Или введите первые несколько символов:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Искать элементы, которые начинаются с этих символов</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Перейти к определенному пункту оглавления</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Выберите месяц)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Выбрите год)</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Или укажите год:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Искать элементы указанного года.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">К сожалению, этот поиск не дал результатов.</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Отсортировать по:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Порядку:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Результатам:</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Авторам/Элементам:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Или введите первые несколько символов:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Искать элементы, которые начинаются с этих символов</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Перейти к определенному пункту оглавления</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Выберите месяц)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Выбрите год)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Или укажите год:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Искать элементы указанного года.</message>
+        <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">К сожалению, этот поиск не дал результатов.</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.sort_by">Отсортировать по:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.order">Порядку:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.rpp">Результатам:</message><!-- /Page -->
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.etal">Авторам/Элементам:</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Все</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.etal.all">Все</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">названию</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">дате публикации</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">дате утверждения</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.title">названию</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateissued">дате публикации</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.sort_by.dateaccessioned">дате утверждения</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">по возрастанию</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">по убыванию</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.asc">по возрастанию</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.order.desc">по убыванию</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">авторам</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">темам</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.author.column_heading">авторам</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.subject.column_heading">темам</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Просмотр {0} по автору {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Просмотр {0} по автору</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.author">Просмотр {0} по автору {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.author">Просмотр {0} по автору</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Просмотр{0} по теме {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Просмотр {0} по теме</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Просмотр{0} по теме {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Просмотр {0} по теме</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Посмотр {0} по названию {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Посмотр {0} по названию</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Посмотр {0} по названию {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Посмотр {0} по названию</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Посмотр {0} по дате публикации {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Посмотр {0} по дате публикации</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Посмотр {0} по дате публикации {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Посмотр {0} по дате публикации</message>
 
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Посмотр {0} по дате загрузки {1}</message>
-<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Посмотр {0} по дате загрузки</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Посмотр {0} по дате загрузки {1}</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Посмотр {0} по дате загрузки</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
-<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Область поиска</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Весь DSpace</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Поиск в этой коллекции:</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Искать по</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Названию</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Авторам</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Датам</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Продвинутый поиск</message>
-<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Недавние добавления</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Область поиска</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Весь DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.full_text_search">Поиск в этой коллекции:</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_browse">Искать по</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_titles">Названию</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_authors">Авторам</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Датам</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Продвинутый поиск</message>
+	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Недавние добавления</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Список сообществ</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Список сообществ</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Сообщества DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Выберите сообщество для просмотра его коллекций</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Список сообществ</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Список сообществ</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.head">Сообщества DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityBrowser.select">Выберите сообщество для просмотра его коллекций</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityViewer.java -->
-<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Область поиска</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Весь DSpace</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Поиск в данном сообществе и его коллекциях:</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Просмотр по</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Названию</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Автору</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Дате</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Продвинутый поиск</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Разделы данного сообщества</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Коллекции данного сообщества</message>
-<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Последние добавления</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.search_scope">Область поиска</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.all_of_dspace">Весь DSpace</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.full_text_search">Поиск в данном сообществе и его коллекциях:</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_browse">Просмотр по</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_titles">Названию</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_authors">Автору</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.browse_dates">Дате</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.advanced_search_link">Продвинутый поиск</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Разделы данного сообщества</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Коллекции данного сообщества</message>
+	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Последние добавления</message>
 
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
-<message key="xmlui.ArtifactBrowser.Contact.title">Наши контакты</message>
-<message key="xmlui.ArtifactBrowser.Contact.trail">Наши контакты</message>
-<message key="xmlui.ArtifactBrowser.Contact.head">Наши контакты</message>
-<message key="xmlui.ArtifactBrowser.Contact.para1">С {0} администраторами Вы можете связаться через:</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_label">On-line форму</message>
-<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Комментарий</message>
-<message key="xmlui.ArtifactBrowser.Contact.email">Электронный адрес</message>
+	<message key="xmlui.ArtifactBrowser.Contact.title">Наши контакты</message>
+	<message key="xmlui.ArtifactBrowser.Contact.trail">Наши контакты</message>
+	<message key="xmlui.ArtifactBrowser.Contact.head">Наши контакты</message>
+	<message key="xmlui.ArtifactBrowser.Contact.para1">С {0} администраторами Вы можете связаться через:</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">On-line форму</message>
+	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Комментарий</message>
+	<message key="xmlui.ArtifactBrowser.Contact.email">Электронный адрес</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Оставить комментарий</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Оставить комментарий</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Оставить комментарий</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Благодарим Вас за комментарий. Все комментарии будут учтены!</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Ваш электронный адрес</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Данный электронный адрес будет использован для отслеживания Вашего комментария.</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Комментарии</message>
-<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.head">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.para1">Благодарим Вас за комментарий. Все комментарии будут учтены!</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email">Ваш электронный адрес</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Данный электронный адрес будет использован для отслеживания Вашего комментария.</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Комментарии</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Оставить комментарий</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
-<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Оставить комментарий</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Оставить комментарий</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Комментарий отправлен</message>
-<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Ваш комментарий был получен</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Оставить комментарий</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Комментарий отправлен</message>
+	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Ваш комментарий был получен</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
-<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Просмотр элемента</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Данный элемент включен в следующие коллекции</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Показать сокращенную информацию</message>
-<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Показать полную информацию</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Просмотр элемента</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Данный элемент включен в следующие коллекции</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Показать сокращенную информацию</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Показать полную информацию</message>
 
-<message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Этот элемент не доступен, т. к. был удален</message>
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Этот элемент не доступен, т. к. был удален</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
-<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Просмотр</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Весь DSpace</message>
-<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Сообщества и коллекции</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Названия</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Авторы</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Тематика</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Дата публикации</message>
-<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Дата добавления</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Эта коллекция</message>
-<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Это сообщество</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Просмотр</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Весь DSpace</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.communities_and_collections">Сообщества и коллекции</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_title">Названия</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_author">Авторы</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_subject">Тематика</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateissued">Дата публикации</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">Дата добавления</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Эта коллекция</message>
+	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Это сообщество</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
-<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Искать</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Искать</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Искать</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Область поиска</message>
-<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Искать целый текст</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Искать</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Искать</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Искать</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Область поиска</message>
+	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Искать целый текст</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Доступ к данному ресурсу ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Доступ ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Доступ к данному ресурсу ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Доступ к данному сообществу ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Доступ к данной коллекции ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Доступ к данному документу ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Доступ к данному архиву ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">У Вас недостаточно прав для доступа к данному ресурсу</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">У Вас недостаточно прав для доступа к данному сообществу</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">У Вас недостаточно прав для доступа к данной коллекции</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">У Вас недостаточно прав для доступа к данному документу</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">У Вас недостаточно прав для доступа к данному архиву</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">коллекция</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">сообщество</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">архив</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">документ</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">ресурс</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">неизвестно</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.login">Войдите в систему</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Доступ к данному ресурсу ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Доступ ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_resource">Доступ к данному ресурсу ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_community">Доступ к данному сообществу ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_collection">Доступ к данной коллекции ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Доступ к данному документу ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Доступ к данному архиву ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">У Вас недостаточно прав для доступа к данному ресурсу</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community">У Вас недостаточно прав для доступа к данному сообществу<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection">У Вас недостаточно прав для доступа к данной коллекции<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item">У Вас недостаточно прав для доступа к данному документу<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream">У Вас недостаточно прав для доступа к данному архиву<b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">коллекция</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">сообщество</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">архив</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">документ</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">ресурс</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">неизвестно</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Войдите в систему</message>
 
-<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Документ был удалён</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Запрашиваемый Вами документ был удалён и недоступен для просмотра</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Вы не обладаете достаточными правами для просмотра данного документа. </message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Вы не обладаете достаточными правами для просмотра данного документа. Пожалуйста, обратитесь к администратору.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">Документ был удалён</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">Запрашиваемый Вами документ был удалён и недоступен для просмотра</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">Вы не обладаете достаточными правами для просмотра данного документа. </message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Вы не обладаете достаточными правами для просмотра данного документа. Пожалуйста, обратитесь к администратору.</message>
         
 	<!-- Authentication messages used at the top of the login page:  -->
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Доступ к данному документу ограничен</message>
-<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Доступ к данному документу ограничен.Пожалуйста, войдите в систему.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Доступ к данному документу ограничен</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Доступ к данному документу ограничен.Пожалуйста, войдите в систему.</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Отчёт за месяц</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Статистика</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Отчёт за месяц</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.report.title">Статистика</message>
 
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Нет доступных отчётов</message>
-<message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Нет доступных отчётов, пожалуйста, проверьте позже.</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.title">Нет доступных отчётов</message>
+    <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">Нет доступных отчётов, пожалуйста, проверьте позже.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-<message key="xmlui.BitstreamReader.auth_header">Доступ к архиву ограничен.</message>
-<message key="xmlui.BitstreamReader.auth_message">Доступ к архиву ограничен. Для получения доступа, пожалуйста, войдите в систему.</message>
+	<message key="xmlui.BitstreamReader.auth_header">Доступ к архиву ограничен.</message>
+	<message key="xmlui.BitstreamReader.auth_message">Доступ к архиву ограничен. Для получения доступа, пожалуйста, войдите в систему.</message>
 
 	<!-- Export Archive download messages -->
-<message key="xmlui.ItemExportDownloadReader.auth_header">Доступ к архиву ограничен.</message>
-<message key="xmlui.ItemExportDownloadReader.auth_message">Доступ к архиву ограничен. Для получения доступа, пожалуйста, войдите в систему.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_header">Доступ к архиву ограничен.</message>
+	<message key="xmlui.ItemExportDownloadReader.auth_message">Доступ к архиву ограничен. Для получения доступа, пожалуйста, войдите в систему.</message>
 
 
 	<!-- REQUEST COPY -->
@@ -315,7 +329,9 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Address is required</message>
@@ -340,7 +356,9 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
@@ -380,6 +398,36 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
 	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -394,168 +442,168 @@ Translated by Ekaterina Chubich
 
 
 	<!-- General keys used by the EPerson aspect -->
-<message key="xmlui.EPerson.trail_new_registration">Регистрация нового пользователя</message>
-<message key="xmlui.EPerson.trail_forgot_password">Забыли пароль?</message>
+	<message key="xmlui.EPerson.trail_new_registration">Регистрация нового пользователя</message>
+	<message key="xmlui.EPerson.trail_forgot_password">Забыли пароль?</message>
 
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
-<message key="xmlui.EPerson.CannotRegister.title">Регистрация недоступна</message>
-<message key="xmlui.EPerson.CannotRegister.head">Регистрация недоступна</message>
-<message key="xmlui.EPerson.CannotRegister.para1">Текущая конфигурация DSpace не позволяет проводить регистрацию. Пожалуйста, обратитесь к <a href="../contact">администратору</a>.</message>
+	<message key="xmlui.EPerson.CannotRegister.title">Регистрация недоступна</message>
+	<message key="xmlui.EPerson.CannotRegister.head">Регистрация недоступна</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Текущая конфигурация DSpace не позволяет проводить регистрацию. Пожалуйста, обратитесь к <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
-<message key="xmlui.EPerson.EditProfile.title_update">Обновить профиль</message>
-<message key="xmlui.EPerson.EditProfile.title_create">Создать профиль</message>
-<message key="xmlui.EPerson.EditProfile.trail_update">Обновить профиль</message>
-<message key="xmlui.EPerson.EditProfile.head_update">Обновить профиль</message>
-<message key="xmlui.EPerson.EditProfile.head_create">Создать профиль</message>
-<message key="xmlui.EPerson.EditProfile.email_address">Адрес электронной почты</message>
-<message key="xmlui.EPerson.EditProfile.first_name">Имя</message>
-<message key="xmlui.EPerson.EditProfile.last_name">Фамилия</message>
-<message key="xmlui.EPerson.EditProfile.telephone">Контактный телефон</message>
-<message key="xmlui.EPerson.EditProfile.Language">Язык</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions">Подписки</message>
-<message key="xmlui.EPerson.EditProfile.subscriptions_help">Вы можете подписаться на получение ежедневных извещений о новых загруженных элементах в интересующих Вас коллекциях. Также вы можете использовать RSS ленту новостей, доступную для каждой коллекции.</message>
-<message key="xmlui.EPerson.EditProfile.email_subscriptions">Email подписка</message>
-<message key="xmlui.EPerson.EditProfile.select_collection">(Выберите коллекцию)</message>
-<message key="xmlui.EPerson.EditProfile.update_password_instructions">По желанию, Вы также можете изменить свой пароль(введите новый пароль и подтвердите его). Новый пароль должен содержать не менее шести символов.</message>
-<message key="xmlui.EPerson.EditProfile.create_password_instructions">Пожалуйста, введите новый пароль и подтвердите его. Пароль должен содержать не менее шести символов.</message>
-<message key="xmlui.EPerson.EditProfile.password">Пароль</message>
-<message key="xmlui.EPerson.EditProfile.confirm_password">Подтвердите пароль</message>
-<message key="xmlui.EPerson.EditProfile.submit_update">Завершение регистрации</message>
-<message key="xmlui.EPerson.EditProfile.submit_create">Редактировать профиль</message>
-<message key="xmlui.EPerson.EditProfile.error_required">Данное поле обязательно для заполнения</message>
-<message key="xmlui.EPerson.EditProfile.error_invalid_password">Пароль должен содержать не менее шести символов</message>
-<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Пожалуйста, подтвердите пароль</message>
-<message key="xmlui.EPerson.EditProfile.head_auth">Группы, к которым Вы принадлежите</message>
-<message key="xmlui.EPerson.EditProfile.head_identify">Данные</message>
-<message key="xmlui.EPerson.EditProfile.head_security">Безопасность</message>
+	<message key="xmlui.EPerson.EditProfile.title_update">Обновить профиль</message>
+	<message key="xmlui.EPerson.EditProfile.title_create">Создать профиль</message>
+	<message key="xmlui.EPerson.EditProfile.trail_update">Обновить профиль</message>
+	<message key="xmlui.EPerson.EditProfile.head_update">Обновить профиль</message>
+	<message key="xmlui.EPerson.EditProfile.head_create">Создать профиль</message>
+	<message key="xmlui.EPerson.EditProfile.email_address">Адрес электронной почты</message>
+	<message key="xmlui.EPerson.EditProfile.first_name">Имя</message>
+	<message key="xmlui.EPerson.EditProfile.last_name">Фамилия</message>
+	<message key="xmlui.EPerson.EditProfile.telephone">Контактный телефон</message>
+        <message key="xmlui.EPerson.EditProfile.Language">Язык</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions">Подписки</message>
+	<message key="xmlui.EPerson.EditProfile.subscriptions_help">Вы можете подписаться на получение ежедневных извещений о новых загруженных элементах в интересующих Вас коллекциях. Также вы можете использовать RSS ленту новостей, доступную для каждой коллекции.</message>
+	<message key="xmlui.EPerson.EditProfile.email_subscriptions">Email подписка</message>
+	<message key="xmlui.EPerson.EditProfile.select_collection">(Выберите коллекцию)</message>
+	<message key="xmlui.EPerson.EditProfile.update_password_instructions">По желанию, Вы также можете изменить свой пароль(введите новый пароль и подтвердите его). Новый пароль должен содержать не менее шести символов.</message>
+	<message key="xmlui.EPerson.EditProfile.create_password_instructions">Пожалуйста, введите новый пароль и подтвердите его. Пароль должен содержать не менее шести символов.</message>
+	<message key="xmlui.EPerson.EditProfile.password">Пароль</message>
+	<message key="xmlui.EPerson.EditProfile.confirm_password">Подтвердите пароль</message>
+	<message key="xmlui.EPerson.EditProfile.submit_update">Завершение регистрации</message>
+	<message key="xmlui.EPerson.EditProfile.submit_create">Редактировать профиль</message>
+	<message key="xmlui.EPerson.EditProfile.error_required">Данное поле обязательно для заполнения</message>
+	<message key="xmlui.EPerson.EditProfile.error_invalid_password">Пароль должен содержать не менее шести символов</message>
+	<message key="xmlui.EPerson.EditProfile.error_unconfirmed_password">Пожалуйста, подтвердите пароль</message>
+	<message key="xmlui.EPerson.EditProfile.head_auth">Группы, к которым Вы принадлежите</message>
+	<message key="xmlui.EPerson.EditProfile.head_identify">Данные</message>
+	<message key="xmlui.EPerson.EditProfile.head_security">Безопасность</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
-<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Подтвердите адрес электронной почты</message>
-<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Создание учетной записи</message>
-<message key="xmlui.EPerson.EPersonUtils.register_finished">Выполнено</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Подтвердите адрес электронной почты</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Восстановить пароль</message>
-<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Выполнено</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Подтвердите адрес электронной почты</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Создание учетной записи</message>
+	<message key="xmlui.EPerson.EPersonUtils.register_finished">Выполнено</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_verify_email">Подтвердите адрес электронной почты</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_reset_password">Восстановить пароль</message>
+	<message key="xmlui.EPerson.EPersonUtils.forgot_finished">Выполнено</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ForgotPasswordFinished.java -->
-<message key="xmlui.EPerson.ForgotPasswordFinished.title">Восстановление пароля</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.head">Восстановление пароля</message>
-<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Ваш пароль был восстановлен</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Восстановление пароля</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Восстановление пароля</message>
+	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Ваш пароль был восстановлен</message>
 
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
-<message key="xmlui.EPerson.InvalidToken.title">Неверный адрес</message>
-<message key="xmlui.EPerson.InvalidToken.trail">Неверный адрес</message>
-<message key="xmlui.EPerson.InvalidToken.head">Неверный адрес</message>
-<message key="xmlui.EPerson.InvalidToken.para1">Неправильный URL. URL мог быть изменен при переносе строк Вашим почтовым клиентом, например, так:</message>
-<message key="xmlui.EPerson.InvalidToken.para2">Если это случилось, скопируйте и вставьте URL в адресную строку Вашего браузера. Ардресная строка, в таком случае, должна содержать следующее:</message>
+	<message key="xmlui.EPerson.InvalidToken.title">Неверный адрес</message>
+	<message key="xmlui.EPerson.InvalidToken.trail">Неверный адрес</message>
+	<message key="xmlui.EPerson.InvalidToken.head">Неверный адрес</message>
+	<message key="xmlui.EPerson.InvalidToken.para1">Неправильный URL. URL мог быть изменен при переносе строк Вашим почтовым клиентом, например, так:</message>
+	<message key="xmlui.EPerson.InvalidToken.para2">Если это случилось, скопируйте и вставьте URL в адресную строку Вашего браузера. Ардресная строка, в таком случае, должна содержать следующее:</message>
 
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
-<message key="xmlui.EPerson.Navigation.my_account">Моя учетная запись</message>
-<message key="xmlui.EPerson.Navigation.profile">Профиль</message>
-<message key="xmlui.EPerson.Navigation.logout">Выйти</message>
-<message key="xmlui.EPerson.Navigation.login">Войти</message>
-<message key="xmlui.EPerson.Navigation.register">Регистрация</message>
+	<message key="xmlui.EPerson.Navigation.my_account">Моя учетная запись</message>
+	<message key="xmlui.EPerson.Navigation.profile">Профиль</message>
+	<message key="xmlui.EPerson.Navigation.logout">Выйти</message>
+	<message key="xmlui.EPerson.Navigation.login">Войти</message>
+	<message key="xmlui.EPerson.Navigation.register">Регистрация</message>
 
 	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-<message key="xmlui.EPerson.PasswordLogin.title">Войти</message>
-<message key="xmlui.EPerson.PasswordLogin.trail">Войти</message>
-<message key="xmlui.EPerson.PasswordLogin.head1">Войти в DSpace</message>
-<message key="xmlui.EPerson.PasswordLogin.email_address">Адрес электронной почты</message>
-<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Введенные Вами адрес электронной почты и/или пароль недействительны.</message>
-<message key="xmlui.EPerson.PasswordLogin.password">Пароль</message>
-<message key="xmlui.EPerson.PasswordLogin.forgot_link">Забыли пароль?</message>
-<message key="xmlui.EPerson.PasswordLogin.submit">Войти</message>
-<message key="xmlui.EPerson.PasswordLogin.head2">Регистрация нового пользователя</message>
-<message key="xmlui.EPerson.PasswordLogin.para1">Зарегистрируйте аккаунт, чтобы подписаться на коллекции, получать обновления по электронной почте, а также добавлять новые элементы в DSpace.</message>
-<message key="xmlui.EPerson.PasswordLogin.register_link">Нажмите здесь,чтобы зарегистрироваться.</message>
+	<message key="xmlui.EPerson.PasswordLogin.title">Войти</message>
+	<message key="xmlui.EPerson.PasswordLogin.trail">Войти</message>
+	<message key="xmlui.EPerson.PasswordLogin.head1">Войти в DSpace</message>
+	<message key="xmlui.EPerson.PasswordLogin.email_address">Адрес электронной почты</message>
+	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Введенные Вами адрес электронной почты и/или пароль недействительны.</message>
+	<message key="xmlui.EPerson.PasswordLogin.password">Пароль</message>
+	<message key="xmlui.EPerson.PasswordLogin.forgot_link">Забыли пароль?</message>
+	<message key="xmlui.EPerson.PasswordLogin.submit">Войти</message>
+	<message key="xmlui.EPerson.PasswordLogin.head2">Регистрация нового пользователя</message>
+	<message key="xmlui.EPerson.PasswordLogin.para1">Зарегистрируйте аккаунт, чтобы подписаться на коллекции, получать обновления по электронной почте, а также добавлять новые элементы в DSpace.</message>
+	<message key="xmlui.EPerson.PasswordLogin.register_link">Нажмите здесь,чтобы зарегистрироваться.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-<message key="xmlui.EPerson.LDAPLogin.title">Войти</message>
-<message key="xmlui.EPerson.LDAPLogin.trail">Войти</message>
-<message key="xmlui.EPerson.LDAPLogin.head1">Войти в DSpace</message>
-<message key="xmlui.EPerson.LDAPLogin.username">Имя пользователя</message>
-<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Неверные имя и/или пароль</message>
-<message key="xmlui.EPerson.LDAPLogin.password">Пароль</message>
-<message key="xmlui.EPerson.LDAPLogin.submit">Войти</message>
+	<message key="xmlui.EPerson.LDAPLogin.title">Войти</message>
+	<message key="xmlui.EPerson.LDAPLogin.trail">Войти</message>
+	<message key="xmlui.EPerson.LDAPLogin.head1">Войти в DSpace</message>
+	<message key="xmlui.EPerson.LDAPLogin.username">Имя пользователя</message>
+	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Неверные имя и/или пароль</message>
+	<message key="xmlui.EPerson.LDAPLogin.password">Пароль</message>
+	<message key="xmlui.EPerson.LDAPLogin.submit">Войти</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
-<message key="xmlui.EPerson.LoginChooser.title">Выберите способ входа</message>
-<message key="xmlui.EPerson.LoginChooser.trail">Выберите имя пользователя</message>
-<message key="xmlui.EPerson.LoginChooser.head1">Выбрать способ входа</message>
-<message key="xmlui.EPerson.LoginChooser.para1">Войти с помощью:</message>
-<message key="org.dspace.authenticate.ShibAuthentication.title">Аутентификация посредством Shibboleth</message>
-<message key="org.dspace.eperson.LDAPAuthentication.title">Аутентификация посредством LDAP</message>
-<message key="org.dspace.eperson.PasswordAuthentication.title">Пароля</message>
-<message key="org.dspace.eperson.X509Authentication.title">Web-сертификата</message>
+	<message key="xmlui.EPerson.LoginChooser.title">Выберите способ входа</message>
+	<message key="xmlui.EPerson.LoginChooser.trail">Выберите имя пользователя</message>
+	<message key="xmlui.EPerson.LoginChooser.head1">Выбрать способ входа</message>
+	<message key="xmlui.EPerson.LoginChooser.para1">Войти с помощью:</message>
+	<message key="org.dspace.authenticate.ShibAuthentication.title">Аутентификация посредством Shibboleth</message>
+	<message key="org.dspace.eperson.LDAPAuthentication.title">Аутентификация посредством LDAP</message>
+	<message key="org.dspace.eperson.PasswordAuthentication.title">Пароля</message>
+	<message key="org.dspace.eperson.X509Authentication.title">Web-сертификата</message>
 
 	<!-- org.dspace.app.xmlui.eperson.FailedAuthentication -->
-<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Предоставленные данные недействительны.</message>
-<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Невозможно произвести аутентификацию из-за неверных аргументов.</message>
-<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">По указанным данным пользователь не найден.</message>
-<message key="xmlui.EPerson.FailedAuthentication.title">Не удалось выполнить вход</message>
-<message key="xmlui.EPerson.FailedAuthentication.trail">Не удалось выполнить вход</message>
-<message key="xmlui.EPerson.FailedAuthentication.h1">Не удалось выполнить вход</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadCreds">Предоставленные данные недействительны.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.BadArgs">Невозможно произвести аутентификацию из-за неверных аргументов.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.NoSuchUser">По указанным данным пользователь не найден.</message>
+	<message key="xmlui.EPerson.FailedAuthentication.title">Не удалось выполнить вход</message>
+    <message key="xmlui.EPerson.FailedAuthentication.trail">Не удалось выполнить вход</message>
+    <message key="xmlui.EPerson.FailedAuthentication.h1">Не удалось выполнить вход</message>
 
 	<!-- Login xml files -->
-<message key="xmlui.eperson.noAuthMethod.head">Невозможно выполнить вход</message>
-<message key="xmlui.eperson.noAuthMethod.p1">Невозможно выполнить вход. Пожалуйста, свяжитесь с администрацией сайта.</message>
-<message key="xmlui.eperson.shibbLoginFailure.head">Вход с помощью Shibboleth не удался.</message>
-<message key="xmlui.eperson.shibbLoginFailure.p1">Аутентификация с помощью Shibboleth недоступна в этот момент. Пожалуйста, свяжитесь с администратором сайта.</message>
+	<message key="xmlui.eperson.noAuthMethod.head">Невозможно выполнить вход</message>
+	<message key="xmlui.eperson.noAuthMethod.p1">Невозможно выполнить вход. Пожалуйста, свяжитесь с администрацией сайта.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.head">Вход с помощью Shibboleth не удался.</message>
+	<message key="xmlui.eperson.shibbLoginFailure.p1">Аутентификация с помощью Shibboleth недоступна в этот момент. Пожалуйста, свяжитесь с администратором сайта.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
-<message key="xmlui.EPerson.ProfileUpdated.title">Профиль изменён</message>
-<message key="xmlui.EPerson.ProfileUpdated.trail">Изменить профиль</message>
-<message key="xmlui.EPerson.ProfileUpdated.head">Профиль изменён</message>
-<message key="xmlui.EPerson.ProfileUpdated.para1">Данные Вашего профиля были изменены.</message>
+	<message key="xmlui.EPerson.ProfileUpdated.title">Профиль изменён</message>
+	<message key="xmlui.EPerson.ProfileUpdated.trail">Изменить профиль</message>
+	<message key="xmlui.EPerson.ProfileUpdated.head">Профиль изменён</message>
+	<message key="xmlui.EPerson.ProfileUpdated.para1">Данные Вашего профиля были изменены.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
-<message key="xmlui.EPerson.RegistrationFinished.title">Регистрация закончена</message>
-<message key="xmlui.EPerson.RegistrationFinished.head">Регистрация закончена</message>
-<message key="xmlui.EPerson.RegistrationFinished.para1">Вы успешно зарегистрированы в системе DSpace. Теперь Вы можете подписаться на получение обновлений в коллекциях DSpace по электронной почте.</message>
+	<message key="xmlui.EPerson.RegistrationFinished.title">Регистрация закончена</message>
+	<message key="xmlui.EPerson.RegistrationFinished.head">Регистрация закончена</message>
+	<message key="xmlui.EPerson.RegistrationFinished.para1">Вы успешно зарегистрированы в системе DSpace. Теперь Вы можете подписаться на получение обновлений в коллекциях DSpace по электронной почте.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
-<message key="xmlui.EPerson.ResetPassword.title">Восстановление пароля</message>
-<message key="xmlui.EPerson.ResetPassword.head">Восстановление пароля</message>
-<message key="xmlui.EPerson.ResetPassword.para1">Пожалуйста, вевдите новый пароль и подтвердите его. Пароль должен содержать не менее шести символов.</message>
-<message key="xmlui.EPerson.ResetPassword.email_address">Email адрес</message>
-<message key="xmlui.EPerson.ResetPassword.new_password">Новый пароль</message>
-<message key="xmlui.EPerson.ResetPassword.confirm_password">Подтвердите пароль</message>
-<message key="xmlui.EPerson.ResetPassword.submit">Восстановить пароль</message>
-<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Пароль должен содержать не менее 6 символов</message>
-<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Пожалуйста, введите пароль ещё раз для подтверждения</message>
+	<message key="xmlui.EPerson.ResetPassword.title">Восстановление пароля</message>
+	<message key="xmlui.EPerson.ResetPassword.head">Восстановление пароля</message>
+	<message key="xmlui.EPerson.ResetPassword.para1">Пожалуйста, вевдите новый пароль и подтвердите его. Пароль должен содержать не менее шести символов.</message>
+	<message key="xmlui.EPerson.ResetPassword.email_address">Email адрес</message>
+	<message key="xmlui.EPerson.ResetPassword.new_password">Новый пароль</message>
+	<message key="xmlui.EPerson.ResetPassword.confirm_password">Подтвердите пароль</message>
+	<message key="xmlui.EPerson.ResetPassword.submit">Восстановить пароль</message>
+	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Пароль должен содержать не менее 6 символов</message>
+	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Пожалуйста, введите пароль ещё раз для подтверждения</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
-<message key="xmlui.EPerson.StartForgotPassword.title">Забыли пароль?</message>
-<message key="xmlui.EPerson.StartForgotPassword.head">Забыли пароль?</message>
-<message key="xmlui.EPerson.StartForgotPassword.para1">Введите Email-адрес, указанный при регистрации. На него Вам будет выслано письмо с дальнейшими инструкциями.</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address">Email-адрес</message>
-<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Введите Email адрес, указанный при регистрации.</message>
-<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Email-адрес не найден.</message>
-<message key="xmlui.EPerson.StartForgotPassword.submit">Восстановить пароль</message>
+	<message key="xmlui.EPerson.StartForgotPassword.title">Забыли пароль?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.head">Забыли пароль?</message>
+	<message key="xmlui.EPerson.StartForgotPassword.para1">Введите Email-адрес, указанный при регистрации. На него Вам будет выслано письмо с дальнейшими инструкциями.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address">Email-адрес</message>
+	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Введите Email адрес, указанный при регистрации.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Email-адрес не найден.</message>
+	<message key="xmlui.EPerson.StartForgotPassword.submit">Восстановить пароль</message>
 
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
-<message key="xmlui.EPerson.StartRegistration.title">Регистрация нового пользователя</message>
-<message key="xmlui.EPerson.StartRegistration.head1">Данный Email-адрес уже зарегистрирован в системе</message>
-<message key="xmlui.EPerson.StartRegistration.para1">Данный Email-адрес уже зарегистрирован в системе. Нажмите Восстановить пароль, если Вы хотите сбросить пароль.</message>
-<message key="xmlui.EPerson.StartRegistration.reset_password_for">Сбросить пароль для:</message>
-<message key="xmlui.EPerson.StartRegistration.submit_reset">Сбросить пароль</message>
-<message key="xmlui.EPerson.StartRegistration.head2">Регистрация нового пользователя</message>
-<message key="xmlui.EPerson.StartRegistration.para2">Зарегистрируйте аккаунт, чтобы подписаться на обновления коллекций DSpace по электронной почте.</message>
-<message key="xmlui.EPerson.StartRegistration.email_address">Email-адрес</message>
-<message key="xmlui.EPerson.StartRegistration.email_address_help">После подтверждения этот адрес будет использоватья для входа в систему.</message>
-<message key="xmlui.EPerson.StartRegistration.error_bad_email">Не удаётся отправить письмо на указанный электронный адрес.</message>
-<message key="xmlui.EPerson.StartRegistration.submit_register">Регистрация</message>
+	<message key="xmlui.EPerson.StartRegistration.title">Регистрация нового пользователя</message>
+	<message key="xmlui.EPerson.StartRegistration.head1">Данный Email-адрес уже зарегистрирован в системе</message>
+	<message key="xmlui.EPerson.StartRegistration.para1">Данный Email-адрес уже зарегистрирован в системе. Нажмите Восстановить пароль, если Вы хотите сбросить пароль.</message>
+	<message key="xmlui.EPerson.StartRegistration.reset_password_for">Сбросить пароль для:</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_reset">Сбросить пароль</message>
+	<message key="xmlui.EPerson.StartRegistration.head2">Регистрация нового пользователя</message>
+	<message key="xmlui.EPerson.StartRegistration.para2">Зарегистрируйте аккаунт, чтобы подписаться на обновления коллекций DSpace по электронной почте.</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address">Email-адрес</message>
+	<message key="xmlui.EPerson.StartRegistration.email_address_help">После подтверждения этот адрес будет использоватья для входа в систему.</message>
+	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Не удаётся отправить письмо на указанный электронный адрес.</message>
+	<message key="xmlui.EPerson.StartRegistration.submit_register">Регистрация</message>
 
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
-<message key="xmlui.EPerson.VerifyEmail.title">Подтверждающее письмо отправлено</message>
-<message key="xmlui.EPerson.VerifyEmail.head">Подтверждающее письмо отправлено</message>
-<message key="xmlui.EPerson.VerifyEmail.para">На адрес  {0} было отправлено подтверждающее письмо с дальнейшими инструкциями.</message>
+	<message key="xmlui.EPerson.VerifyEmail.title">Подтверждающее письмо отправлено</message>
+	<message key="xmlui.EPerson.VerifyEmail.head">Подтверждающее письмо отправлено</message>
+	<message key="xmlui.EPerson.VerifyEmail.para">На адрес  {0} было отправлено подтверждающее письмо с дальнейшими инструкциями.</message>
 
-                                 
-                                 
-                                 
-                                 
+
+
+
+
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -570,157 +618,157 @@ Translated by Ekaterina Chubich
 
 
 	<!-- general submission aspect messages -->
-<message key="xmlui.Submission.general.mydspace_home">Главная DSpace</message>
-<message key="xmlui.Submission.general.go_mydspace">Мой DSpace</message>
-<message key="xmlui.Submission.general.submission.title">Отправка элемента</message>
-<message key="xmlui.Submission.general.submission.trail">Отправка элемента</message>
-<message key="xmlui.Submission.general.submission.head">Отправка элемента</message>
-<message key="xmlui.Submission.general.submission.previous">&lt; Передыдущий</message>
-<message key="xmlui.Submission.general.submission.save">Сохранить / Выйти</message>
-<message key="xmlui.Submission.general.submission.next">Следующий &gt;</message>
-<message key="xmlui.Submission.general.submission.complete">Завершить отправку</message>
-<message key="xmlui.Submission.general.workflow.title">Отправка элементов</message>
-<message key="xmlui.Submission.general.workflow.trail">Отправка элементов</message>
-<message key="xmlui.Submission.general.workflow.head">Отправка элементов</message>
-<message key="xmlui.Submission.general.showfull">Показать полную запись элемента</message>
-<message key="xmlui.Submission.general.showsimple">Показать сокращенную запись элемента</message>
-<message key="xmlui.Submission.general.default.title">Отправка</message>
-<message key="xmlui.Submission.general.default.trail">Отправка</message>
+	<message key="xmlui.Submission.general.mydspace_home">Главная DSpace</message>
+	<message key="xmlui.Submission.general.go_mydspace">Мой DSpace</message>
+	<message key="xmlui.Submission.general.submission.title">Отправка элемента</message>
+	<message key="xmlui.Submission.general.submission.trail">Отправка элемента</message>
+	<message key="xmlui.Submission.general.submission.head">Отправка элемента</message>
+	<message key="xmlui.Submission.general.submission.previous">&lt; Передыдущий</message>
+	<message key="xmlui.Submission.general.submission.save">Сохранить / Выйти</message>
+	<message key="xmlui.Submission.general.submission.next">Следующий &gt;</message>
+	<message key="xmlui.Submission.general.submission.complete">Завершить отправку</message>
+	<message key="xmlui.Submission.general.workflow.title">Отправка элементов</message>
+	<message key="xmlui.Submission.general.workflow.trail">Отправка элементов</message>
+	<message key="xmlui.Submission.general.workflow.head">Отправка элементов</message>
+	<message key="xmlui.Submission.general.showfull">Показать полную запись элемента</message>
+	<message key="xmlui.Submission.general.showsimple">Показать сокращенную запись элемента</message>
+	<message key="xmlui.Submission.general.default.title">Отправка</message>
+	<message key="xmlui.Submission.general.default.trail">Отправка</message>
 
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
-<message key="xmlui.Submission.CollectionViewer.link1">Добавить элемент в эту коллекцию</message>
+	<message key="xmlui.Submission.CollectionViewer.link1">Добавить элемент в эту коллекцию</message>
 
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
-<message key="xmlui.Submission.Navigation.submissions">Отправления</message>
+	<message key="xmlui.Submission.Navigation.submissions">Отправления</message>
 
-	
-  <!-- org.dspace.app.xmlui.Submission.submissions -->
-<message key="xmlui.Submission.Submissions.title">Отправления и задачи</message>
-<message key="xmlui.Submission.Submissions.trail">Отправления</message>
-<message key="xmlui.Submission.Submissions.head">Отправления и задачи</message>
-<message key="xmlui.Submission.Submissions.untitled"><i>Без названия</i></message>
-<message key="xmlui.Submission.Submissions.email">email-адрес:</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submissions -->
+	<message key="xmlui.Submission.Submissions.title">Отправления и задачи</message>
+	<message key="xmlui.Submission.Submissions.trail">Отправления</message>
+	<message key="xmlui.Submission.Submissions.head">Отправления и задачи</message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
+	<message key="xmlui.Submission.Submissions.email">email-адрес:</message>
 	<!-- Same transformer, workflow section -->
-<message key="xmlui.Submission.Submissions.workflow_head1">Задачи</message>
-<message key="xmlui.Submission.Submissions.workflow_info1">Эти задачи включают в себя документы, требующие подтверждения, перед добавлением в репозиторий. Одна очередь задач состоит из задач, выбранных Вами, другая - из тех, которые пока не выбрал никто.</message>
-<message key="xmlui.Submission.Submissions.workflow_head2">Ваши задачи</message>
-<message key="xmlui.Submission.Submissions.workflow_column1"></message>
-<message key="xmlui.Submission.Submissions.workflow_column2">Задача</message>
-<message key="xmlui.Submission.Submissions.workflow_column3">Документ</message>
-<message key="xmlui.Submission.Submissions.workflow_column4">Коллекция</message>
-<message key="xmlui.Submission.Submissions.workflow_column5">Отправитель</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_return">Добавить выбранные задачи в очередь</message>
-<message key="xmlui.Submission.Submissions.workflow_info2">Нет задач, принадлежащих Вам</message>
-<message key="xmlui.Submission.Submissions.workflow_head3">Задачи, ожидающие очереди</message>
-<message key="xmlui.Submission.Submissions.workflow_submit_take">Взяться за следующие задачи</message>
-<message key="xmlui.Submission.Submissions.workflow_info3">Нет задач, ожидающих очереди</message>   
+	<message key="xmlui.Submission.Submissions.workflow_head1">Задачи</message>
+	<message key="xmlui.Submission.Submissions.workflow_info1">Эти задачи включают в себя документы, требующие подтверждения, перед добавлением в репозиторий. Одна очередь задач состоит из задач, выбранных Вами, другая - из тех, которые пока не выбрал никто.</message>
+	<message key="xmlui.Submission.Submissions.workflow_head2">Ваши задачи</message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
+	<message key="xmlui.Submission.Submissions.workflow_column2">Задача</message>
+	<message key="xmlui.Submission.Submissions.workflow_column3">Документ</message>
+	<message key="xmlui.Submission.Submissions.workflow_column4">Коллекция</message>
+	<message key="xmlui.Submission.Submissions.workflow_column5">Отправитель</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_return">Добавить выбранные задачи в очередь</message>
+	<message key="xmlui.Submission.Submissions.workflow_info2">Нет задач, принадлежащих Вам</message>
+	<message key="xmlui.Submission.Submissions.workflow_head3">Задачи, ожидающие очереди</message>
+	<message key="xmlui.Submission.Submissions.workflow_submit_take">Взяться за следующие задачи</message>
+	<message key="xmlui.Submission.Submissions.workflow_info3">Нет задач, ожидающих очереди</message>
 	<!-- Same transformer, submissions section -->
-<message key="xmlui.Submission.Submissions.submit_head1">Отправка</message>
-<message key="xmlui.Submission.Submissions.submit_info1a">Вы можете </message>
-<message key="xmlui.Submission.Submissions.submit_info1b"> начать пополнение коллекции</message>
-<message key="xmlui.Submission.Submissions.submit_info1c">Пополнение коллекции заключается в описании элемента и загрузки файлов, относящихся к нему. Каждое сообщество или коллекция может иметь свои правила пополнения.</message>
-<message key="xmlui.Submission.Submissions.submit_head2">Незавершенные пополнения</message>
-<message key="xmlui.Submission.Submissions.submit_info2a">У Вас есть незавершённые пополнения. Вы также можете</message>
-<message key="xmlui.Submission.Submissions.submit_info2b"> загрузить ещё один документь</message>
-<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-<message key="xmlui.Submission.Submissions.submit_column1"></message>
-<message key="xmlui.Submission.Submissions.submit_column2">Название</message>
-<message key="xmlui.Submission.Submissions.submit_column3">Коллекция</message>
-<message key="xmlui.Submission.Submissions.submit_column4">Отправитель</message>
-<message key="xmlui.Submission.Submissions.submit_head3">Автор(ы)</message>
-<message key="xmlui.Submission.Submissions.submit_info3">У Вас нет незаконченных загрузок</message>
-<message key="xmlui.Submission.Submissions.submit_head4">Отвественный:</message>
-<message key="xmlui.Submission.Submissions.submit_submit_remove">Удалить незаконченные загрузки</message>
+	<message key="xmlui.Submission.Submissions.submit_head1">Отправка</message>
+	<message key="xmlui.Submission.Submissions.submit_info1a">Вы можете </message>
+	<message key="xmlui.Submission.Submissions.submit_info1b"> начать пополнение коллекции</message>
+	<message key="xmlui.Submission.Submissions.submit_info1c">Пополнение коллекции заключается в описании элемента и загрузки файлов, относящихся к нему. Каждое сообщество или коллекция может иметь свои правила пополнения.</message>
+	<message key="xmlui.Submission.Submissions.submit_head2">Незавершенные пополнения</message>
+	<message key="xmlui.Submission.Submissions.submit_info2a">У Вас есть незавершённые пополнения. Вы также можете</message>
+	<message key="xmlui.Submission.Submissions.submit_info2b"> загрузить ещё один документь</message>
+	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
+	<message key="xmlui.Submission.Submissions.submit_column2">Название</message>
+	<message key="xmlui.Submission.Submissions.submit_column3">Коллекция</message>
+	<message key="xmlui.Submission.Submissions.submit_column4">Отправитель</message>
+	<message key="xmlui.Submission.Submissions.submit_head3">Автор(ы)</message>
+	<message key="xmlui.Submission.Submissions.submit_info3">У Вас нет незаконченных загрузок</message>
+	<message key="xmlui.Submission.Submissions.submit_head4">Отвественный:</message>
+	<message key="xmlui.Submission.Submissions.submit_submit_remove">Удалить незаконченные загрузки</message>
 	<!-- Same transformer, inprogress section -->
-<message key="xmlui.Submission.Submissions.progress_head1">Документы, ожидающие модерации</message>
-<message key="xmlui.Submission.Submissions.progress_info1">Документы, добавленные Вами и ожидающие модерации.</message>
-<message key="xmlui.Submission.Submissions.progress_column1">Название</message>
-<message key="xmlui.Submission.Submissions.progress_column2">Коллекция</message>
-<message key="xmlui.Submission.Submissions.progress_column3">Состояние</message>
+	<message key="xmlui.Submission.Submissions.progress_head1">Документы, ожидающие модерации</message>
+	<message key="xmlui.Submission.Submissions.progress_info1">Документы, добавленные Вами и ожидающие модерации.</message>
+	<message key="xmlui.Submission.Submissions.progress_column1">Название</message>
+	<message key="xmlui.Submission.Submissions.progress_column2">Коллекция</message>
+	<message key="xmlui.Submission.Submissions.progress_column3">Состояние</message>
 	<!-- Same transformer, workflow status -->
-<message key="xmlui.Submission.Submissions.status_0">Отправлено</message>
-<message key="xmlui.Submission.Submissions.status_1">Ожидает модерации</message>
-<message key="xmlui.Submission.Submissions.status_2">Модерируется</message>
-<message key="xmlui.Submission.Submissions.status_3">Ожидает редавтуры</message>
-<message key="xmlui.Submission.Submissions.status_4">Редактируется</message>
-<message key="xmlui.Submission.Submissions.status_5">Ожидает финальной редактуры</message>
-<message key="xmlui.Submission.Submissions.status_6">Отредактировано</message>
-<message key="xmlui.Submission.Submissions.status_7">Добавлено в архив</message>
-<message key="xmlui.Submission.Submissions.status_unknown">Неизвестно</message>
+	<message key="xmlui.Submission.Submissions.status_0">Отправлено</message>
+	<message key="xmlui.Submission.Submissions.status_1">Ожидает модерации</message>
+	<message key="xmlui.Submission.Submissions.status_2">Модерируется</message>
+	<message key="xmlui.Submission.Submissions.status_3">Ожидает редавтуры</message>
+	<message key="xmlui.Submission.Submissions.status_4">Редактируется</message>
+	<message key="xmlui.Submission.Submissions.status_5">Ожидает финальной редактуры</message>
+	<message key="xmlui.Submission.Submissions.status_6">Отредактировано</message>
+	<message key="xmlui.Submission.Submissions.status_7">Добавлено в архив</message>
+	<message key="xmlui.Submission.Submissions.status_unknown">Неизвестно</message>
         <!-- Same transformer, completed submissions section -->
-<message key="xmlui.Submission.Submissions.completed.head">В архиве</message>
-<message key="xmlui.Submission.Submissions.completed.info">Файлы, загруженные Вами в Dspace</message>
-<message key="xmlui.Submission.Submissions.completed.column1">Дата загрузки</message>
-<message key="xmlui.Submission.Submissions.completed.column2">Название</message>
-<message key="xmlui.Submission.Submissions.completed.column3">Коллекция</message>
-<message key="xmlui.Submission.Submissions.completed.limit">Показано 50 документов, добавленных Вами в архив</message>
-<message key="xmlui.Submission.Submissions.completed.displayall">Показать все</message>
+        <message key="xmlui.Submission.Submissions.completed.head">В архиве</message>
+        <message key="xmlui.Submission.Submissions.completed.info">Файлы, загруженные Вами в Dspace</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Дата загрузки</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Название</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Коллекция</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">Показано 50 документов, добавленных Вами в архив</message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Показать все</message>
 
 	<!-- submission progress bar messages -->
-<message key="xmlui.Submission.submit.progressbar.initial-questions">Основные вопросы</message>
-<message key="xmlui.Submission.submit.progressbar.describe">Описание</message>
-  <message key="xmlui.Submission.submit.progressbar.access">Загрузка</message>
-  <message key="xmlui.Submission.submit.progressbar.upload">Загрузить  </message>
-<message key="xmlui.Submission.submit.progressbar.verify">Редактировать</message>
-<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-<message key="xmlui.Submission.submit.progressbar.CClicense">Лицензия CC</message>
-<message key="xmlui.Submission.submit.progressbar.license">Лицензия</message>
-<message key="xmlui.Submission.submit.progressbar.complete">Закончить</message>
+	<message key="xmlui.Submission.submit.progressbar.initial-questions">Основные вопросы</message>
+	<message key="xmlui.Submission.submit.progressbar.describe">Описание</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Загрузка</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Загрузить  </message>
+	<message key="xmlui.Submission.submit.progressbar.verify">Редактировать</message>
+	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">Лицензия CC</message>
+    <message key="xmlui.Submission.submit.progressbar.license">Лицензия</message>
+	<message key="xmlui.Submission.submit.progressbar.complete">Закончить</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
-<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Вернуться</message>
+	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Вернуться</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SelectCollection -->
-<message key="xmlui.Submission.submit.SelectCollection.head">Выберите коллекцию...</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection">Коллекция</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_help">Выберите коллекцию, в которую хотите добавить документ.</message>
-<message key="xmlui.Submission.submit.SelectCollection.collection_default">Выберите коллекцию...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.head">Выберите коллекцию...</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection">Коллекция</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_help">Выберите коллекцию, в которую хотите добавить документ.</message>
+	<message key="xmlui.Submission.submit.SelectCollection.collection_default">Выберите коллекцию...</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.SaveOrRemoveStep -->
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Сохранить или отменить загрузку?</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Удалить загрузку, или вернуться к работе с ней позже? Вы можете вернуться к работе с пополнением коллекции, если Вы нажали Выйти по ошибке.</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Продолжить загрузку документа</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Сохранить и продолжить работу позже</message>
-<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Прекратить загрузку документа</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.head">Сохранить или отменить загрузку?</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.info1">Удалить загрузку, или вернуться к работе с ней позже? Вы можете вернуться к работе с пополнением коллекции, если Вы нажали Выйти по ошибке.</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_back">Продолжить загрузку документа</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Сохранить и продолжить работу позже</message>
+	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Прекратить загрузку документа</message>
 
 
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
-<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Основные вопросы</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Важно:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.and">и</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Множественное именование</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Если документ имеет несколько названий, <i>например, переведённое название</i></message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Название будет удалено, если галочка у соответствующего пункта не поставлена:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Опубликовано</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Документ уже был опубликован ранее</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Элемент будет удалён, если галочка у соответствующего пункта не поставлена:</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Дата публикации</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Цитата</message>
-<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Редактор</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Основные вопросы</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Важно:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.and">и</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.separator">,</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set">(</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Множественное именование</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Если документ имеет несколько названий, <i>e.g. a translated title</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Название будет удалено, если галочка у соответствующего пункта не поставлена:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Опубликовано</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Документ уже был опубликован ранее</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_note">Элемент будет удалён, если галочка у соответствующего пункта не поставлена:</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Дата публикации</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Цитата</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Редактор</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
-<message key="xmlui.Submission.submit.DescribeStep.head">Описание документа</message>
-<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Ошибка: неизвестное поле</message>
-<message key="xmlui.Submission.submit.DescribeStep.required_field">Данное поле обязательно</message>
-<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Фамилия, <i>например, Иванов</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Имя, <i>например, Иван</i></message>
-<message key="xmlui.Submission.submit.DescribeStep.year">Год</message>
-<message key="xmlui.Submission.submit.DescribeStep.month">Месяц</message>
-<message key="xmlui.Submission.submit.DescribeStep.day">День</message>
-<message key="xmlui.Submission.submit.DescribeStep.series_name">Наименование серии</message>
-<message key="xmlui.Submission.submit.DescribeStep.report_no">Доклад номер</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Тематические категории</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Тематические категории</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Тематические фильтры</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Отфильтровать</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Подождите, пока загружаются фильтры.</message>
-<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Ошибка загрузки. Повторите попытку позже</message>
- 
+	<message key="xmlui.Submission.submit.DescribeStep.head">Описание документа</message>
+	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Ошибка: неизвестное поле</message>
+	<message key="xmlui.Submission.submit.DescribeStep.required_field">Данное поле обязательно</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Фамилия, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Имя, <i>e.g. Donald Jr</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.year">Год</message>
+	<message key="xmlui.Submission.submit.DescribeStep.month">Месяц</message>
+	<message key="xmlui.Submission.submit.DescribeStep.day">День</message>
+	<message key="xmlui.Submission.submit.DescribeStep.series_name">Наименование серии</message>
+	<message key="xmlui.Submission.submit.DescribeStep.report_no">Доклад номер</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Тематические категории</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Тематические категории</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Тематические фильтры</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Отфильтровать</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Подождите, пока загружаются фильтры.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Ошибка загрузки. Повторите попытку позже</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
     <message key="xmlui.Submission.submit.AccessStep.head">Управление доступом</message>
     <message key="xmlui.Submission.submit.AccessStep.access_settings">Доступно группе пользователей(не распространяется на анонимных пользователей)</message>
     <message key="xmlui.Submission.submit.AccessStep.open_access">Документ станет доступен, как только будет добавлен в архив</message>
@@ -756,40 +804,41 @@ Translated by Ekaterina Chubich
     <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
 
 
+
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Изменить политику</message>
-    
-<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
-<message key="xmlui.Submission.submit.UploadStep.head">Загрузить документ(ы)</message>
-<message key="xmlui.Submission.submit.UploadStep.file">Файл</message>
-<message key="xmlui.Submission.submit.UploadStep.file_help">Пожалуйста, введите полный путь к файлу на вашем компьютере. При нажатии "Обзор..." появится новое окно, позволяющее выбрать файл на Вашем компьютере.</message>
-<message key="xmlui.Submission.submit.UploadStep.file_error">Файл должен содержать как минимум один документ.</message>
-<message key="xmlui.Submission.submit.UploadStep.upload_error">Ошибка загрузки документа. Возможно, неверное имя файла, проблема соединения, или неверный формат документа.ПОжалуйста, посвторите попытку.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_error">Документ не был загружен, т.к., возможно, содержит вирус. Пожалуйста, свяжитесь с администрацией.</message>
-<message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Ошибка распознания вируса в документе. Пожалуйста, свяжитесь с администрацией.</message>
-<message key="xmlui.Submission.submit.UploadStep.description">Описание документа</message>
-<message key="xmlui.Submission.submit.UploadStep.description_help">При желании, Вы можете добавить краткое описание документа, например "<i>Главная статья</i>", или "<i>Текст лекции</i>".</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_upload">Загрузить документ и добавить ещё один</message>
-<message key="xmlui.Submission.submit.UploadStep.head2">Мои документы</message>
-<message key="xmlui.Submission.submit.UploadStep.column0">Первичный файл</message>
-<message key="xmlui.Submission.submit.UploadStep.column1"></message>
-<message key="xmlui.Submission.submit.UploadStep.column2">Документ</message>
-<message key="xmlui.Submission.submit.UploadStep.column3">Размер</message>
-<message key="xmlui.Submission.submit.UploadStep.column4">Описание</message>
-<message key="xmlui.Submission.submit.UploadStep.column5">Формат</message>
-<message key="xmlui.Submission.submit.UploadStep.column6"></message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_name">Неизвестный</message>
-<message key="xmlui.Submission.submit.UploadStep.unknown_format">неизвестный формат</message>
-<message key="xmlui.Submission.submit.UploadStep.supported">(Поддерживаемый)</message>
-<message key="xmlui.Submission.submit.UploadStep.known">(Известный)</message>
-<message key="xmlui.Submission.submit.UploadStep.unsupported">(Не поддерживается)</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_edit">Редактировать</message>
-<message key="xmlui.Submission.submit.UploadStep.checksum">Верификация документа:</message>
-<message key="xmlui.Submission.submit.UploadStep.submit_remove">Удалить выбранные документы</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+	<message key="xmlui.Submission.submit.UploadStep.head">Загрузить документ(ы)</message>
+	<message key="xmlui.Submission.submit.UploadStep.file">Файл</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_help">Пожалуйста, введите полный путь к файлу на вашем компьютере. При нажатии "Обзор..." появится новое окно, позволяющее выбрать файл на Вашем компьютере.</message>
+	<message key="xmlui.Submission.submit.UploadStep.file_error">Файл должен содержать как минимум один документ.</message>
+	<message key="xmlui.Submission.submit.UploadStep.upload_error">Ошибка загрузки документа. Возможно, неверное имя файла, проблема соединения, или неверный формат документа.ПОжалуйста, посвторите попытку.</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">Документ не был загружен, т.к., возможно, содержит вирус. Пожалуйста, свяжитесь с администрацией.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Ошибка распознания вируса в документе. Пожалуйста, свяжитесь с администрацией.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Описание документа</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">При желании, Вы можете добавить краткое описание документа, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Загрузить документ и добавить ещё один</message>
+	<message key="xmlui.Submission.submit.UploadStep.head2">Мои документы</message>
+	<message key="xmlui.Submission.submit.UploadStep.column0">Первичный файл</message>
+	<message key="xmlui.Submission.submit.UploadStep.column1"/>
+	<message key="xmlui.Submission.submit.UploadStep.column2">Документ</message>
+	<message key="xmlui.Submission.submit.UploadStep.column3">Размер</message>
+	<message key="xmlui.Submission.submit.UploadStep.column4">Описание</message>
+	<message key="xmlui.Submission.submit.UploadStep.column5">Формат</message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Неизвестный</message>
+	<message key="xmlui.Submission.submit.UploadStep.unknown_format">неизвестный формат</message>
+	<message key="xmlui.Submission.submit.UploadStep.supported">(Поддерживаемый)</message>
+	<message key="xmlui.Submission.submit.UploadStep.known">(Известный)</message>
+	<message key="xmlui.Submission.submit.UploadStep.unsupported">(Не поддерживается)</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Редактировать</message>
+	<message key="xmlui.Submission.submit.UploadStep.checksum">Верификация документа:</message>
+	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Удалить выбранные документы</message>
 
 
 
- <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Загрузить документ(ы)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Загрузить документ(ы)</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">Файл</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Пожалуйста, введите полный путь к файлу на вашем компьютере, соответствущему документу. Если вы нажмете "Просмотр", то сможете выбрать файл в новом окне.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">Документ должен содержать хотя бы один документ.</message>
@@ -797,7 +846,7 @@ Translated by Ekaterina Chubich
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Не удалось загрузить файл, так как, возможно, он содержит вирус. Пожалуйста, свяжитесь с администратором системы.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Возникла ошибка в процессе проверки файла на вирусы. Пожалуйста, свяжитесь с администратором системы.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Описание файла</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">По желанию добавьте краткое описание документа, например, "<i>Основная статья</i>", или "<i>Экспериментальные данные</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">По желанию добавьте краткое описание документа, например, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Загрузка файла &amp; добавить еще один</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Загруженные файлы</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Главный</message>
@@ -806,7 +855,7 @@ Translated by Ekaterina Chubich
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Размер</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Описание</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Формат</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Неизвестный</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">неизвестный формат</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Поддерживаемый)</message>
@@ -817,93 +866,93 @@ Translated by Ekaterina Chubich
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Удалить выбранные файлы</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Правила включения</message>
 
-       
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
-<message key="xmlui.Submission.submit.EditFileStep.head">Редактировать файл</message>
-<message key="xmlui.Submission.submit.EditFileStep.file">Файл</message>
-<message key="xmlui.Submission.submit.EditFileStep.description">Описание файла</message>
-<message key="xmlui.Submission.submit.EditFileStep.description_help">По желанию Вы можете добавить краткое описание содержания файла, например "<i>Главная статья</i>", или "<i>Экспериментальные данные</i>".</message>
-<message key="xmlui.Submission.submit.EditFileStep.info1">Выберите из списка формат архива, например "<i>Adobe PDF</i>" или "<i>Microsoft Word</i>", <b>O</b> если формат не присутствует в списке, пожалуйста, укажите формат в поле под списком.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_detected">Определен формат</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_selected">Выбран формат</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_default">Формата нет в списке</message>
-<message key="xmlui.Submission.submit.EditFileStep.info2">Если формата нет в списке, <strong>выберите "Формата нет в списке" </strong> и укажите его в поле ниже.</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user">Другой формат</message>
-<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Название и версия приложения, которое вы использовали для создания документа (например, "<i>ACMESoft SuperApp версия 1.5</i>").</message>
+	<message key="xmlui.Submission.submit.EditFileStep.head">Редактировать файл</message>
+	<message key="xmlui.Submission.submit.EditFileStep.file">Файл</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description">Описание файла</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">По желанию Вы можете добавить краткое описание содержания файла, например "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Выберите из списка формат архива, например "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Определен формат</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Выбран формат</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_default">Формата нет в списке</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Если формата нет в списке, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user">Другой формат</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Название и версия приложения, которое вы использовали для создания документа (например, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
-	   <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Доступ к Bitstream</message>
-    
 
-    <!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
-<message key="xmlui.Submission.submit.ReviewStep.head">Проверить отправляемый документ</message>
-<message key="xmlui.Submission.submit.ReviewStep.yes">Да</message>
-<message key="xmlui.Submission.submit.ReviewStep.no">Нет</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Отредактировать один из элементов</message>
-<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Добавить или удалить файл</message>
-<message key="xmlui.Submission.submit.ReviewStep.head1">Основные вопросы</message>
-<message key="xmlui.Submission.submit.ReviewStep.head2">Описание страницы {0}</message>
-<message key="xmlui.Submission.submit.ReviewStep.head3">Загруженные файлы</message>
-<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Несколько названий</message>
-<message key="xmlui.Submission.submit.ReviewStep.published_before">Опубликовано до</message>
-<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
-<message key="xmlui.Submission.submit.ReviewStep.unknown">неизвестный</message>
-<message key="xmlui.Submission.submit.ReviewStep.known">известный</message>
-<message key="xmlui.Submission.submit.ReviewStep.supported">поддерживаемый</message>
+
+	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
+	<message key="xmlui.Submission.submit.ReviewStep.head">Проверить отправляемый документ</message>
+	<message key="xmlui.Submission.submit.ReviewStep.yes">Да</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no">Нет</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump">Отредактировать один из элементов</message>
+	<message key="xmlui.Submission.submit.ReviewStep.submit_jump_files">Добавить или удалить файл</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head1">Основные вопросы</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head2">Описание страницы {0}</message>
+	<message key="xmlui.Submission.submit.ReviewStep.head3">Загруженные файлы</message>
+	<message key="xmlui.Submission.submit.ReviewStep.multiple_titles">Несколько названий</message>
+	<message key="xmlui.Submission.submit.ReviewStep.published_before">Опубликовано до</message>
+	<message key="xmlui.Submission.submit.ReviewStep.no_metadata">-</message>
+	<message key="xmlui.Submission.submit.ReviewStep.unknown">неизвестный</message>
+	<message key="xmlui.Submission.submit.ReviewStep.known">известный</message>
+	<message key="xmlui.Submission.submit.ReviewStep.supported">поддерживаемый</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-<message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Произошла ошибка .. {0}</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.head">Лицензия для документа</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.info1">По желанию вы можете добавить лицензию для вашего документа <a href="http://creativecommons.org/">Creative Commons</a>. Лицензия Creative Commons определяет, какие действия могут совершать читатели с вашим документом.</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Выберите лицензию</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Войти в Creative Commons, чтобы выбрать лицензию</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.license">Тип лицензии</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.select_change">Выберите или измените лицензию...</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.no_license">Без лицензии Creative Commons</message>
-<message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Нажмите "Далее", чтобы сохранить изменения.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Произошла ошибка .. {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Лицензия для документа</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">По желанию вы можете добавить лицензию для вашего документа <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Выберите лицензию</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Войти в Creative Commons, чтобы выбрать лицензию</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Тип лицензии</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Выберите или измените лицензию...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">Без лицензии Creative Commons</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">Нажмите "Далее", чтобы сохранить изменения.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
-<message key="xmlui.Submission.submit.LicenseStep.head">Лицензию распространения</message>
-<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Остался последний шаг:</strong> чтобы в DSpace можно было воспроизводить, переводить и распространять ваш документ по всему миру, нам нужно чтобы вы приняли следующие условия.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info2">Предоставьте стандартную лицензию распространения, выбрав 'Предоставить лицензию' и нажав 'Закончить отправку'.</message>
-<message key="xmlui.Submission.submit.LicenseStep.info3">Если у Вас возникли какие-либо вопросы по поводу лицензии, пожалуйста, свяжитесь с администратором системы.</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_label">Лицензия распространения</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Предоставить лицензию</message>
-<message key="xmlui.Submission.submit.LicenseStep.decision_error">Вам нужно предоставить лицензию, чтобы закончить отправку. Если вы не можете это сделать сейчас, вам придется сохранить ваш документ, возобновить работу позже или сейчас же удалить ваш документ, нажав "Удалить документ".</message>
+	<message key="xmlui.Submission.submit.LicenseStep.head">Лицензию распространения</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info2">Предоставьте стандартную лицензию распространения, выбрав 'Предоставить лицензию' и нажав 'Закончить отправку'.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info3">Если у Вас возникли какие-либо вопросы по поводу лицензии, пожалуйста, свяжитесь с администратором системы.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Лицензия распространения</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_checkbox">Предоставить лицензию</message>
+	<message key="xmlui.Submission.submit.LicenseStep.decision_error">Вам нужно предоставить лицензию, чтобы закончить отправку. Если вы не можете это сделать сейчас, вам придется сохранить ваш документ, возобновить работу позже или сейчас же удалить ваш документ, нажав "Удалить документ".</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
-<message key="xmlui.Submission.submit.RemovedStep.head">Документ удален</message>
-<message key="xmlui.Submission.submit.RemovedStep.info1">Ваше отправление было отменено, и неполный документ был удален из системы.</message>
-<message key="xmlui.Submission.submit.RemovedStep.go_submission">Перейти на страницу отправки</message>
+	<message key="xmlui.Submission.submit.RemovedStep.head">Документ удален</message>
+	<message key="xmlui.Submission.submit.RemovedStep.info1">Ваше отправление было отменено, и неполный документ был удален из системы.</message>
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">Перейти на страницу отправки</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-<message key="xmlui.Submission.submit.CompletedStep.head">Отправка завершена</message>
-<message key="xmlui.Submission.submit.CompletedStep.info1">Ваш документ пройдет через процесс модерации для данной коллекции. Вы получите оповещение по электронной почте как только ваш файл будет добавлен в коллекцию. Вы также можете проверить состояние отправки на странице 'Мой DSpace'.</message>
-<message key="xmlui.Submission.submit.CompletedStep.go_submission">Перейти на страницу отправки</message>
-<message key="xmlui.Submission.submit.CompletedStep.submit_again">Добавить другой документ</message>
+	<message key="xmlui.Submission.submit.CompletedStep.head">Отправка завершена</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Ваш документ пройдет через процесс модерации для данной коллекции. Вы получите оповещение по электронной почте как только ваш файл будет добавлен в коллекцию. Вы также можете проверить состояние отправки на странице 'Мой DSpace'.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Перейти на страницу отправки</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Добавить другой документ</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
-<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Действия, доступные для этой задачи:</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Назначить задачу себе.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Взять задачу</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Оставить задачу в очереди, чтобы другой пользователь мог её взять.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Оставить задачу</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Если вы проверили документ и считаете его подходящим для коллекции, выберите "Подтвердить".</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Подтвердить</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Когда закончите редактировать документ, воспользуйтесь этой опцией, чтобы отправить его в архив.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Отправить в архив</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Если вы проверили документ и обнаружили, что он <strong>не</strong> подходит для включения в эту коллекцию, выберите "Отклонить". Вам будет предложено ввести сообщение, в котором вам нужно будет пояснить, почему документ не подходит для коллекции и что нужно поменять, чтобы документ начал подходить.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Отклонить документ</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Выберите этот пункт, чтобы исправить или отредактировать метаданные документа.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Редактировать метаданные</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Чтобы вернуть задачу в очередь чтобы другой человек мог закончить её проверку, нажмите здесь.</message>
-<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Вернуть в очередь</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Действия, доступные для этой задачи:</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_help">Назначить задачу себе.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.take_submit">Взять задачу</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_help">Оставить задачу в очереди, чтобы другой пользователь мог её взять.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.leave_submit">Оставить задачу</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_help">Если вы проверили документ и считаете его подходящим для коллекции, выберите "Подтвердить".</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Подтвердить</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Когда закончите редактировать документ, воспользуйтесь этой опцией, чтобы отправить его в архив.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Отправить в архив</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Если вы проверили документ и обнаружили, что он <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Отклонить документ</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Выберите этот пункт, чтобы исправить или отредактировать метаданные документа.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Редактировать метаданные</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_help">Чтобы вернуть задачу в очередь чтобы другой человек мог закончить её проверку, нажмите здесь.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.return_submit">Вернуть в очередь</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.RejectTaskStep -->
-<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Пожалуйста, укажите причину, по которой Вы отклоняете документ. Укажите в сообщении, что именно следует изменить отправителю перед повторной отправкой.</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Причина</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Поле "Причина" обязательно</message>
-<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Отклонить документ</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.info1">Пожалуйста, укажите причину, по которой Вы отклоняете документ. Укажите в сообщении, что именно следует изменить отправителю перед повторной отправкой.</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason">Причина</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Поле "Причина" обязательно</message>
+	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Отклонить документ</message>
 
 
 
@@ -916,330 +965,332 @@ Translated by Ekaterina Chubich
 
 	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
 
-<message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Задача успешно выполнена.</message>
-<message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Задача была прервана или закончена неудачно. Свяжитесь с администратором или проверьте журнал системы</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Задача успешно добавлена в очередь.</message>
-<message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Не удалось добавить файл в очередь из-за ошибки. За дополнительной информацией, пожалуйста, обратитесь к администратору или проверьте журнал на возможные ошибки.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Пользователь успешно добавлен.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Пользователь успешно отредактирован.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Пользователю отправлено сообщение, содержащее код, который может быть использован для восстановления пароля</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Пользовател(и) успешно удалены.</message>
-<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Пользователи из списка не были удалены из-за ограничений, не позволяющих их удалить. Для дополнительной информации просмотрите страницу с данными пользователя.</message>
-<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Группа успешно отредактирована.</message>
-<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Выбранные группы успешно удалены.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Новая схема создана успешно.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Схема была успешно удалена.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Поле метаданных успешно добавлено.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Поле метаданных успешно отредактировано.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Поле метаданных успешно перемещено.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Поле метаданных успешно удалено.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Формат успешно сохранен.</message>
-<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Формат(ы) успешно удалены.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Метаданные документа успешно изменены.</message>
-<message key="xmlui.administrative.FlowItemUtils.metadata_added">Добавлены новые метаданные.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Документ был удален.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Документ был восстановлен.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_moved">Документ был перемещен.</message>
-<message key="xmlui.administrative.FlowItemUtils.item_move_failed">Выбранная коллекция не найдена.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Новый архив успешно загружен.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Ошибка при загрузке архива.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Архив измененен.</message>
-<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Выбранные архивы были удалены.</message>
-<message key="xmlui.administrative.FlowMapperUtils.map_items">Выбранные документы успешно упорядочены.</message>
-<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Документы были успешно отсоединены.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">Задача успешно выполнена.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">Задача была прервана или закончена неудачно. Свяжитесь с администратором или проверьте журнал системы</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">Задача успешно добавлена в очередь.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">Не удалось добавить файл в очередь из-за ошибки. За дополнительной информацией, пожалуйста, обратитесь к администратору или проверьте журнал на возможные ошибки.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Пользователь успешно добавлен.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Пользователь успешно отредактирован.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Пользователю отправлено сообщение, содержащее код, который может быть использован для восстановления пароля</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Пользовател(и) успешно удалены.</message>
+	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_failed_notice">Пользователи из списка не были удалены из-за ограничений, не позволяющих их удалить. Для дополнительной информации просмотрите страницу с данными пользователя.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.edit_group_success_notice">Группа успешно отредактирована.</message>
+	<message key="xmlui.administrative.FlowGroupUtils.delete_group_success_notice">Выбранные группы успешно удалены.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_schema_success_notice">Новая схема создана успешно.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_schema_success_notice">Схема была успешно удалена.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.add_metadata_field_success_notice">Поле метаданных успешно добавлено.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_metadata_field_success_notice">Поле метаданных успешно отредактировано.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.move_metadata_field_success_notice">Поле метаданных успешно перемещено.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_metadata_field_success_notice">Поле метаданных успешно удалено.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.edit_bitstream_format_success_notice">Формат успешно сохранен.</message>
+	<message key="xmlui.administrative.FlowRegistryUtils.delete_bitstream_format_success_notice">Формат(ы) успешно удалены.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_updated">Метаданные документа успешно изменены.</message>
+	<message key="xmlui.administrative.FlowItemUtils.metadata_added">Добавлены новые метаданные.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_withdrawn">Документ был удален.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_reinstated">Документ был восстановлен.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_moved">Документ был перемещен.</message>
+	<message key="xmlui.administrative.FlowItemUtils.item_move_failed">Выбранная коллекция не найдена.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_added">Новый архив успешно загружен.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_failed">Ошибка при загрузке архива.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_updated">Архив измененен.</message>
+	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Выбранные архивы были удалены.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.map_items">Выбранные документы успешно упорядочены.</message>
+	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Документы были успешно отсоединены.</message>
 
 	<!-- general items for all of the eperson classes -->
-<message key="xmlui.administrative.eperson.general.epeople_trail">Администрирование пользователей</message>
+	<message key="xmlui.administrative.eperson.general.epeople_trail">Администрирование пользователей</message>
 
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
-<message key="xmlui.administrative.Navigation.context_head">Контекст</message>
-<message key="xmlui.administrative.Navigation.context_edit_item">Изменить этот документ</message>
-<message key="xmlui.administrative.Navigation.context_edit_collection">Редактировать коллекцию</message>
-<message key="xmlui.administrative.Navigation.context_item_mapper">Каталог документов</message>
-<message key="xmlui.administrative.Navigation.context_edit_community">Редактировать сообщество</message>
-<message key="xmlui.administrative.Navigation.context_create_collection">Создать коллекцию</message>
-<message key="xmlui.administrative.Navigation.context_create_subcommunity">Создать под-сообщество</message>
-<message key="xmlui.administrative.Navigation.context_create_community">Создать сообщество</message>
-<message key="xmlui.administrative.Navigation.context_export_item">Экспортировать документ</message>
-<message key="xmlui.administrative.Navigation.context_export_collection">Экспортировать коллекцию</message>
-<message key="xmlui.administrative.Navigation.context_export_community">Экспортировать сообщество</message>
-<message key="xmlui.administrative.Navigation.context_export_metadata">Экспортировать метаданные</message>
+	<message key="xmlui.administrative.Navigation.context_head">Контекст</message>
+	<message key="xmlui.administrative.Navigation.context_edit_item">Изменить этот документ</message>
+	<message key="xmlui.administrative.Navigation.context_edit_collection">Редактировать коллекцию</message>
+	<message key="xmlui.administrative.Navigation.context_item_mapper">Каталог документов</message>
+	<message key="xmlui.administrative.Navigation.context_edit_community">Редактировать сообщество</message>
+	<message key="xmlui.administrative.Navigation.context_create_collection">Создать коллекцию</message>
+	<message key="xmlui.administrative.Navigation.context_create_subcommunity">Создать под-сообщество</message>
+	<message key="xmlui.administrative.Navigation.context_create_community">Создать сообщество</message>
+	<message key="xmlui.administrative.Navigation.context_export_item">Экспортировать документ</message>
+        <message key="xmlui.administrative.Navigation.context_export_collection">Экспортировать коллекцию</message>
+        <message key="xmlui.administrative.Navigation.context_export_community">Экспортировать сообщество</message>
+        <message key="xmlui.administrative.Navigation.context_export_metadata">Экспортировать метаданные</message>
 
 	<!-- Site administrator options -->
-<message key="xmlui.administrative.Navigation.administrative_head">Администрирование</message>
-<message key="xmlui.administrative.Navigation.administrative_access_control">Контроль доступа</message>
-<message key="xmlui.administrative.Navigation.administrative_people">Люди</message>
-<message key="xmlui.administrative.Navigation.administrative_groups">Группы</message>
-<message key="xmlui.administrative.Navigation.administrative_authorizations">Авторизация</message>
-<message key="xmlui.administrative.Navigation.administrative_registries">Журналы</message>
-<message key="xmlui.administrative.Navigation.administrative_metadata">Метаданные</message>
-<message key="xmlui.administrative.Navigation.administrative_format">Формат</message>
-<message key="xmlui.administrative.Navigation.administrative_items">Элементы</message>
-<message key="xmlui.administrative.Navigation.administrative_withdrawn">Удаленные элементы</message>
-<message key="xmlui.administrative.Navigation.administrative_private">Элементы персонального доступа</message>
-  <message key="xmlui.administrative.Navigation.administrative_control_panel">Панель управления</message>
-<message key="xmlui.administrative.Navigation.statistics">Статистика</message>
-<message key="xmlui.administrative.Navigation.administrative_import_metadata">Импортировать метаданные</message>
-<message key="xmlui.administrative.Navigation.administrative_curation">Административное курирование</message>
+	<message key="xmlui.administrative.Navigation.administrative_head">Администрирование</message>
+	<message key="xmlui.administrative.Navigation.administrative_access_control">Контроль доступа</message>
+	<message key="xmlui.administrative.Navigation.administrative_people">Люди</message>
+	<message key="xmlui.administrative.Navigation.administrative_groups">Группы</message>
+	<message key="xmlui.administrative.Navigation.administrative_authorizations">Авторизация</message>
+	<message key="xmlui.administrative.Navigation.administrative_registries">Журналы</message>
+	<message key="xmlui.administrative.Navigation.administrative_metadata">Метаданные</message>
+	<message key="xmlui.administrative.Navigation.administrative_format">Формат</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
+	<message key="xmlui.administrative.Navigation.administrative_items">Элементы</message>
+    <message key="xmlui.administrative.Navigation.administrative_withdrawn">Удаленные элементы</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Элементы персонального доступа</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Панель управления</message>
+    <message key="xmlui.administrative.Navigation.statistics">Статистика</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
+        <message key="xmlui.administrative.Navigation.administrative_import_metadata">Импортировать метаданные</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Административное курирование</message>
 
     <!-- my account items -->
-<message key="xmlui.administrative.Navigation.account_export">Мой экспорт</message>
+	<message key="xmlui.administrative.Navigation.account_export">Мой экспорт</message>
 
 
 	<!-- export item -->
-<message key="xmlui.administrative.ItemExport.head">Экспортировать архив</message>
-<message key="xmlui.administrative.ItemExport.item.id.error">Неверный код документа</message>
-<message key="xmlui.administrative.ItemExport.collection.id.error">Неверный код коллекции.</message>
-<message key="xmlui.administrative.ItemExport.community.id.error">Неверный код сообщества.</message>
-<message key="xmlui.administrative.ItemExport.item.not.found">Запрашиваемый документ не найден.</message>
-<message key="xmlui.administrative.ItemExport.collection.not.found">Запрашиваемая коллекция не найдена.</message>
-<message key="xmlui.administrative.ItemExport.community.not.found">Запрашиваемыое сообщество не найдено.</message>
-<message key="xmlui.administrative.ItemExport.item.success">Документ успешно экспортирован. Элемент успешно экспортирован. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
-<message key="xmlui.administrative.ItemExport.collection.success">Коллекция успешно экспортирована. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
-<message key="xmlui.administrative.ItemExport.community.success">Сообщество успешно экспортировано. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
-<message key="xmlui.administrative.ItemExport.available.head">Архивы, доступные для скачивания:</message>
+	<message key="xmlui.administrative.ItemExport.head">Экспортировать архив</message>
+	<message key="xmlui.administrative.ItemExport.item.id.error">Неверный код документа</message>
+	<message key="xmlui.administrative.ItemExport.collection.id.error">Неверный код коллекции.</message>
+	<message key="xmlui.administrative.ItemExport.community.id.error">Неверный код сообщества.</message>
+	<message key="xmlui.administrative.ItemExport.item.not.found">Запрашиваемый документ не найден.</message>
+	<message key="xmlui.administrative.ItemExport.collection.not.found">Запрашиваемая коллекция не найдена.</message>
+	<message key="xmlui.administrative.ItemExport.community.not.found">Запрашиваемыое сообщество не найдено.</message>
+	<message key="xmlui.administrative.ItemExport.item.success">Документ успешно экспортирован. Элемент успешно экспортирован. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
+	<message key="xmlui.administrative.ItemExport.collection.success">Коллекция успешно экспортирована. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
+	<message key="xmlui.administrative.ItemExport.community.success">Сообщество успешно экспортировано. На Ваш электронный адрес будет отправлено письмо, когда архив будет доступен для загрузки. Вы также може использовать ссылку Мой экспорт, чтобы посмотреть список доступных архивов.</message>
+	<message key="xmlui.administrative.ItemExport.available.head">Архивы, доступные для скачивания:</message>
 
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Управление пользователями</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Управление пользователями</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Действия</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Создать нового пользователя</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Нажмите здесь, для создания нового пользователя.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Обзор пользователей</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Нажмите здесь, чтобы посмотреть всех пользователей.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Поиск пользователей</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Поиск производится по имени и e-mail адресу</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Пользователи, отвечающие условиям запроса. Выберите пользователя, которого хотите удалить и нажмите кнопку Удалить или нажмите на имя или e-mail пользователя для редактирования.</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Результаты поиска</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Имя</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Е-mail адрес</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Удалить пользователей</message>
-<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Поиск не дал результатов...</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.title">Управление пользователями</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.main_head">Управление пользователями</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_head">Действия</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create">Создать нового пользователя</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_create_link">Нажмите здесь, для создания нового пользователя.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse">Обзор пользователей</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_browse_link">Нажмите здесь, чтобы посмотреть всех пользователей.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.actions_search">Поиск пользователей</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Поиск производится по имени и e-mail адресу</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Пользователи, отвечающие условиям запроса. Выберите пользователя, которого хотите удалить и нажмите кнопку Удалить или нажмите на имя или e-mail пользователя для редактирования.</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Результаты поиска</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Имя</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Е-mail адрес</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Удалить пользователей</message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">Поиск не дал результатов...</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
-<message key="xmlui.administrative.eperson.AddEPersonForm.title">Добавить пользователя</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Добавить пользователя</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Создать нового пользователя</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Этот адрес электронной почты уже используется.</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Данные нового пользователя:</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">E-mail адрес должен быть уникален</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Введите адрес электронной почты</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Необходимо заполнить поле Имя</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Необходимо заполнить поле Фамилия</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Необходим сертификат</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Можете войти в систему</message>
-<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Создать пользователя</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Добавить пользователя</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Добавить пользователя</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head1">Создать нового пользователя</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.email_taken">Этот адрес электронной почты уже используется.</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.head2">Данные нового пользователя:</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email_unique">E-mail адрес должен быть уникален</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_email">Введите адрес электронной почты</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_fname">Необходимо заполнить поле Имя</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.error_lname">Необходимо заполнить поле Фамилия</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Необходим сертификат</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Можете войти в систему</message>
+	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Создать пользователя</message>
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
-<message key="xmlui.administrative.eperson.EditEPersonForm.title">Редактировать пользователя</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Редактировать пользователя</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Редактировать пользователя</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Этот адрес электронной почты уже используется.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Информация {0}:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">E-mail адрес должен быть уникален</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Введите адрес электронной почты</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Необходимо заполнить поле Имя</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Необходимо заполнить поле Фамилия</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Необходим сертификат</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Можете войти в систему</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Восстановление пароля</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Вы также можете удалить этого пользователя из системы или восстановить его пароль. В случае восстановления пароля пользователь получит письмо с инструкцией и ссылкой, пройдя по которой он сможет создать новый пароль.</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Удалить пользователя</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Войти как пользователь</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Редактировать пользователя</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Редактировать пользователя</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head1">Редактировать пользователя</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.email_taken">Этот адрес электронной почты уже используется.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.head2">Информация {0}:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email_unique">E-mail адрес должен быть уникален</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_email">Введите адрес электронной почты</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_fname">Необходимо заполнить поле Имя</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.error_lname">Необходимо заполнить поле Фамилия</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.req_certs">Необходим сертификат</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.can_log_in">Можете войти в систему</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_reset_password">Восстановление пароля</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Вы также можете удалить этого пользователя из системы или восстановить его пароль. В случае восстановления пароля пользователь получит письмо с инструкцией и ссылкой, пройдя по которой он сможет создать новый пароль.</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Удалить пользователя</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Войти как пользователь</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Пользователь не может быть удалён ввиду следующих ограничений:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">и</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">пользователь загрузил один или более документ</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">у пользователь ещё не завершил отправку документа</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">el usuario tiene una tarea de flujo de trabajo por atender</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">ограничение не распознано системой</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Пользователь не может быть удалён ввиду следующих ограничений:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">и</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">пользователь загрузил один или более документ</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">у пользователь ещё не завершил отправку документа</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">el usuario tiene una tarea de flujo de trabajo por atender</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">ограничение не распознано системой</message>
 
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Этот пользователь состоит в следующих группах:</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(посредством группы: {0})</message>
-<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">нет</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Этот пользователь состоит в следующих группах:</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(посредством группы: {0})</message>
+	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">нет</message>
 
 
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Подтвердить удаление пользователя</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Подтверить удаление</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Подтверить удаление</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Пользователи будут удалены:</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Подтверить удаление</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Имя</message>
-<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Электронная почта</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Подтвердить удаление пользователя</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Подтверить удаление</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_head">Подтверить удаление</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.confirm_para">Пользователи будут удалены:</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.submit_confirm">Подтверить удаление</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_name">Имя</message>
+	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.head_email">Электронная почта</message>
 
 	<!-- general items for all of the group classes -->
-<message key="xmlui.administrative.group.general.group_trail">Управление группами</message>
+	<message key="xmlui.administrative.group.general.group_trail">Управление группами</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.ManageGroupsMain -->
-<message key="xmlui.administrative.group.ManageGroupsMain.title">Управление группами</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Управление группами</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Действия</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Создать новую группу</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Нажмите здесь для создания новой группы.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Обзор групп</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Нажмите здесь для просмотра всех групп.</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Поиск групп</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Поиск осуществляется по названию группы</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Результаты поиска</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Название</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Участники</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Сообщество / Коллекция</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Просмотр</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Удаление групп</message>
-<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Поиск не дал результатов...</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.title">Управление группами</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.main_head">Управление группами</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_head">Действия</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create">Создать новую группу</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_create_link">Нажмите здесь для создания новой группы.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse">Обзор групп</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_browse_link">Нажмите здесь для просмотра всех групп.</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Поиск групп</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Поиск осуществляется по названию группы</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Результаты поиска</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Название</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Участники</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column5">Сообщество / Коллекция</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.collection_link">Просмотр</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.submit_delete">Удаление групп</message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.no_results">Поиск не дал результатов...</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.EditGroupForm -->
-<message key="xmlui.administrative.group.EditGroupForm.title">Редактор групп</message>
-<message key="xmlui.administrative.group.EditGroupForm.trail">Редактировать группу</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head">Редактор групп: {0} (id: {1})</message>
-<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Редактор групп: новая группа</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Очистить поиск</message>
-<message key="xmlui.administrative.group.EditGroupForm.member">Участники</message>
-<message key="xmlui.administrative.group.EditGroupForm.cycle">Цикл</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending">В ожидании</message>
-<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Внимание: внесенные изменения не будут сохранены, пока Вы не нажмёте Сохранить.</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_add">Добавить</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Удалить </message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_para">Связать группу с коллекцией:</message>
-<message key="xmlui.administrative.group.EditGroupForm.community_para">Связать группу с сообществом: </message>
-<message key="xmlui.administrative.group.EditGroupForm.label_name">Изменить название группы:</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Данная группа связанна с определённой коллекцией и её название не может быть изменено.</message>
-<message key="xmlui.administrative.group.EditGroupForm.label_search">ПОиск и добавление пользователей:</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Пользователи...</message>
-<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Группы...</message>
-<message key="xmlui.administrative.group.EditGroupForm.no_results">Поиск не дал результатов...</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Имя</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Электронный адрес</message>
-<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Название</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Коллекция</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Участники</message>
-<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
-<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">просмотр</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_head">Участники</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column2">Имя</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column3">Электронный адрес</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-<message key="xmlui.administrative.group.EditGroupForm.members_group_name">группа: {0}</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_none">В данной группе никто не состоит.</message>
-<message key="xmlui.administrative.group.EditGroupForm.members_pending">[в ожидании]</message>
-<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Удалить участников</message>
-<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Удалить участников</message>
+	<message key="xmlui.administrative.group.EditGroupForm.title">Редактор групп</message>
+	<message key="xmlui.administrative.group.EditGroupForm.trail">Редактировать группу</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head">Редактор групп: {0} (id: {1})</message>
+	<message key="xmlui.administrative.group.EditGroupForm.main_head_new">Редактор групп: новая группа</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_clear">Очистить поиск</message>
+	<message key="xmlui.administrative.group.EditGroupForm.member">Участники</message>
+	<message key="xmlui.administrative.group.EditGroupForm.cycle">Цикл</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending">В ожидании</message>
+	<message key="xmlui.administrative.group.EditGroupForm.pending_warn">Внимание: внесенные изменения не будут сохранены, пока Вы не нажмёте Сохранить.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_add">Добавить</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_remove">Удалить </message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_para">Связать группу с коллекцией:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.community_para">Связать группу с сообществом: </message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_name">Изменить название группы:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_instructions">Данная группа связанна с определённой коллекцией и её название не может быть изменено.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.label_search">ПОиск и добавление пользователей:</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_people">Пользователи...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.submit_search_groups">Группы...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.no_results">Поиск не дал результатов...</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Имя</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Электронный адрес</message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Название</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Участники</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Коллекция</message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
+	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">просмотр</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_head">Участники</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Имя</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Электронный адрес</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">группа: {0}</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_none">В данной группе никто не состоит.</message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[в ожидании]</message>
+	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Удалить участников</message>
+	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Удалить участников</message>
 
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Подтвердить удаление группы</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Подтвердить удаление </message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Подтвердить удаление</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Будут удалены следующие группы:</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Название</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Пользователи</message>
-<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Группы</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Подтвердить удаление группы</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Подтвердить удаление </message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.head">Подтвердить удаление</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.para">Будут удалены следующие группы:</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Название</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">Пользователи</message>
+	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Группы</message>
 
 	<!-- general items for all of the registries classes -->
-<message key="xmlui.administrative.registries.general.format_registry_trail">Регистр форматов</message>
-<message key="xmlui.administrative.registries.general.metadata_registry_trail">Регистр метаданных</message>
+	<message key="xmlui.administrative.registries.general.format_registry_trail">Регистр форматов</message>
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Регистр метаданных</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Удалить форматы архива</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Удалить форматы архива</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Подтвердить удаление</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Вы уверены, что хотите удалить данный формат? Все файлы этих форматов будут считаться файлами неизвестного формата.</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Тип MIME</message>
-<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Название</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Удалить форматы архива</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">Удалить форматы архива</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.head">Подтвердить удаление</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.para1">Вы уверены, что хотите удалить данный формат? Все файлы этих форматов будут считаться файлами неизвестного формата.</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column2">Тип MIME</message>
+	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.column3">Название</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataFieldsConfirm.java -->
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Удалить поля</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Удалить поля</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Подтвердить удаление</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Вы <b>действительно</b> уверены, что хотите удалить эти поля? Если существуют элементы, содержащие метаданные для этих полей, то поля не будут удалены.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ПРЕДУПРЕЖДЕНИЕ:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Если какой-либо документ содержит метаданные этих полей, их удаление прведёт к появлению ошибки.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Имя</message>
-<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Ограничительная помета</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Удалить поля</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Удалить поля</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Подтвердить удаление</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Вы <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ПРЕДУПРЕЖДЕНИЕ:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Если какой-либо документ содержит метаданные этих полей, их удаление прведёт к появлению ошибки.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column2">Имя</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column3">Ограничительная помета</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteMetadataSchemaConfirm.java-->
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Удаление схемы</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Удаление схемы</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Подтвердить удаление</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Вы <b>действительно</b> уверены, что хотите удалить эту схему? Если существуют элементы, содержащие метаданные для полей из этой схемы, то схема не будет удалена и система предупредит Вас об шибке. Убедитесь, что данная схема не используется ни в одном из полей.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ВНИМАНИЕ:</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Если какой-то из документов содержит метаданные в любом из полей схемы, возникнет ошибка.</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Пространство имен</message>
-<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Имя</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Удаление схемы</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Удаление схемы</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Подтвердить удаление</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Вы <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ВНИМАНИЕ:</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Если какой-то из документов содержит метаданные в любом из полей схемы, возникнет ошибка.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column2">Пространство имен</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column3">Имя</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditBitstreamFormat.java -->
-<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Формат архива</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Формат архива</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Новый формат архива</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Формат архива: {0}</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Предоставьте описательные метаданные для формата архива указанного ниже. Имена форматов должны быть уникальными, типы MIME не должны. У Вас может быть несколько разных форматов для разных версий Microsoft Word, а MIME тип может быть одним и тем же.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Имя</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Уникальное имя для формата (например Microsoft Word XP или Microsoft Word 2000)</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Поле имя обязательное.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Тип MIME</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">MIME-тип, связанный с этим форматом, не должен быть уникальным.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Описание</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Уровень поддержки</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Уровень поддержки, которая ваша организация предусматривает для данного формата.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Неизвестный</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Известный</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Поддерживаемый</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Внутренний</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Внутренние форматы недоступны и используются для административных целей.</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Расширения файлов</message>
-<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Расширения это расширения файлов, которые используются для автоматического определения типов загружаемых файлов. Вы можете указать несколько расширений для каждого формата.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.title">Формат архива</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.trail">Формат архива</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head1">Новый формат архива</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.head2">Формат архива: {0}</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.para1">Предоставьте описательные метаданные для формата архива указанного ниже. Имена форматов должны быть уникальными, типы MIME не должны. У Вас может быть несколько разных форматов для разных версий Microsoft Word, а MIME тип может быть одним и тем же.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name">Имя</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_help">Уникальное имя для формата (например Microsoft Word XP или Microsoft Word 2000)</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.name_error">Поле имя обязательное.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype">Тип MIME</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.mimetype_help">MIME-тип, связанный с этим форматом, не должен быть уникальным.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.description">Описание</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support">Уровень поддержки</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_help">Уровень поддержки, которая ваша организация предусматривает для данного формата.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_0">Неизвестный</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_1">Известный</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.support_2">Поддерживаемый</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal">Внутренний</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.internal_help">Внутренние форматы недоступны и используются для административных целей.</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions">Расширения файлов</message>
+	<message key="xmlui.administrative.registries.EditBitstreamFormat.extensions_help">Расширения это расширения файлов, которые используются для автоматического определения типов загружаемых файлов. Вы можете указать несколько расширений для каждого формата.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.EditMetadataSchema.java -->
-<message key="xmlui.administrative.registries.EditMetadataSchema.title">Схема метаданных</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Схема метаданных</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Схема метаданных: "{0}"</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Это схема "{0}". Вы можете добавить или изменить поля метаданных, которые уже существуют в этой схеме. Поля также могут быть помечены для удаления или перемещены в другую схему.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Поля метаданных схемы</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Поле</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Заметка об области применимости</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Без полей метаданных</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Удалить поля</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Переместить поля в другую схему</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Добавить новое поле метаданных</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.name">Название поля</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note">Заметка об области применимости</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Дополнительные данные об этом поле метаданных.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Добавить новое поле метаданных</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Изменить поле: {0}</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Изменить поле</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error">Ошибка</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Название поля уже используется. Все элементы и спецификаторы должны быть уникальны.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">Этот элемент поля обязателен.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Этот элемент поля содержит неправильный символ, элемент не может содержать точки, подчеркивания и пробелы.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">Этот элемент поля слишком длинный, должен быть менее 32 символов.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Спецификатор поля слишком длинный, он должен содержать не больше 32 символов.</message>
-<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Спецификатор содержит неправильный символ, спецификатор не может содержать точки, подчеркивания и пробелы.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.title">Схема метаданных</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.trail">Схема метаданных</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Схема метаданных: "{0}"</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Это схема "{0}". Вы можете добавить или изменить поля метаданных, которые уже существуют в этой схеме. Поля также могут быть помечены для удаления или перемещены в другую схему.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Поля метаданных схемы</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Поле</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Заметка об области применимости</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.empty">Без полей метаданных</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_delete">Удалить поля</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_move">Переместить поля в другую схему</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head3">Добавить новое поле метаданных</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.name">Название поля</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note">Заметка об области применимости</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.note_help">Дополнительные данные об этом поле метаданных.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_add">Добавить новое поле метаданных</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.head4">Изменить поле: {0}</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.submit_update">Изменить поле</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error">Ошибка</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_duplicate_field">Название поля уже используется. Все элементы и спецификаторы должны быть уникальны.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_empty">Этот элемент поля обязателен.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_badchar">Этот элемент поля содержит неправильный символ, элемент не может содержать точки, подчеркивания и пробелы.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_element_tolong">Этот элемент поля слишком длинный, должен быть менее 32 символов.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_tolong">Спецификатор поля слишком длинный, он должен содержать не больше 32 символов.</message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.error_qualifier_badchar">Спецификатор содержит неправильный символ, спецификатор не может содержать точки, подчеркивания и пробелы.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.registries.FormatRegistryMain.java -->
 	<message key="xmlui.administrative.registries.FormatRegistryMain.title">Format Registry</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Bitstream format registry</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">This list of bitstream formats provides information about known formats and their support level. You can edit or add new bitstream formats with this tool. Formats marked as 'internal' are hidden from the user, and are used for administrative purposes.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Add a new bitstream format</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Name</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Type</message>
@@ -1254,7 +1305,7 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadata Registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadata registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas.  However, DSpace requires the qualified Dublin Core schema. You may extend the Dublin Core schema with additional fields or add new schemas to the registry.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namespace</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Name</message>
@@ -1283,8 +1334,8 @@ Translated by Ekaterina Chubich
 
 
 	<!-- general authorization keywords -->
-<message key="xmlui.administrative.authorization.general.authorize_trail">Авторизация</message>
-<message key="xmlui.administrative.authorization.general.policyList_trail">Список привилегий</message>
+	<message key="xmlui.administrative.authorization.general.authorize_trail">Авторизация</message>
+	<message key="xmlui.administrative.authorization.general.policyList_trail">Список привилегий</message>
 
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Administer Authorization Policies</message>
@@ -1342,7 +1393,7 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edit policy {0} for {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No group selected</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No action selected</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Name</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Actions for this resource</message>
@@ -1363,8 +1414,8 @@ Translated by Ekaterina Chubich
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
-    
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Advanced Policy Manager</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Advanced Authorizations</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Advanced Policy Manager</message>
@@ -1389,31 +1440,66 @@ Translated by Ekaterina Chubich
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Выберите как минимум одну группу</message>
     <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Выберите как минимум одну коллекцию</message>
-    
-    	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Подтвердите удаление привилегий</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Подтвердить удаление</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Подтвердить удаление</message>
+
+	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Подтвердите удаление привилегий</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Подтвердить удаление</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_head">Подтвердить удаление</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.confirm_para">The following Policies will be removed: </message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Действие</message>
-<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Группа</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Действие</message>
+	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Группа</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
 
 	<!-- general edit item messages -->
-<message key="xmlui.administrative.item.general.item_trail">Документы</message>
+	<message key="xmlui.administrative.item.general.item_trail">Документы</message>
 	<message key="xmlui.administrative.item.general.template_head">Edit Template Item for Collection: {0}</message>
-<message key="xmlui.administrative.item.general.option_head">Редактирование документа</message>
-<message key="xmlui.administrative.item.general.option_status">Состояние документа</message>
-<message key="xmlui.administrative.item.general.option_bitstreams">Архивы документа</message>
-<message key="xmlui.administrative.item.general.option_metadata">Метаданные документа</message>
-<message key="xmlui.administrative.item.general.option_view">Просмотр документа</message>
-<message key="xmlui.administrative.item.general.option_curate">Курировать</message>
-<message key="xmlui.administrative.item.general.option_queue">Поставить в очередь</message>
+	<message key="xmlui.administrative.item.general.option_head">Редактирование документа</message>
+	<message key="xmlui.administrative.item.general.option_status">Состояние документа</message>
+	<message key="xmlui.administrative.item.general.option_bitstreams">Архивы документа</message>
+	<message key="xmlui.administrative.item.general.option_metadata">Метаданные документа</message>
+	<message key="xmlui.administrative.item.general.option_view">Просмотр документа</message>
+        <message key="xmlui.administrative.item.general.option_curate">Курировать</message>
+        <message key="xmlui.administrative.item.general.option_queue">Поставить в очередь</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
-<message key="xmlui.administrative.item.AddBitstreamForm.title">Загрузить архив</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.trail">Загрузить архив</message>
-<message key="xmlui.administrative.item.AddBitstreamForm.head1">Загрузить новый архив</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.title">Загрузить архив</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Загрузить архив</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.head1">Загрузить новый архив</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle_label">Bundle</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.ORIGINAL">Content Files (default)</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Metadata Files</message>
@@ -1432,45 +1518,45 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Confirm deletion</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.head1">Confirm Deletion(s)</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.para1">Are you sure you want to delete these bitstreams:</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Имя</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Описание</message>
-<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Формат</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Имя</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Описание</message>
+	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Формат</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
-<message key="xmlui.administrative.item.ConfirmItemForm.title">Подтвердить</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.trail">Подтвердить</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.title">Подтвердить</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Подтвердить</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.head1">Modify item: {0}</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.para_delete">Are you sure this item should be completely deleted? Caution: At present, no tombstone would be left.</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.para_withdraw">Are you sure this item should be withdrawn from the archive?</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.para_reinstate">Are you sure this item should be reinstated to the archive?</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column1">Field</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.column2">Value</message>
-<message key="xmlui.administrative.item.ConfirmItemForm.column3">Язык</message>
+	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Язык</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Withdraw</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Reinstate</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
     <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
-<message key="xmlui.administrative.item.MoveItemForm.title">Переместить</message>
-<message key="xmlui.administrative.item.MoveItemForm.trail">Переместить</message>
-<message key="xmlui.administrative.item.MoveItemForm.head1">Переместить документ: {0}</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection">Коллекция</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_help">Выберите коллекцию, в которую желаете переместить файл.</message>
-<message key="xmlui.administrative.item.MoveItemForm.collection_default">Выберите коллекцию...</message>
-<message key="xmlui.administrative.item.MoveItemForm.submit_move">Переместить</message>
+	<message key="xmlui.administrative.item.MoveItemForm.title">Переместить</message>
+	<message key="xmlui.administrative.item.MoveItemForm.trail">Переместить</message>
+	<message key="xmlui.administrative.item.MoveItemForm.head1">Переместить документ: {0}</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection">Коллекция</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_help">Выберите коллекцию, в которую желаете переместить файл.</message>
+	<message key="xmlui.administrative.item.MoveItemForm.collection_default">Выберите коллекцию...</message>
+	<message key="xmlui.administrative.item.MoveItemForm.submit_move">Переместить</message>
     <message key="xmlui.administrative.item.MoveItemForm.inherit_policies">Inherit policies</message>
     <message key="xmlui.administrative.item.MoveItemForm.inherit_policies_help">Inherit the default policies of the destination collection</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditBitstreamForm -->
-<message key="xmlui.administrative.item.EditBitstreamForm.title">Редактировать архив</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.trail">Редактировать архив</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.head1">Редактировать архив</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.title">Редактировать архив</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.trail">Редактировать архив</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.head1">Редактировать архив</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.file_label">File</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Основной архив</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Да</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Нет</message>
-<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Описание</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_label">Основной архив</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">Да</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">Нет</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Описание</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Select the format of the file from the list below, for example "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Selected Format</message>
@@ -1485,33 +1571,33 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Имя</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Описание</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Формат</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Просмотр</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Имя</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Описание</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Формат</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Просмотр</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (primary) </message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Просмотр</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Просмотр</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Upload a new bitstream</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Delete bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">You need the ADD &amp; WRITE privilege on the item and bundles to be able to upload new bitstreams.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Only System Administrators can delete bitstreams / files.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Загрузить</message>
-<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Скачать</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Загрузить</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Скачать</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
-<message key="xmlui.administrative.item.EditItemMetadataForm.title">Метаданные документа</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Метаданные документа</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Добавить новые метаданные</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Название</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Ценность</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Язык</message>
-<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Добавить новые метаданные</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Метаданные документа</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Метаданные документа</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.head1">Добавить новые метаданные</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.name_label">Название</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Ценность</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Язык</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Добавить новые метаданные</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.para1">PLEASE NOTE: These changes are not validated in any way. You are responsible for entering the data in the correct format. If you are not sure what the format is, please do NOT make changes.</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Metadata</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Remove</message>
@@ -1546,7 +1632,9 @@ Translated by Ekaterina Chubich
     <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
     <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
-    
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">View Item</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">View Item</message>
@@ -1554,7 +1642,7 @@ Translated by Ekaterina Chubich
         <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
         <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
         <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
-<message key="xmlui.administrative.item.CurateItemForm.label_name">Задача</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Задача</message>
 
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Find Item</message>
@@ -1595,8 +1683,8 @@ Translated by Ekaterina Chubich
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
 
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Добавить: </message>
-<message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Удалить:</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Добавить: </message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Удалить:</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_newowner">Add to owning collection</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_oldowner">Remove from owning collection</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.collection_mapped">Map to collection</message>
@@ -1628,28 +1716,28 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Search items</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Search items matching: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Map selected items</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Collection</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column3">Автор</message>
-<message key="xmlui.administrative.mapper.SearchItemForm.column4">Название</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Автор</message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Название</message>
 
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Browse Mapped Items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Browse mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Browsing mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Unmap selected items</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Author</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Title</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">You need the REMOVE privilege on this collection to be able to unmap items from this collection.</message>
 
 	<!-- General tags for collection management -->
-<message key="xmlui.administrative.collection.general.collection_trail">Коллекции</message>
-<message key="xmlui.administrative.collection.general.options_metadata">Редактировать метаданные</message>
-<message key="xmlui.administrative.collection.general.options_roles">Распределение ролей</message>
-<message key="xmlui.administrative.collection.general.options_curate">Curar</message>
-<message key="xmlui.administrative.collection.general.options_queue">Очередь</message>
+	<message key="xmlui.administrative.collection.general.collection_trail">Коллекции</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Редактировать метаданные</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Распределение ролей</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curar</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Очередь</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Edit Collection Roles</message>
@@ -1682,285 +1770,286 @@ Translated by Ekaterina Chubich
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Курирование коллекции: {0}</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.title">Курирование коллекции</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.trail">Куратор</message>
-<message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Задача</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Курирование коллекции: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Курирование коллекции</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Куратор</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Задача</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Подтвердить удаление</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Подтвердить</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">ПОдтвердить удаление коллекции {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">¿Вы уверены, что хотите удалить коллекцию {0}? При этом будет удалено:</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Все файлы, содержащиеся в этой коллекции, не привязанные к другим коллекциям</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Содержимое данных документов</message>
-<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Привязанные привилегии</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Подтвердить удаление</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.trail">Подтвердить</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_head">ПОдтвердить удаление коллекции {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.main_para">¿Вы уверены, что хотите удалить коллекцию {0}? При этом будет удалено:</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Все файлы, содержащиеся в этой коллекции, не привязанные к другим коллекциям</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Содержимое данных документов</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Привязанные привилегии</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Подтвердить удаление роли</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Подтвердить</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Подтвердить удаление роли {0}</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Вы действительно хотите удалить эту роль? Удаление этой группы предоставит всем пользователям право на ЧТЕНИЕ всех элементов, содержащихся в данной коллекции. Это изменение необратимо. Существующие в системе файлы будут по-прежнему недоступны участникам, определяемым ролью, которую Вы хотите удалить.</message>
-<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Вы действительно хотите удалить эту роль? Все изменения, примененные к группе {0} будут потеряны и Вам придётся применить их снова.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Подтвердить удаление роли</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Подтвердить</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Подтвердить удаление роли {0}</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Вы действительно хотите удалить эту роль? Удаление этой группы предоставит всем пользователям право на ЧТЕНИЕ всех элементов, содержащихся в данной коллекции. Это изменение необратимо. Существующие в системе файлы будут по-прежнему недоступны участникам, определяемым ролью, которую Вы хотите удалить.</message>
+	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Вы действительно хотите удалить эту роль? Все изменения, примененные к группе {0} будут потеряны и Вам придётся применить их снова.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Редактировать метаданные коллекции</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Метаданные</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Редактировать коллекцию: {0}</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Имя</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Краткое описание:</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Вводный текст (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Авторские права (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Новости (HTML)</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Лицензия</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Источник</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Загрузить новый логотип</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Текущий логотип</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Шаблон документа</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Создать...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Редактировать...</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Удалить логотип</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Удалить коллекцию</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Сохранить изменения</message>
-<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(Только администраторы системы)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Редактировать метаданные коллекции</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Метаданные</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.main_head">Редактировать коллекцию: {0}</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_name">Имя</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_short_description">Краткое описание:</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_introductory_text">Вводный текст (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_copyright_text">Авторские права (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_side_bar_text">Новости (HTML)</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_license">Лицензия</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_provenance_description">Источник</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_logo">Загрузить новый логотип</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_existing_logo">Текущий логотип</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.label_item_template">Шаблон документа</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_create_template">Создать...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_edit_template">Редактировать...</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Удалить логотип</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Удалить коллекцию</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Сохранить изменения</message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
-<message key="xmlui.administrative.collection.CreateCollectionForm.title">Создать коллекцию</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Создать коллекцию</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Введите метаданные новой коллекции {0}</message>
-<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Создать</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Создать коллекцию</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Создать коллекцию</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Введите метаданные новой коллекции {0}</message>
+	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Создать</message>
 
 	<!-- General to the harvesting options under collection -->
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Параметры подбора коллекции</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Сборка</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Источник контента</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Источник контента</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Это стандартные параметры коллекции DSpace</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Эта коллекция получает свой контент из внешних источников</message>
-<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Сохранить</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Параметры подбора коллекции</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Сборка</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.options_harvest">Источник контента</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.label_source">Источник контента</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Это стандартные параметры коллекции DSpace</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Эта коллекция получает свой контент из внешних источников</message>
+	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Сохранить</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Расположение собранной коллекции</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Опции сборки</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Поставщик OAI</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Формат метаданных</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">URL сервиса OAI</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Вы должны предоставить набор идентификации целевой коллекции.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Постоянный идентификатор, используемый поставщиком OAI для обозначения целевой коллекции</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Вы должны предоставить набор идентификатор целевой коллекции.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Собирается контент</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Собирать только метаданные.</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Собирать метаданные и ссылки на файлы (необходима поддержка ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Собирать метаданные и файлы (необходима поддержка ORE).</message>
-<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Применить параметры</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Расположение собранной коллекции</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Опции сборки</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_oai_provider">Поставщик OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_metadata_format">Формат метаданных</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaiurl">URL сервиса OAI</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaiurl">Вы должны предоставить набор идентификации целевой коллекции.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Постоянный идентификатор, используемый поставщиком OAI для обозначения целевой коллекции</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Вы должны предоставить набор идентификатор целевой коллекции.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Собирается контент</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Собирать только метаданные.</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Собирать метаданные и ссылки на файлы (необходима поддержка ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Собирать метаданные и файлы (необходима поддержка ORE).</message>
+	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">Применить параметры</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Расположение созданной коллекции</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Поставщик OAI</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Формат метаданных</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Собирается контент</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Результаты последней сборки</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Эта коллекция еще не была собрана.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Текущий статус сборки</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Коллекция готова к сборке</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Коллекция собирается</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Коллекция ожидает сборки</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">При последней сборке возникла ошибка OAI</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">При последней сборке возникла ошибка</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Собирать только метаданные.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Собирать метаданные и ссылки на файлы.</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Собирать метаданные и ссылки на файлы(полная сборка).</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Изменить параметры</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Импортировать сейчас</message>
-<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Сбросить и импортировать заново</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Расположение созданной коллекции</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">Поставщик OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_setid">OAI Set id</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_metadata_format">Формат метаданных</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_level">Собирается контент</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_result">Результаты последней сборки</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_result_new">Эта коллекция еще не была собрана.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_harvest_status">Текущий статус сборки</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_ready">Коллекция готова к сборке</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_busy">Коллекция собирается</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_queued">Коллекция ожидает сборки</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_oai_error">При последней сборке возникла ошибка OAI</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.harvest_status_unknown_error">При последней сборке возникла ошибка</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_only">Собирать только метаданные.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_ref">Собирать метаданные и ссылки на файлы.</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.option_md_and_bs">Собирать метаданные и ссылки на файлы(полная сборка).</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_change_settings">Изменить параметры</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_import_now">Импортировать сейчас</message>
+	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.submit_reimport_collection">Сбросить и импортировать заново</message>
 
-<message key="xmlui.administrative.ControlPanel.option_harvest">Сборка</message>
-<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Планирование управления сборкой</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_status">Состояние</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Действия</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Начать сборку</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Сбросить статус сборки</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Продолжить</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Пауза</message>
-<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Пауза</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Коллекция готова к сборке</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_active">Активные сборки</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Сборки в очереди</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Ошибки OAI</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Внутренние ошибки</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Параметры генератора</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
-<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Источник ORE</message>
-<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Параметры сборщика</message>
+	<message key="xmlui.administrative.ControlPanel.option_harvest">Сборка</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_scheduler_head">Планирование управления сборкой</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_status">Состояние</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_actions">Действия</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_start">Начать сборку</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_reset">Сбросить статус сборки</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_resume">Продолжить</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_pause">Пауза</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_submit_stop">Пауза</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_collections">Коллекция готова к сборке</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_active">Активные сборки</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_queued">Сборки в очереди</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_errors">Ошибки OAI</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_internal_errors">Внутренние ошибки</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Параметры генератора</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">Источник ORE</message>
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Параметры сборщика</message>
 
 	<!-- General tags for community management -->
-<message key="xmlui.administrative.community.general.community_trail">Сообщества</message>
-<message key="xmlui.administrative.community.general.options_metadata">Редактировать метаданные</message>
-<message key="xmlui.administrative.community.general.options_roles">Распределение ролей</message>
-<message key="xmlui.administrative.community.general.options_curate">Курировать</message>
-<message key="xmlui.administrative.community.general.options_queue">Поставить в очередь</message>
+	<message key="xmlui.administrative.community.general.community_trail">Сообщества</message>
+	<message key="xmlui.administrative.community.general.options_metadata">Редактировать метаданные</message>
+	<message key="xmlui.administrative.community.general.options_roles">Распределение ролей</message>
+        <message key="xmlui.administrative.community.general.options_curate">Курировать</message>
+        <message key="xmlui.administrative.community.general.options_queue">Поставить в очередь</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
-<message key="xmlui.administrative.community.AssignCommunityRoles.title">Редактировать роли в сообществе</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Роли</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Редактировать сообщество: {0}</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">нет ролей</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.create">Создать...</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Администраторы сообщества могут создавать под-сообщества или коллекции, а также управлять или назначать управляющего данными под-сообществами или коллекциями. Кроме того, они могут определять, кто сможет добавлять новые документы в под-коллекции, редактировать метаданные (после отправки), и привязывать файлы из других коллекций (при условии получения прав доступа к этой коллекции).</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Это сообщество использует пользовательские настройки доступа по умолчанию. </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">По умолчанию читать входящие элементы и файлы архивов в настоящее время могут пользователи группы Аноним.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Редактировать политики доступа.</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Роль</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Привязанная группа</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Администраторы</message>
-<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(Только администраторы системы)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Редактировать роли в сообществе</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.trail">Роли</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.main_head">Редактировать сообщество: {0}</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.no_role">нет ролей</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.create">Создать...</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.help_admins">Администраторы сообщества могут создавать под-сообщества или коллекции, а также управлять или назначать управляющего данными под-сообществами или коллекциями. Кроме того, они могут определять, кто сможет добавлять новые документы в под-коллекции, редактировать метаданные (после отправки), и привязывать файлы из других коллекций (при условии получения прав доступа к этой коллекции).</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_custom">Это сообщество использует пользовательские настройки доступа по умолчанию. </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.default_read_anonymous">По умолчанию читать входящие элементы и файлы архивов в настоящее время могут пользователи группы Аноним.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.edit_authorizations">Редактировать политики доступа.</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_name">Роль</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Привязанная группа</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Администраторы</message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
-<message key="xmlui.administrative.community.CurateCommunityForm.main_head">Курировать сообщество: {0}</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.title">Курировать сообщество</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.trail">Куратор</message>
-<message key="xmlui.administrative.community.CurateCommunityForm.label_name">Задача</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Курировать сообщество: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Курировать сообщество</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Куратор</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Задача</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Подтвердить удаление</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Подтвердить</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Подтвердить удаление сообщества {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Вы уверены, что хотите удалить сообщество {0}? Будет удалено:</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Коллекции в сообществе, которые не содержатся в других сообществах.</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Файлы в сообществе, которые не содержатся в других сообществах</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Содержание этих файлов</message>
-<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Связанные политики</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Подтвердить удаление</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.trail">Подтвердить</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_head">Подтвердить удаление сообщества {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.main_para">Вы уверены, что хотите удалить сообщество {0}? Будет удалено:</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item1">Коллекции в сообществе, которые не содержатся в других сообществах.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item2">Файлы в сообществе, которые не содержатся в других сообществах</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item3">Содержание этих файлов</message>
+	<message key="xmlui.administrative.community.DeleteCommunityConfirm.confirm_item4">Связанные политики</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityRoleConfirm.java -->
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Подтвердите удаление роли</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Подтвердить</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Подтвердите удаление роли {0}</message>
-<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Вы уверены, что хотите удалить эту роль? Все изменения, примененные к группе {0} будут потеряны.</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.title">Подтвердите удаление роли</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.trail">Подтвердить</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_head">Подтвердите удаление роли {0}</message>
+	<message key="xmlui.administrative.community.DeleteCommunityRoleConfirm.main_para">Вы уверены, что хотите удалить эту роль? Все изменения, примененные к группе {0} будут потеряны.</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.EditCommunityMetadataForm.java -->
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Редактировать метаданные сообщества</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Метаданные</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Редактировать метаданные сообщества {0}</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Редактировать политики авторизации</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Название</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Краткое описание</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Вводный текст(HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Копирайт (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Новости (HTML)</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Загрузить новый логотип</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Текущий логотип</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Удалить логотип</message>
-<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Удалить сообщество</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.title">Редактировать метаданные сообщества</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.trail">Метаданные</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.main_head">Редактировать метаданные сообщества {0}</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.edit_authorizations">Редактировать политики авторизации</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_name">Название</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_short_description">Краткое описание</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_introductory_text">Вводный текст(HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_copyright_text">Копирайт (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_side_bar_text">Новости (HTML)</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_logo">Загрузить новый логотип</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Текущий логотип</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Удалить логотип</message>
+	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Удалить сообщество</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
-<message key="xmlui.administrative.community.CreateCommunityForm.title">Создать сообщество</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.trail">Создать сообщество</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Введите метаданные для нового подсообщества {0}</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Редактировать метаданные для сообщества верхнего уровня</message>
-<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Создать</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.title">Создать сообщество</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Создать сообщество</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_sub">Введите метаданные для нового подсообщества {0}</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.main_head_top">Редактировать метаданные для сообщества верхнего уровня</message>
+	<message key="xmlui.administrative.community.CreateCommunityForm.submit_save">Создать</message>
+
 
 	<!-- org.dspace.app.xmlui.administrative.ControlPanel.java -->
-<message key="xmlui.administrative.ControlPanel.title">Панель управления</message>
-<message key="xmlui.administrative.ControlPanel.trail">Панель управления</message>
-<message key="xmlui.administrative.ControlPanel.head">Панель управления</message>
-<message key="xmlui.administrative.ControlPanel.option_java">Информация Java</message>
-<message key="xmlui.administrative.ControlPanel.option_dspace">Конфигурация Dspace</message>
-<message key="xmlui.administrative.ControlPanel.option_alerts">Системные оповещения</message>
-<message key="xmlui.administrative.ControlPanel.hours">{0} ч</message>
-<message key="xmlui.administrative.ControlPanel.minutes">{0} мин</message>
-<message key="xmlui.administrative.ControlPanel.seconds">{0} сек</message>
-<message key="xmlui.administrative.ControlPanel.java_head">Java и операционная система</message>
-<message key="xmlui.administrative.ControlPanel.java_version">Версия Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.java_vendor">Поставщик Java Runtime Environment</message>
-<message key="xmlui.administrative.ControlPanel.os_name">Название операционной системы</message>
-<message key="xmlui.administrative.ControlPanel.os_arch">Архитектура операционной системы</message>
-<message key="xmlui.administrative.ControlPanel.os_version">Версия операционной системы</message>
-<message key="xmlui.administrative.ControlPanel.runtime_head">Статистика</message>
-<message key="xmlui.administrative.ControlPanel.runtime_processors">Доступные процессоры</message>
-<message key="xmlui.administrative.ControlPanel.runtime_max">Максимальное количество памяти</message>
-<message key="xmlui.administrative.ControlPanel.runtime_total">Выделенное количество памяти</message>
-<message key="xmlui.administrative.ControlPanel.runtime_used">Использованное количество памяти</message>
-<message key="xmlui.administrative.ControlPanel.runtime_free">Свободное количество памяти</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_head">Информация Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_version">Версия Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Директория Cache Cocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Рабочая директория Сocoon</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Объём основной Cache памяти({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Немедленно очистить Cachе)</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Объём основной Cache памяти ({0})</message>
-<message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Объём транзитной Cache памяти  ({0})</message>
-<message key="xmlui.administrative.ControlPanel.dspace_head">Конфигурация DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_version">Версия Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_dir">Версия установки DSpace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_url">URL база Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_hostname">Название Host Dspace</message>
-<message key="xmlui.administrative.ControlPanel.dspace_name">Название сайта</message>
-<message key="xmlui.administrative.ControlPanel.db_name">Название базы данных</message>
-<message key="xmlui.administrative.ControlPanel.db_url">URL базы данных</message>
-<message key="xmlui.administrative.ControlPanel.db_driver">Драйвер JDBC</message>
-<message key="xmlui.administrative.ControlPanel.db_maxconnections">Максимальное количество соединений с БД в пуле</message>
-<message key="xmlui.administrative.ControlPanel.db_maxwait">Максимальное время ожидания БД</message>
-<message key="xmlui.administrative.ControlPanel.db_maxidle">Максимальное время Idle Connections</message>
-<message key="xmlui.administrative.ControlPanel.mail_server">Сервер SMTP</message>
-<message key="xmlui.administrative.ControlPanel.mail_from_address">Отправитель</message>
-<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Получатель</message>
-<message key="xmlui.administrative.ControlPanel.mail_admin">E-mail адрес главного администратора</message>
-<message key="xmlui.administrative.ControlPanel.alerts_head">Системные оповещения</message>
-<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Предупреждение для балансировки нагрузок</strong>: системные предупреждения актуальны только для узла, на котором запущен процесс. Необходимо удостовериться, что все узлы сконфигурированы для приёма системных предупреждений.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_label">Оповещения</message>
-<message key="xmlui.administrative.ControlPanel.alerts_message_default">Система будет остановлена для регулярного обслуживания. Пожалуйста, сохраните рабочие данные и выйдите из системы.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Обратный отсчёт</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Не использовать обратный отсчёт</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 минут</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 минут</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 минут</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">Один час</message>
-<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Продолжать обратный отсчёт</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_label">Управление сессией</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Продолжить разрешение авторизованных сессий</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Запретить аутентификацию, но сохранить текущую сессию</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Запретить аутентификацию и закрыть текущие сессии</message>
-<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Внимание:</strong> Администраторы сайта освобождены от управления сессиями.</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Активировать</message>
-<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Деактивировать</message>
-<message key="xmlui.administrative.ControlPanel.activity_head">Текущая активность ({0} страниц максимум)</message>
-<message key="xmlui.administrative.ControlPanel.stop_anonymous">ОСТАНОВИТЬ запись анонимной активности.</message>
-<message key="xmlui.administrative.ControlPanel.start_anonymous">НАЧАТЬ запись анонимной активности.</message>
-<message key="xmlui.administrative.ControlPanel.stop_bot">ОСТАНОВИТЬ запись активности ботов.</message>
-<message key="xmlui.administrative.ControlPanel.start_bot">НАЧАТЬ запись активности ботов.</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_time">Временные метки</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_user">Пользователь</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP адрес</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_url">страница URL</message>
-<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-агент</message>
-<message key="xmlui.administrative.ControlPanel.activity_anonymous">Аноним {0}</message>
-<message key="xmlui.administrative.ControlPanel.activity_none">Видимые страницы не обнаружены</message>
+	<message key="xmlui.administrative.ControlPanel.title">Панель управления</message>
+	<message key="xmlui.administrative.ControlPanel.trail">Панель управления</message>
+	<message key="xmlui.administrative.ControlPanel.head">Панель управления</message>
+	<message key="xmlui.administrative.ControlPanel.option_java">Информация Java</message>
+	<message key="xmlui.administrative.ControlPanel.option_dspace">Конфигурация Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.option_alerts">Системные оповещения</message>
+	<message key="xmlui.administrative.ControlPanel.hours">{0} ч</message>
+	<message key="xmlui.administrative.ControlPanel.minutes">{0} мин</message>
+	<message key="xmlui.administrative.ControlPanel.seconds">{0} сек</message>
+	<message key="xmlui.administrative.ControlPanel.java_head">Java и операционная система</message>
+	<message key="xmlui.administrative.ControlPanel.java_version">Версия Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.java_vendor">Поставщик Java Runtime Environment</message>
+	<message key="xmlui.administrative.ControlPanel.os_name">Название операционной системы</message>
+	<message key="xmlui.administrative.ControlPanel.os_arch">Архитектура операционной системы</message>
+	<message key="xmlui.administrative.ControlPanel.os_version">Версия операционной системы</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_head">Статистика</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_processors">Доступные процессоры</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_max">Максимальное количество памяти</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_total">Выделенное количество памяти</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_used">Использованное количество памяти</message>
+	<message key="xmlui.administrative.ControlPanel.runtime_free">Свободное количество памяти</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Информация Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Версия Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Директория Cache Cocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Рабочая директория Сocoon</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Объём основной Cache памяти({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Немедленно очистить Cachе)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Объём основной Cache памяти ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Объём транзитной Cache памяти  ({0})</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_head">Конфигурация DSpace</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">Версия Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_dir">Версия установки DSpace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_url">URL база Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_hostname">Название Host Dspace</message>
+	<message key="xmlui.administrative.ControlPanel.dspace_name">Название сайта</message>
+	<message key="xmlui.administrative.ControlPanel.db_name">Название базы данных</message>
+	<message key="xmlui.administrative.ControlPanel.db_url">URL базы данных</message>
+	<message key="xmlui.administrative.ControlPanel.db_driver">Драйвер JDBC</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxconnections">Максимальное количество соединений с БД в пуле</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxwait">Максимальное время ожидания БД</message>
+	<message key="xmlui.administrative.ControlPanel.db_maxidle">Максимальное время Idle Connections</message>
+	<message key="xmlui.administrative.ControlPanel.mail_server">Сервер SMTP</message>
+	<message key="xmlui.administrative.ControlPanel.mail_from_address">Отправитель</message>
+	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Получатель</message>
+	<message key="xmlui.administrative.ControlPanel.mail_admin">E-mail адрес главного администратора</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_head">Системные оповещения</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Оповещения</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Система будет остановлена для регулярного обслуживания. Пожалуйста, сохраните рабочие данные и выйдите из системы.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Обратный отсчёт</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_none">Не использовать обратный отсчёт</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_5">5 минут</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_15">15 минут</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 минут</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">Один час</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Продолжать обратный отсчёт</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Управление сессией</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Продолжить разрешение авторизованных сессий</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Запретить аутентификацию, но сохранить текущую сессию</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Запретить аутентификацию и закрыть текущие сессии</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Активировать</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Деактивировать</message>
+	<message key="xmlui.administrative.ControlPanel.activity_head">Текущая активность ({0} страниц максимум)</message>
+	<message key="xmlui.administrative.ControlPanel.stop_anonymous">ОСТАНОВИТЬ запись анонимной активности.</message>
+	<message key="xmlui.administrative.ControlPanel.start_anonymous">НАЧАТЬ запись анонимной активности.</message>
+	<message key="xmlui.administrative.ControlPanel.stop_bot">ОСТАНОВИТЬ запись активности ботов.</message>
+	<message key="xmlui.administrative.ControlPanel.start_bot">НАЧАТЬ запись активности ботов.</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_time">Временные метки</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_user">Пользователь</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP адрес</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_url">страница URL</message>
+	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-агент</message>
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Аноним {0}</message>
+	<message key="xmlui.administrative.ControlPanel.activity_none">Видимые страницы не обнаружены</message>
 
-<message key="xmlui.administrative.ControlPanel.select_panel">Выберите информацию, отображаемую на вкладках</message>
+	<message key="xmlui.administrative.ControlPanel.select_panel">Выберите информацию, отображаемую на вкладках</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Через {0} минут</strong>:</message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
-<message key="xmlui.administrative.NotAuthorized.title">Не авторизован</message>
-<message key="xmlui.administrative.NotAuthorized.trail">Не авторизован</message>
-<message key="xmlui.administrative.NotAuthorized.head">Не предоставлены права</message>
-<message key="xmlui.administrative.NotAuthorized.para1a">Ваш аккаунт не наделен правами для совершения указанного действия. Если Вы считаете, что возникла ошибка или если у Вас есть вопросы по режимам привилегий - свяжитесь </message>
-<message key="xmlui.administrative.NotAuthorized.para1b">с администратором системы</message>
-<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
-<message key="xmlui.administrative.NotAuthorized.para2">Войти ка другой пользователь</message>
+	<message key="xmlui.administrative.NotAuthorized.title">Не авторизован</message>
+	<message key="xmlui.administrative.NotAuthorized.trail">Не авторизован</message>
+	<message key="xmlui.administrative.NotAuthorized.head">Не предоставлены права</message>
+	<message key="xmlui.administrative.NotAuthorized.para1a">Ваш аккаунт не наделен правами для совершения указанного действия. Если Вы считаете, что возникла ошибка или если у Вас есть вопросы по режимам привилегий - свяжитесь </message>
+	<message key="xmlui.administrative.NotAuthorized.para1b">с администратором системы</message>
+	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
+	<message key="xmlui.administrative.NotAuthorized.para2">Войти ка другой пользователь</message>
         
         <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
-<message key="xmlui.administrative.CurateForm.title">Задачи по курированию системы</message>
-<message key="xmlui.administrative.CurateForm.trail">Задачи по курированию</message>
-<message key="xmlui.administrative.CurateForm.object_label_name">Управление объектами Dspace</message>
+        <message key="xmlui.administrative.CurateForm.title">Задачи по курированию системы</message>
+        <message key="xmlui.administrative.CurateForm.trail">Задачи по курированию</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Управление объектами Dspace</message>
         <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
-<message key="xmlui.administrative.CurateForm.task_label_name">Задача</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Задача</message>
     <!-- Used by Curate<DSO>Form classes also -->
-<message key="xmlui.administrative.CurateForm.taskgroup_label_name">Выбор между следующими группами</message>
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Выбор между следующими группами</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1968,28 +2057,29 @@ Translated by Ekaterina Chubich
                      Statistics Aspect
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-<message key="xmlui.statistics.title">Статистика</message>
-<message key="xmlui.statistics.search.title">Статистика поиска</message>
-<message key="xmlui.statistics.search.head">Статистика поиска</message>
-<message key="xmlui.statistics.search.head-dso">Статистика поиска для {0}</message>
-<message key="xmlui.statistics.search.error">Произошла ошибка при рассчёте статистики поиска. Пожалуйста, повторите попытку позже.</message>
-<message key="xmlui.statistics.search.no-results">Для указанного периода не обнаружено статистик поиска.</message>
-<message key="xmlui.statistics.workflow.title">Статистика потока работ</message>
-<message key="xmlui.statistics.visits.total">Общее число посещений</message>
-<message key="xmlui.statistics.visits.month">Посещений за месяц</message>
-<message key="xmlui.statistics.visits.views">Просмотры</message>
-<message key="xmlui.statistics.visits.countries">по странам</message>
-<message key="xmlui.statistics.visits.cities">по городам</message>
-<message key="xmlui.statistics.visits.bitstreams">Обращения к файлам</message>
-<message key="xmlui.statistics.Navigation.title">Статистика</message>
-<message key="xmlui.statistics.Navigation.usage.view">Просмотр статистики использования</message>
-<message key="xmlui.statistics.Navigation.search.view">Просмотр статистики поиска</message>
-<message key="xmlui.statistics.Navigation.workflow.view">Просмотр статистики потока работ</message>
-<message key="xmlui.statistics.trail">Статистика</message>
-<message key="xmlui.statistics.trail-search">Статистика поиска</message>
-<message key="xmlui.statistics.trail-workflow">Статистика потока работ</message>
-<message key="xmlui.statistics.workflow.no-results">Для указанного периода не обнаружено статистик работ..</message>
-<message key="xmlui.statistics.workflow.error">Произошла ошибка при рассчёте статистики потока работ. Пожалуйста, повторите попытку позже.</message>
+    <message key="xmlui.statistics.title">Статистика</message>
+    <message key="xmlui.statistics.search.title">Статистика поиска</message>
+    <message key="xmlui.statistics.search.head">Статистика поиска</message>
+    <message key="xmlui.statistics.search.head-dso">Статистика поиска для {0}</message>
+    <message key="xmlui.statistics.search.error">Произошла ошибка при рассчёте статистики поиска. Пожалуйста, повторите попытку позже.</message>
+    <message key="xmlui.statistics.search.no-results">Для указанного периода не обнаружено статистик поиска.</message>
+    <message key="xmlui.statistics.workflow.title">Статистика потока работ</message>
+    <message key="xmlui.statistics.visits.total">Общее число посещений</message>
+    <message key="xmlui.statistics.visits.month">Посещений за месяц</message>
+    <message key="xmlui.statistics.visits.views">Просмотры</message>
+    <message key="xmlui.statistics.visits.countries">по странам</message>
+    <message key="xmlui.statistics.visits.cities">по городам</message>
+    <message key="xmlui.statistics.visits.bitstreams">Обращения к файлам</message>
+    <message key="xmlui.statistics.Navigation.title">Статистика</message>
+    <message key="xmlui.statistics.Navigation.usage.view">Просмотр статистики использования</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">Просмотр статистики поиска</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">Просмотр статистики потока работ</message>
+    <message key="xmlui.statistics.trail">Статистика</message>
+    <message key="xmlui.statistics.trail-search">Статистика поиска</message>
+    <message key="xmlui.statistics.trail-workflow">Статистика потока работ</message>
+    <message key="xmlui.statistics.workflow.no-results">Для указанного периода не обнаружено статистик работ..</message>
+    <message key="xmlui.statistics.workflow.error">Произошла ошибка при рассчёте статистики потока работ. Пожалуйста, повторите попытку позже.</message>
     <message key="xmlui.statistics.workflow.head">Статистика потока работ</message>
     <message key="xmlui.statistics.workflow.head-dso">Статистика потока работ для{0}</message>
 
@@ -2002,7 +2092,7 @@ Translated by Ekaterina Chubich
     <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Всего</message>
 
 
-    <message key="xmlui.statistics.display.table.column-label.search-terms">Критерий поиска</message>                    
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Критерий поиска</message>
     <message key="xmlui.statistics.display.table.column-label.searches">Поиск</message>
     <message key="xmlui.statistics.display.table.column-label.percent-total">всего % </message>
     <message key="xmlui.statistics.display.table.column-label.views-search">Просмотры / Поиск</message>
@@ -2030,10 +2120,23 @@ Translated by Ekaterina Chubich
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
 
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2049,7 +2152,7 @@ Translated by Ekaterina Chubich
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
 			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
@@ -2059,34 +2162,34 @@ Translated by Ekaterina Chubich
 			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
-<message key="xmlui.dri2xhtml.structural.contact-link">Контакты</message>
-<message key="xmlui.dri2xhtml.structural.feedback-link">Отправить отзыв</message>
+	<message key="xmlui.dri2xhtml.structural.contact-link">Контакты</message>
+	<message key="xmlui.dri2xhtml.structural.feedback-link">Отправить отзыв</message>
 
-<message key="xmlui.dri2xhtml.structural.head-subtitle">Репозиторий Dspace</message>
+	<message key="xmlui.dri2xhtml.structural.head-subtitle">Репозиторий Dspace</message>
 
-<message key="xmlui.dri2xhtml.structural.profile">Профиль:</message>
-<message key="xmlui.dri2xhtml.structural.logout">Выйти</message>
-<message key="xmlui.dri2xhtml.structural.login">Войти</message>
+	<message key="xmlui.dri2xhtml.structural.profile">Профиль:</message>
+	<message key="xmlui.dri2xhtml.structural.logout">Выйти</message>
+	<message key="xmlui.dri2xhtml.structural.login">Войти</message>
 
-<message key="xmlui.dri2xhtml.structural.search">Поиск в DSpace</message>
-<message key="xmlui.dri2xhtml.structural.search-advanced">Расширенный поиск</message>
-<message key="xmlui.dri2xhtml.structural.search-in-community">В этом сообществе</message>
-<message key="xmlui.dri2xhtml.structural.search-in-collection">В этой коллекции</message>
+	<message key="xmlui.dri2xhtml.structural.search">Поиск в DSpace</message>
+	<message key="xmlui.dri2xhtml.structural.search-advanced">Расширенный поиск</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-community">В этом сообществе</message>
+	<message key="xmlui.dri2xhtml.structural.search-in-collection">В этой коллекции</message>
 
-<message key="xmlui.dri2xhtml.structural.pagination-previous">Предыдущая страница</message>
-<message key="xmlui.dri2xhtml.structural.pagination-info">Отображаемые элементы {0}-{1} из {2}</message>
-<message key="xmlui.dri2xhtml.structural.pagination-next">Следующая страница</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-previous">Предыдущая страница</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-info">Отображаемые элементы {0}-{1} из {2}</message>
+	<message key="xmlui.dri2xhtml.structural.pagination-next">Следующая страница</message>
 
-<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
-<message key="xmlui.dri2xhtml.structural.link_original_license">Оригинальная лицензия</message>
+	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
+	<message key="xmlui.dri2xhtml.structural.link_original_license">Оригинальная лицензия</message>
 
 
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
-<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Предварительный просмотр недоступен</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-title">Без названия</message>
-<message key="xmlui.dri2xhtml.METS-1.0.no-author">Неизвестный автор</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-preview">Предварительный просмотр недоступен</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-title">Без названия</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.no-author">Неизвестный автор</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.non-conformant">
 		This is not a DSpace object conformant to the METS 1.0 profile and as such cannot be
         rendered effectively. You can override either the template that handles the general
@@ -2094,31 +2197,30 @@ Translated by Ekaterina Chubich
         whatever profile you use.
     </message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Предварительный просмотр</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-title">Название</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-author">Автор</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Аннотации</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-description">Описание</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-date">Дата</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Редактор</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Тематика</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Предварительный просмотр</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Название</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Автор</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-abstract">Аннотации</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-description">Описание</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-uri">URI</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Дата</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Редактор</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Тематика</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Файлы в этом документе</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Файл</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Имя</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Размер</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Формат</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Просмотр</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Описание</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Открыть</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Read access available for</message>
-<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">В этом документе нет ни одного файла.</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Файлы в этом документе</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Файл</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Имя</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Размер</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Формат</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Просмотр</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Описание</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Открыть<wbr/>Open</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">В этом документе нет ни одного файла.</message>
 
-<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
-<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">The following license files are associated with this item:</message>
     <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
@@ -2152,71 +2254,71 @@ Translated by Ekaterina Chubich
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->
-<message key="xmlui.dri2xhtml.pioneer.preview">Предварительный просмотр</message>
-<message key="xmlui.dri2xhtml.pioneer.date">Дата</message>
-<message key="xmlui.dri2xhtml.pioneer.title">Название</message>
-<message key="xmlui.dri2xhtml.pioneer.author">Автор</message>
+	<message key="xmlui.dri2xhtml.pioneer.preview">Предварительный просмотр</message>
+	<message key="xmlui.dri2xhtml.pioneer.date">Дата</message>
+	<message key="xmlui.dri2xhtml.pioneer.title">Название</message>
+	<message key="xmlui.dri2xhtml.pioneer.author">Автор</message>
 
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
-<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
+	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
   <!--###### File Format MIME Type Mappings ######-->
 
   <!-- Application-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.application/marc">регистр MARC</message>
-<message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
-<message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/marc">регистр MARC</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/mathematica">Mathematica</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/msword">Microsoft Word</message>
   <message key="xmlui.dri2xhtml.mimetype.application/octet-stream">Unknown</message>
-<message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
-<message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
-<message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
-<message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
-<message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
-<message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/pdf">PDF</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/postscript">Postscript</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/sgml">SGML</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-excel">Microsoft Excel</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-powerpoint">Microsoft PowerPoint</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.ms-project">Microsoft Project</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.database">OpenOffice Base</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.formula">OpenOffice Math</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.graphics">OpenOffice Draw</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.presentation">OpenOffice Impress</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.spreadsheet">OpenOffice Calc</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.oasis.opendocument.text">OpenOffice Writer</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.presentationml.presentation">Microsoft PowerPoint 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">Microsoft Excel 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.openxmlformats-officedocument.wordprocessingml.document">Microsoft Word 2007</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.calc">OpenOffice Calc (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.draw">OpenOffice Draw (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.impress">OpenOffice Impress (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.sun.xml.writer.global">OpenOffice Writer (1.x)</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/vnd.visio">Microsoft Visio</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/wordperfect5.1">WordPerfect</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-dvi">TeX DVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-filemaker">FileMaker Pro</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-java-applet">Java applet</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-latex">LaTeX</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-photoshop">Photoshop</message>
+  <message key="xmlui.dri2xhtml.mimetype.application/x-tex">TeX</message>
 
   <!-- Audio-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
-<message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/basic">Basic Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/flac">FLAC Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/m4a-latm">AAC audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/mpeg">mp3 audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-aiff">AIFF audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-mpeg">MPEG Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wma">WMA Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ms-wmv">WMV Audio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-ogg">Ogg Vorbis</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-pn-realaudio">RealAudio</message>
+  <message key="xmlui.dri2xhtml.mimetype.audio/x-wav">WAV audio</message>
 
   <!-- Image-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.image/gif">изображение GIF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jp2">изображение JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.image/jpeg">изображение JPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/png">изображение PNG</message>
-<message key="xmlui.dri2xhtml.mimetype.image/tiff">изображение TIFF</message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">изображение BMP </message>
-<message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Фото CD</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/gif">изображение GIF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jp2">изображение JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/jpeg">изображение JPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/png">изображение PNG</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/tiff">изображение TIFF</message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-ms-bmp">изображение BMP </message>
+  <message key="xmlui.dri2xhtml.mimetype.image/x-photo-cd">Фото CD</message>
 
   <!-- Text-based formats -->
   <message key="xmlui.dri2xhtml.mimetype.text/css">CSS file</message>
@@ -2228,12 +2330,12 @@ Translated by Ekaterina Chubich
   <message key="xmlui.dri2xhtml.mimetype.text/xml">XML</message>
 
   <!-- Video-based formats -->
-<message key="xmlui.dri2xhtml.mimetype.video/avi">video AVI</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg">video MPEG</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
-<message key="xmlui.dri2xhtml.mimetype.video/mp4">video MPEG-4</message>
-<message key="xmlui.dri2xhtml.mimetype.video/quicktime">Video QuickTime</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/avi">video AVI</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mjp2">Motion JPEG 2000</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg">video MPEG</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mpeg2">MPEG-2 video</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/mp4">video MPEG-4</message>
+  <message key="xmlui.dri2xhtml.mimetype.video/quicktime">Video QuickTime</message>
 
   <!-- explanatory messages for choice authority confidence values -->
   <message key="xmlui.authority.confidence.description.cf_unset">Confidence was never recorded for this value</message>
@@ -2261,6 +2363,7 @@ Translated by Ekaterina Chubich
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Results @1@ to @2@ of @3@ for "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
@@ -2348,133 +2451,45 @@ Translated by Ekaterina Chubich
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
 
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
 
-    <!-- org.dspace.app.xmlui.artifactbrowser.AdvancedSearch.java -->
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.contributor.author_filter">Author</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.subject_filter">Subject</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.type_filter">Content Type</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.date.issued">Date Issued</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dateIssued">Date Issued</message>
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
 
-
-
-    <!-- Site Leve Recently Added Content -->
-    <message key="xmlui.ArtifactBrowser.SiteViewer.head_recent_submissions">Недавно добавленные</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractRecentSubmissionTransformer.recent_submissions_more">Просмотреть больше</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.head">{0}: Недавние поступления</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.trail">Recent submissions</message>
-    <message key="xmlui.Discovery.RecentSubmissions.RecentSubmissionTransformer.recent.head">Недавно добавленные</message>
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_type_filter">Тип</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_publisher_filter">Издатель</message>
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
 
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.ispartof">Родитель</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by">Группировать по</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.none">Ничего</message>
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
 
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
 
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.group_by.publication_grp">Публикация</message>
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
 
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.comm">Сообщество</message>
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_location.coll">Коллекция</message>
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
 
-
-    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_dc.relation.ispartofseries_filter">Серии</message>
-
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.contributor.author_browse">Просмотр по: Автору</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.title_browse">Просмотр по: Названию</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.subject_browse">Просмотр по: Теме</message>
-        
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dc.description.abstract_browse">Просмотр по: Резюме</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_series_browse">Просмотр по: Сериям</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_sponsor_browse">Просмотр по: Спонсору</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_identifier_browse">Просмотр по: Идентификатору</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_language_browse">Просмотр по: Языку (ISO)</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_keyword_browse">Просмотр по: Ключевому слову</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_taxon_browse">Просмотр по: Научному названию</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_contributor_browse">Просмотр по: Участнику</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_creator_browse">Просмотр по: Создателю</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_subject_browse">Просмотр по: Теме</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_description_browse">Просмотр по: Описанию</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_relation_browse">Просмотр по: Связям</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_mime_browse">Просмотр по: Mime-Type</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_other_browse">Просмотр по: Другим участникам</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_advisor_browse">Просмотр по: Советнику</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_department_browse">Просмотр по: Департаменту</message>
-    <message key="xmlui.ArtifactBrowser.AbstractSearch.type_dateissued_dt_browse">Просмотр по: Дате издания</message>
-
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Автор</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.title">Название</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Тема</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued">Дата издания</message>
-
-
-
-    <message key="xmlui.dri2xhtml.structural.pagination-info.nototal">Просмотр элементов {0}-{1}</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.type_author">Фильтровать по: Автору</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author">Автор</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.author_filter">Автор</message>
-    <message key="xmlui.Discovery.AbstractSearch.type_subject">Фильтровать по: Теме</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject">Тема</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.subject_filter">Тема</message>
-    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.dateIssued.year">Дата издания</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.startswith">Начинается с</message>
-    <message key="xmlui.Discovery.AbstractSearch.startswith.help">Или введите первые несколько букв:</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.head">Параметры сортировки:</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.relevance">Релевантность</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_desc">Название по убыв.</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_desc">Дата издания по убыв.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.title_sort_asc">Название по возр.</message>
-    <message key="xmlui.Discovery.AbstractSearch.sort_by.dc.date.issued_dt_asc">Дата издания по возр.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.rpp">Результатов на стр.:</message>
-
-
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.add-filter">Добавить фильтр</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.apply-filters">Применить</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.remove-filter">Удалить</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.new-filters.head">Новые фильтры:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.controls.current-filters.head">Текущие фильтры:</message>
-    <message key="xmlui.Discovery.AbstractSearch.filters.display">Добавить фильтры</message>
-
-    <message key="xmlui.discovery.SearchFacetFilter.no-results">Не найдено результатов, подходящих под фильтр</message>
-
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.head">Просмотр</message>
-    <message key="xmlui.discovery.AbstractFiltersTransformer.filters.view-more">... больше</message>
-
-
-    <message key="xmlui.Discovery.SimpleSearch.search_scope">Поиск</message>
-    <message key="xmlui.discovery.SimpleSearch.search_label">Поиск</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_head">Фильтры</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter_help">Используйте фильтры для уточнения результатов поиска.</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.filter.contains">Содержит</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.equals">Равен</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.authority">ID</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notcontains">Не содержит</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notequals">Не равен</message>
-    <message key="xmlui.Discovery.SimpleSearch.filter.notauthority">Не ID</message>
-    
-    <message key="xmlui.Discovery.RelatedItems.head">Связанные элементы</message>
-    <message key="xmlui.Discovery.RelatedItems.help">Просмотр элементов, связанных по названию, автору, создателю или теме.</message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head1_community">Просмотр {0} из {1} всего результатов для сообщества: {2}. <span class="searchTime">({3} секунд(а))</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_collection">Просмотр {0} из {1} всего результатов для коллекции: {2}. <span class="searchTime">({3} секунд(а))</span></message>
-    <message key="xmlui.Discovery.AbstractSearch.head1_none">Просмотр {0} из {1} результатов. <span class="searchTime">({2} секунд(а))</span></message>
-
-    <message key="xmlui.Discovery.AbstractSearch.head2">Сообщества и коллекции, подходящие под ваш запрос</message>
-    <message key="xmlui.Discovery.AbstractSearch.head3">Документы, подходящие под ваш запрос</message>
-
-    <message key="xmlui.Discovery.SimpleSearch.did_you_mean">Может быть, вы имели в виду: </message>
-
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_ru.xml
+++ b/src/main/webapp/i18n/messages_ru.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ru">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_sw.xml
+++ b/src/main/webapp/i18n/messages_sw.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="sw">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_sw.xml
+++ b/src/main/webapp/i18n/messages_sw.xml
@@ -1,14 +1,4 @@
-<?xml version="1.0"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="sw" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -38,6 +28,11 @@
         <message key="xmlui.general.perform">Fanya</message>
         <message key="xmlui.general.queue">mstari</message>
 
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
 	<!--
 		Page not found keys
 
@@ -55,6 +50,7 @@
     <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Ni watawala tu wanaweza kuingia kwenye kitumio kingine.</message>
     <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
     <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">Hauwezi kuingia kama si mtawala.</message>
+
 
 	<!--
 		This section is for feed syndications (RSS, atom, etc)
@@ -125,7 +121,6 @@
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Mchangiaji</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Mwandishi mkuu</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Somo</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Maelezo</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Huusiano</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Mime-Type</message>
@@ -180,6 +175,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Utafuta {0} kwa tarehe ya kuwasilisha kitabu {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Utafutaji {0}kwa tarehe ya kuwasilisha kitabu </message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Tafuta kwa kiwango</message>
@@ -240,6 +255,9 @@
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Kioneshe</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">kinaonekana kwenye vifungu vifuatavyo</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Show simple item record</message>
+	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Show full item record</message>
+
         <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">Hakipo kimeisha tolewa.</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
@@ -311,7 +329,9 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Ombi la kopi ya nakala</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Ombi la kopi ya nakala</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Ombi la kopi ya nakala</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Ingiza taarifa zifuatazo kupata kopi ya nakala kutoka kwa mtu husika</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Ingiza taarifa zifuatazo kupata kopi ya nakala kutoka kwa mtu husika</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Address is required</message>
@@ -336,7 +356,9 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Kopi ya nakala imetumwa</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">KAMA NI MWANDISHI WA NAKALA {0}" tumia kitufe kujibu maombi ya msomaji.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Tuma kopi ya nakala</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Tuma kopi ya nakala</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Usitume kopi</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
@@ -376,6 +398,36 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Ombi lako la kubadilisha ruhusa limetumwa</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Ombi lako limetumwa kwa watawara</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Asante</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
 	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -454,10 +506,9 @@
 	<message key="xmlui.EPerson.Navigation.register">Sajili</message>
 
 	<!-- org.dspace.app.xmlui.eperson.PasswordLogin.java -->
-	<message key="xmlui.EPerson.PasswordLogin.title">Ingia</message>
+	<message key="xmlui.EPerson.PasswordLogin.title">Ingia ndani</message>
 	<message key="xmlui.EPerson.PasswordLogin.trail">Ingia</message>
 	<message key="xmlui.EPerson.PasswordLogin.head1">Ingia kwenye Dspace</message>
-	<message key="xmlui.EPerson.PasswordLogin.title">Ingia ndani</message>
 	<message key="xmlui.EPerson.PasswordLogin.email_address">Anuani ya barua pepe</message>
 	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Anuani ya barua pepe/ Au neno la siri lilo tolewa halikubaliki.</message>
 	<message key="xmlui.EPerson.PasswordLogin.password">Neno la siri</message>
@@ -468,10 +519,9 @@
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Bonyeza hapa kurejista.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
-	<message key="xmlui.EPerson.LDAPLogin.title">Ingia</message>
+	<message key="xmlui.EPerson.LDAPLogin.title">Ingia ndani</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Ingia</message>
 	<message key="xmlui.EPerson.LDAPLogin.head1">Ingia kwenye Dispesi</message>
-	<message key="xmlui.EPerson.LDAPLogin.title">Ingia ndani</message>
 	<message key="xmlui.EPerson.LDAPLogin.username">Jina la mtumiaji</message>
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">The user name and/or password supplied were not valid.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Neno la siri</message>
@@ -602,7 +652,7 @@
 	<message key="xmlui.Submission.Submissions.workflow_head1">Mtililiko wa kazi husika</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">These tasks are items that are awaiting approval before they are added to the repository. There are two task queues, one for tasks which you have chosen to accept and another for tasks which have not been taken by anyone yet.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Tasks you own</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Kazi</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Item</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Kifungu</message>
@@ -621,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Uwasilishaji huu Hauja kamilika. Vilevile unaweza </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">Anza Uwasilishaji Mpya</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Kichwa cha habari</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Kifungu</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Muwasilishaji</message>
@@ -776,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Size</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Description</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Format</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Unknown</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">unknown format</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Supported)</message>
@@ -805,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Kiasi</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Maelezo</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Hijulikani</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
@@ -853,7 +903,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Tatizo limetokea... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Leseni ya kazi yako</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Kama unapenda, unaweza kuongeza <a href="http://creativecommons.org/">Unda kawaida</a> Leseni yako ya. <strong>Uundaji wa leseni unaongoza watu wapi ambao wanasoma kazi yako kisha wanaweza kuwa nayo.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Kama unapenda, unaweza kuongeza <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Chagua leseni</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Endelea kuhunda website kisha chagua leseni </message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Ingiza leseni</message>
@@ -863,7 +913,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Usambazaji wa leseni</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Kuna atua moja ya mwisho:</strong> Kwa ajili DSpace kuendelea kujizalisha, tafsiri na uwasilishaji wako dunia nzima, Unatakiwa kukubali vifungu vifuatavyo.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Toa kiwango  cha usambazaji leseni kwa kuchagua 'Ninatoa Leseni'; na kisha bofya 'Kamilisha Uwasilishaji'.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">kama unaswali linalo husu leseni tafadhari wasiliana na watawara.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Sambasa leseni</message>
@@ -891,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Ipitisha</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Unaporekebisha hiki, tumia njia hii kuakikisha kinafaniki.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Hakiki inafanikiwa</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Kama unaipitia na unaikuta kama ilivyo  <strong>not</strong> Inafaha kuijumuhisha ndani ya kifungu, chagua "Kata".kisha utaingiza ujumbe unaonesha kwa nini hakifahi na kama muwasilshaji angefanya mabadiliko na kuwasilisha upya.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Kama unaipitia na unaikuta kama ilivyo  <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Ikatishe</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Chagua njia hii kubadilisha metadata.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Rekebisha metadata</message>
@@ -974,11 +1024,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Visajili</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Metadata</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Format</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Items</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Vitoe</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Mambo binafsi</message>
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Control Panel</message>
     <message key="xmlui.administrative.Navigation.statistics">Takwimu</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Ingiza Metadata</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
@@ -1013,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-People are searched by any partial match on email or name</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Chini ni orodha ya wenye barua pepe ambayo inafana na unayo hiitaji.Chagua wenye barua pepe unaotaka kuwafuta na bofya kitufe kufuta kuendelea au bofya katika au bofya kwenye jina la mwenye barua pepe.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Tafuta majibu</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Jina</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Anuani</message>
@@ -1088,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Tafuta kwa makundi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Makundi ya natafutwa kwa sehemu ndogo ya jina linalofanana na jina la kundi</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Tafuta majibu</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Jina</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Wanachama</message>
@@ -1120,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">jina</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Barua pepe</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Jina</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">wanachama</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Collection</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">view</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Wanachama</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Jina</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Barua pepe</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">kundi: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">This group has no members.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[pending]</message>
@@ -1211,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Metadata Schema: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">This is the metadata schema for "{0}". You may add new or update existing metadata fields to this schema. Fields may also be selected for deletion or be moved to another schema. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Schema metadata fields</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Field</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Scope Note</message>
@@ -1238,7 +1290,7 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Bitstream format registry</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">This list of bitstream formats provides information about known formats and their support level. You can edit or add new bitstream formats with this tool. Formats marked as 'internal' are hidden from the user, and are used for administrative purposes.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Add a new bitstream format</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Jina</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Type</message>
@@ -1253,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Metadata Registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Metadata registry</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas.  However, DSpace requires the qualified Dublin Core schema. You may extend the Dublin Core schema with additional fields or add new schemas to the registry.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namespace</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Jina</message>
@@ -1341,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Edit policy {0} for {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">No group selected</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">No action selected</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Jina</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Actions for this resource</message>
@@ -1397,6 +1449,41 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Action</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Kundi</message>
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
 
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Items</message>
@@ -1484,14 +1571,14 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Item Bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Item bitstreams</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Bitstreams</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Jina</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Maelezo</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Format</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Onesha</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bando: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (primary) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">Onesha</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Weka bitstream mpya</message>
@@ -1629,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Search items</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Search items matching: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Map selected items</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">mwandishi</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Kichwa  cah  habari</message>
@@ -1639,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Browse mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Browsing mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Unmap selected items</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Collection</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Mwandishi</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Kicha cha habari</message>
@@ -1751,7 +1838,6 @@
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">The persistent identifier used by the OAI provider to designate the target collection</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">You must provide a set id of the target collection.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
@@ -1818,7 +1904,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Kundi husika</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Watawala</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(Watawala tu)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Unda jamihii: {0}</message>
@@ -1926,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Endelea kuruhusu kuthibisha kipindi</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Zuia thibitisho ila ondoa kipindi cha sasa</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Zuia thibitisho na ondoa kipindi cha sasa</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Nukuhu:</strong> Site administrators are exempt from session management.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Fanya ijiweze</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Fanya isijiweze</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Kazi ya sasa ({0} Kurasa kiasi cha juu)</message>
@@ -1945,7 +2031,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">Use the tabs above to select the information to display</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>ndani {0} dakika</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Haija mamlakisha</message>
@@ -1986,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Tembelea kablasha</message>
     <message key="xmlui.statistics.Navigation.title">Takwimu</message>
     <message key="xmlui.statistics.Navigation.usage.view">Onesha matumizi  ya takwimu</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Onesh mtililiko wa takwimu</message>
     <message key="xmlui.statistics.Navigation.workflow.view">Onesh mtililiko wa takwimu</message>
     <message key="xmlui.statistics.trail">Takwimu</message>
@@ -2024,7 +2111,6 @@
     <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
     <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
-    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
     <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
@@ -2034,10 +2120,23 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
 
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2053,7 +2152,7 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
 			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
@@ -2264,6 +2363,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Matokeo @1@ hadi @2@ ya @3@ kwa ajili "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Failed to load choice data: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Name of Publisher</message>
@@ -2351,6 +2451,45 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Nukuu</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
 
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
-</catalogue>
 
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
+</catalogue>

--- a/src/main/webapp/i18n/messages_tr.xml
+++ b/src/main/webapp/i18n/messages_tr.xml
@@ -1,14 +1,4 @@
-﻿<?xml version="1.0"?>
-<!--
-
-    The contents of this file are subject to the license and copyright
-    detailed in the LICENSE and NOTICE files at the root of the source
-    tree and available online at
-
-    http://www.dspace.org/license/
-
--->
-<catalogue xml:lang="en" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--
 		The format used by all keys is as follows
@@ -35,8 +25,13 @@
 	<message key="xmlui.general.delete">Sil</message>
 	<message key="xmlui.general.next">Sonraki</message>
 	<message key="xmlui.general.untitled">Başlıksız</message>
-    <message key="xmlui.general.perform">Gerçekleştir</message>
-    <message key="xmlui.general.queue">Kuyruk</message>
+        <message key="xmlui.general.perform">Gerçekleştir</message>
+        <message key="xmlui.general.queue">Kuyruk</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
 
 	<!--
 		Page not found keys
@@ -94,9 +89,9 @@
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.no_results">Sonuç bulunamadı.</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.all_of_dspace">Tüm DSpace</message>
 
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">başlık</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">yayın tarihi</message>
-	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">gönderi tarihi</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.title">başlık</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateissued">yayın tarihi</message>
+   <message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.dateaccessioned">gönderi tarihi</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by.relevance">ilgi</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.sort_by">Sırala</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.order">sıra ile</message>
@@ -180,6 +175,26 @@
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Gönderi tarihi {1} için {0} listeleme</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Gönderi tarihine göre {0} listeleme</message>
 
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Arama Kapsamı</message>
@@ -273,10 +288,10 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_item">Bu öğeye erişim kısıtlıdır</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.head_bitstream">Bu veri akışına erişim kısıtlıdır</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_resource">Kısıtlı kaynağa erişmek için gerekli yetkiye sahip değilsiniz.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community"><b>{0}</b> adlı kısıtlı bölüme erişmek için gerekli yetkiye sahip değilsiniz.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection"><b>{0}</b> adlı kısıtlı koleksiyona erişmek için gerekli yetkiye sahip değilsiniz.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item"><b>{0}</b> adlı kısıtlı öğeye erişmek için gerekli yetkiye sahip değilsiniz.</message>
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream"><b>{0}</b> adlı kısıtlı veri akışına erişmek için gerekli yetkiye sahip değilsiniz.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_community"><b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_collection"><b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_item"><b>{0}</b>.</message>
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.para_bitstream"><b>{0}</b>.</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_collection">koleksiyon</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_community">bölüm</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_bitstream">veri akışı</message>
@@ -308,12 +323,15 @@
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Bu arşiv ihraç için kısıtlanmıştır.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">İhraç etmeye çalıştığınız arşiv kısıtlanmıştır ve ihraç için yetki gerekiyor. Arşiv ihracı için lütfen giriş yapınız.</message>
 
+
 	<!-- REQUEST COPY -->
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Belgenin bir kopyasını isteyin</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Belgenin bir kopyasını isteyin</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Belgenin bir kopyasını isteyin</message>
-	<message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Sorumlu personelden belgenin bir kopyasını istemek için aşağıdaki bilgileri girin.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Sorumlu personelden belgenin bir kopyasını istemek için aşağıdaki bilgileri girin.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">e-posta adresiniz</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">Bu e-posta adresi belgeyi göndermek için kullanılır.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">Adres gerekli</message>
@@ -338,8 +356,9 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Doküman kopya isteği</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">EĞER DOKÜMANIN YAZARIYSANIZ (VEYA YAZARSANIZ) kullanıcının isteğine cevap vermek için "{0}" butonuna basınız.</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">Düzenleyebileceğiniz bu kurumsal arşiv uygun bir modele cevap olarak önerilir.</message>
- 
-	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Kopya gönder</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Kopya gönder</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Kopyayı gönderme</message>
 
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
@@ -361,8 +380,8 @@
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Konu</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Gönder</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Geri</message>
-
-	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Yetki değişim isteği</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Yetki değişim isteği</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Yetki değişim isteği</message>
@@ -372,13 +391,43 @@
     <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">İsim gerekli</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">e-posta adresi gerekli</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Açık erişim için değişim</message>
-
+	        
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">İstek gönderildi</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">İstek gönderildi</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Yetki değiştirme isteğiniz gönderildi</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">İsteğiniz yöneticiye gönderildi</message>
 	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Teşekkürler</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
 	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -399,7 +448,7 @@
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Kayıt alınmıyor</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Kayıt alınmıyor</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">Bu DSpace dijital arşivi yapılandırması bu bağlamda kayıt kabul etmiyor. Lütfen soru veya öneriniz için <a href="../contact">site yöneticisi</a>  ile temasa geçiniz.</message>
+	<message key="xmlui.EPerson.CannotRegister.para1">Bu DSpace dijital arşivi yapılandırması bu bağlamda kayıt kabul etmiyor. Lütfen soru veya öneriniz için <a href="../contact">site administrator</a> with questions or comments.</message>
 
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Profil Güncelle</message>
@@ -597,13 +646,13 @@
 	<message key="xmlui.Submission.Submissions.title">Gönderiler &amp; İş Akışı</message>
 	<message key="xmlui.Submission.Submissions.trail">Gönderiler</message>
 	<message key="xmlui.Submission.Submissions.head">Gönderiler &amp; İş Akış Görevleri</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Başlıksız</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">e-posta: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">İş akış görevleri</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Bu görevler dijital arşive eklenmek üzere onay bekleyen öğelerdir. İki görev kuyruğu vardır. Birincisi görevleri kabul etmek üzere seçtiğiniz, ikincisi ise henüz kimse tarafından alınmamış görevler kuyruğudur.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Görevleriniz</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Görev</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Öğe</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Koleksiyon</message>
@@ -622,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Bunlar tamamlanmamış gönderileridir. Ayrıca isterseniz </message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">başka bir gönderi başlatabilirsiniz</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Başlık</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Koleksiyon</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Gönderici</message>
@@ -691,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Çoklu başlıklar</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Öğenin birden çok başlığı var. <i>(Ör. Türkçe/İngilizce)</i></message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Öğenin birden çok başlığı var. <i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">Eğer yukarıdaki kutu çek edilmez ise aşağıdaki başlık(lar) öğeden silinecektir:</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Yayımlandı</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Öğe daha önce yayımlandı veya dağıtımı yapıldı</message>
@@ -704,8 +753,8 @@
 	<message key="xmlui.Submission.submit.DescribeStep.head">Öğe Tanımlama</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Hata: Bilinmeyen alan türü</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Bu alan gerekli</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Soyadı, <i>Ör. Çelik</i></message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Ad(lar)ı, <i>Ör. Sönmez</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Soyadı, <i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Ad(lar)ı, <i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Yıl</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Ay</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">Gün</message>
@@ -718,7 +767,7 @@
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Kontrollü kelime listesi yüklenirken lütfen bekleyiniz.</message>
 	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">Kontrollü kelime listesi çağırılırken bir hata oluştu, lütfen tekrar deneyiniz.</message>
 
-	
+
     <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
     <message key="xmlui.Submission.submit.AccessStep.head">Erişim Ayarları</message>
     <message key="xmlui.Submission.submit.AccessStep.access_settings">Seçilen kullanıcı grubu için görünür (anonim kullanıcılar için gerekli seçim yoktur)</message>
@@ -726,22 +775,22 @@
     <message key="xmlui.Submission.submit.AccessStep.embargo">Özel Tarihe kadar Ambargolu Erişim</message>
     <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Görünür/Ambargolu</message>
     <message key="xmlui.Submission.submit.AccessStep.name">Ad</message>
-	<message key="xmlui.Submission.submit.AccessStep.name_help">Politika için açıklayıcı, kısa bir isim (en fazla 30 karakter). Son kullanıcılara gösterilebilir. Örneğin: "Yalnızca-Çalışanlar". İsteğe bağlıdır, ancak önerilir.</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">Politika için açıklayıcı, kısa bir isim (en fazla 30 karakter). Son kullanıcılara gösterilebilir. Örneğin: "Yalnızca-Çalışanlar". İsteğe bağlıdır, ancak önerilir.</message>
     <message key="xmlui.Submission.submit.AccessStep.description">Açıklama</message>
     <message key="xmlui.Submission.submit.AccessStep.reason">Neden</message>
-	<message key="xmlui.Submission.submit.AccessStep.reason_help">Genellikle sadece dahili kullanımda olan öğeler için ambargo nedeni. Opsiyonel.</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">Genellikle sadece dahili kullanımda olan öğeler için ambargo nedeni. Opsiyonel.</message>
     <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Politika Onayla &amp; başka ekle</message>
     <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Gruplar</message>
     <message key="xmlui.Submission.submit.AccessStep.error_format_date">Hatalı tarih biçimi</message>
     <message key="xmlui.Submission.submit.AccessStep.error_missing_date">Ambargo seçildiğinde tarih belirleme gereklidir</message>
     <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">Bu grup ve bu eylem için geçerli olan aynı politika zaten mevcut.</message>
     <message key="xmlui.Submission.submit.AccessStep.table_policies">Politikalar Listesi</message>
-	<message key="xmlui.Submission.submit.AccessStep.policies_help">Bu bölümde listelenen politikalar, gönderi yaptığınız koleksiyon için varsayılan herhangi bir politikayı geçersiz kılar. Bir ambargo düzenlemek istiyorsunuz fakat hedef koleksiyon herhangi bir kullanıcı için erişime izin veriyor, o halde spesifik bir veriden sonra Anonim gruplar için erişime izin veen bir politika düzenlemelisiniz.</message>
-	<message key="xmlui.Submission.submit.AccessStep.no_policies">Bu öğe için herhangi bir grup politikası seçilmedi.</message>
-	<message key="xmlui.Submission.submit.AccessStep.new_policy_head">Ambargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Bu bölümde listelenen politikalar, gönderi yaptığınız koleksiyon için varsayılan herhangi bir politikayı geçersiz kılar. Bir ambargo düzenlemek istiyorsunuz fakat hedef koleksiyon herhangi bir kullanıcı için erişime izin veriyor, o halde spesifik bir veriden sonra Anonim gruplar için erişime izin veen bir politika düzenlemelisiniz.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">Bu öğe için herhangi bir grup politikası seçilmedi.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Ambargo</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings">Özel Öğe</message>
     <message key="xmlui.Submission.submit.AccessStep.private_settings_help">Seçim yapılırsa, öğe aramaya kapanır.</message>
-	<message key="xmlui.Submission.submit.AccessStep.private_settings_label">Özel</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Özel</message>
     <message key="xmlui.Submission.submit.AccessStep.column0">Ad</message>
     <message key="xmlui.Submission.submit.AccessStep.column1">Eylem</message>
     <message key="xmlui.Submission.submit.AccessStep.column2">Grup</message>
@@ -750,12 +799,12 @@
     <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Düzenle</message>
     <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Sil</message>
     <message key="xmlui.administrative.authorization.AccessStep.label_date_help">Kabul edilen biçimler: yyyy, yyyy-aa, yyyy-aa-gg</message>
-	<message key="xmlui.Submission.submit.AccessStep.review_policy_line">İsim: {0}; eylem: {1}, grup: {2}, başlama tarihi: {3}, bitiş tarihi: {4}</message>
-	<message key="xmlui.Submission.submit.AccessStep.review_public_item">Öğe aranabilir olacak</message>
-	<message key="xmlui.Submission.submit.AccessStep.review_private_item">Öğe aranabilir olmayacak</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">İsim: {0}; eylem: {1}, grup: {2}, başlama tarihi: {3}, bitiş tarihi: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">Öğe aranabilir olacak</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">Öğe aranabilir olmayacak</message>
 
 
-	
+
     <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
     <message key="xmlui.Submission.submit.EditPolicyStep.head">Politika Düzenle</message>
 
@@ -768,7 +817,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.virus_error">Dosyanın virüs taşıdığı tespit edildiğinden dolayı yüklenmedi. Lütfen sistem yöneticinize başvurun.</message>
     <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">Dosya virüs taramasından geçirilirken teknik bir problem meydana geldi. Lütfen sistem yöneticinize başvurun.</message>
     <message key="xmlui.Submission.submit.UploadStep.description">Dosya Açıklaması</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Ana Makale</i>", veya "<i>Deney verisi okumaları</i>".</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Dosya yükle &amp; başka ekle</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Yüklenmiş Dosyalar</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">İlk</message>
@@ -777,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Boyut</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Açıklama</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Biçim</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Bilinmeyen</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">Bilinmeyen biçim</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Destekli)</message>
@@ -797,7 +846,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">Dosya, içeriğinin virüs taşıdığı tespit edildiğinden dolayı yüklenemedi. Lütfen sistem yöneticinizle temasa geçiniz.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">Dosya virüs taramasından geçirilirken teknik bir problem meydana geldi. Lütfen sistem yöneticinizle temasa geçiniz.</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">Dosya Açıklaması</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Ana Makale</i>", veya "<i>Deney verisi okumaları</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Dosya yükle &amp; başka ekle</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Yüklenmiş Dosyalar</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">İlk</message>
@@ -806,7 +855,7 @@
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Boyut</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Açıklama</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Biçim</message>
-    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"></message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Bilinmeyen</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">bilinmeyen biçim</message>
     <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Destekli)</message>
@@ -822,14 +871,14 @@
 	<message key="xmlui.Submission.submit.EditFileStep.head">Dosya Düzenle</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Dosya</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Dosya Açıklaması</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Ana Makale</i>", veya "<i>Deney verisi okumaları</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Aşağıdaki listeden dosyanın biçimini seçin. Örneğin, "<i>Adobe PDF</i>" veya "<i>Microsoft Word</i>." <strong>Eğer biçim listede yoksa</strong>, aşağıdaki giriş kutusu listesinde tanımlayın.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Aşağıdaki listeden dosyanın biçimini seçin. Örneğin, "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Algılanan Biçim</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Seçilen Biçim</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Biçim listede yoktur</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Eğer biçim yukarıdaki listede yoksa, <strong>"biçim listede yoktur"</strong> seçeneğini seçiniz ve aşağıdaki kutuda dosyanın biçimini tanımlayınız.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Eğer biçim yukarıdaki listede yoksa, <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Diğer Biçim</message>
-	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Dosya oluşturmak için kullandığınız uygulamanın adı ve sürüm numarası (örneğin, "<i>ACMESoft SuperApp sürüm 1.5</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Dosya oluşturmak için kullandığınız uygulamanın adı ve sürüm numarası (örneğin, "<i>ACMESoft SuperApp version 1.5</i>").</message>
 
     <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
     <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Veri Akışı Erişimini Düzenle</message>
@@ -854,7 +903,7 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
         <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">Bir hata oluştu ... {0}</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.head">Çalışmanızın Lisansı</message>
-        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Eğer isterseniz, öğeniz için bir <a href="http://creativecommons.org/">Creative Commons</a> lisansı ekleyebilirsiniz. <strong>Creative Commons lisansı, çalışmanızı okuyan kişilerin çalışmanızdan nasıl yararlanabileceğini gösterir</strong>.</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">Eğer isterseniz, öğeniz için bir <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Bir Lisans Seçiniz</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Bir lisans seçmek için Creative Commons web sayfasına gidin</message>
         <message key="xmlui.Submission.submit.CCLicenseStep.license">Lisans Türleri</message>
@@ -864,7 +913,7 @@
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Dağıtım Lisansı</message>
-	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>Son bir adım daha var</strong>. DSpace'in gönderinizi yeniden üretme, çevirme ve dağıtma işlemlerini dünya çapında gerçekleştirebilmesi için, aşağıdaki koşulları kabul etmeniz gerekektedir.</message>
+	<message key="xmlui.Submission.submit.LicenseStep.info1"><strong>There is one last step:</strong> In order for DSpace to reproduce, translate and distribute your submission worldwide, you must agree to the following terms.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info2">Seçilmiş standart dağıtım lisansını, "Lisansı Kabul Ediyorum" tuşuna basarak kabul ediniz ve "Gönderiyi Tamamlamak" için tıklayınız.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.info3">Eğer bu lisansla ilgili sorularınız var ise sistem yöneticiniz ile temasa geçiniz.</message>
 	<message key="xmlui.Submission.submit.LicenseStep.decision_label">Dağıtım lisansı</message>
@@ -892,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Onayla</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Öğeyi gözden geçirdikten sonra, öğeyi arşivlemek için bu seçeneği kullanınız.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Arşiv Taahhütü</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Eğer öğeyi gözden geçirdiğinizde koleksiyona dahil etmek için uygun <strong>olmadığını</strong> düşünüyorsanız, "Reddet" seçeneğini kullanınız. Daha sonra öğenin neden uygun olmadığını gösteren bir mesaj girmeniz istenecektir. Bu mesajda, göndericiye öğenin reddedilme nedeni belirtilir, düzeltme istenir.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Eğer öğeyi gözden geçirdiğinizde koleksiyona dahil etmek için uygun <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Reddet</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Öğenin üst verisini değiştirmek için bu seçeneği kullanın.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Üst veri düzenle</message>
@@ -975,11 +1024,13 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Kayıtlar</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Üst Veri</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Biçim</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Öğeler</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Çekilmiş Öğeler</message>
     <message key="xmlui.administrative.Navigation.administrative_private">Özel Öğeler</message>
     <message key="xmlui.administrative.Navigation.administrative_control_panel">Kontrol Paneli</message>
     <message key="xmlui.administrative.Navigation.statistics">İstatistikler</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Üst Veri Al</message>
         <message key="xmlui.administrative.Navigation.administrative_curation">Yönetici Görevleri</message>
 
@@ -1014,7 +1065,7 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">E-Kişi, e-posta ve adındaki herhangi bir kısmi eşleşmeyle arandı.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Aramanızla eşleşen E-Kişilerin listesi aşağıdadır. Silmek istediğiniz E-Kişiyi seçiniz ve devam etmek için sil butonuna basınız veya düzenlemek için E-Kişinin email veya adına tıklayınız.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Arama Sonucu</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Ad</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">E-Posta</message>
@@ -1089,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Grup ara</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Gruplar adındaki herhangi bir kısmi eşleşmeyle arandı.</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Arama sonucu</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Ad</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Üyeler</message>
@@ -1121,18 +1172,18 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Ad</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">E-Posta</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Ad</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Üyeler</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Koleksiyon</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">görüntüle</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Üyeler</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Ad</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">E-Posta</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">gruplar: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">Bu grupta üye yok.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[bekleyen]</message>
@@ -1166,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Alanları Sil</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Alanları Sil</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Silmeyi Onayla</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Bu alanları <b>kesinlikle</b> silmek istediğinize emin misiniz? Eğer bu alanlar için üst veri herhangi bir öğe içeriyorsa alanlar silinmeyecektir. Bu alanların herhangi bir öğe içermediğine emin olunuz.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Bu alanları <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">UYARI: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Bu alanlar için üst veri herhangi bir öğe içeriyorsa hataya neden olur.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1177,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Şema Sil</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Şema sil</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Silmeyi Onayla</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Bu şemayı <b>kesinlikle</b> silmek istediğinize emin misiniz? Eğer bu şema için üst veri herhangi bir öğe içeriyorsa alanlar silinmeyecektir. Bu şemanın herhangi bir öğe içermediğine emin olunuz.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Bu şemayı <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">UYARI: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Bu şema için üst veri herhangi bir öğe içeriyorsa hataya neden olur.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1212,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Üst veri şeması: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Bu "{0}" için üst veri şemasıdır. Bu şemaya yeni alanlar ekleyebilir veya açık olan üst veri alanlarını güncelleyebilirsiniz.</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Şema üst veri alanları</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Alan</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Kapsam Notu</message>
@@ -1239,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Veri akış biçimi kaydı</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Bu veri akışı biçimleri bilinen biçimler hakkında bilgi verir ve onların desteklenen düzeyleridir. Bu araçla veri akışlarını düzenleyebilir veya yeni veri akışı ekleyebilirsiniz.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Yeni veri akışı biçimi ekle</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Ad</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME Türü</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Destek Düzeyi</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>dahili</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Bilinmeyen</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Bilinen</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Destek</message>
@@ -1254,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Üst Veri Kaydı</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Üst veri kaydı</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Üst veri kaydı dijital arşivde kullanılabilir tüm üst veri alanlarının bir listesini tutar. Bu alanlar birden çok şema arasında bölünmüş olabilir. Ancak, DSpace nitelikli Dublin Core şeması gerektirir. Ek alanları ile Dublin Core şemasını genişletebilir veya kayıt için yeni şemalar ekleyebilirsiniz.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Alan adı</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Ad</message>
@@ -1323,7 +1374,7 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Öğe Politikalarını Düzenle</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Politikalar Listesi</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.main_head">Öğe için politikalar: {0} (ID={1})</message>
-	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Bu metin düzenleyicisi ile bir öğenin ilkelerini görüntüleyebilir ve değiştirebilirsiniz. Dahası bireysel öğe birleşenlerinin ilkelerini değiştirebilirsiniz (Örneğin; İlke paketleri ve veri akışı). Kısaca bir öğe, paketin kapsayıcısı, paketler de veri akışlarının kapsayıcısıdırlar. Kapsayıcılar <strong>Ekle/Kaldır/Oku/Yaz</strong> ilkelerine sahipken, veri akışları sadece <strong>Oku/Yaz</strong> ilkelerine sahiptir.</message>
+	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para1">Bu metin düzenleyicisi ile bir öğenin ilkelerini görüntüleyebilir ve değiştirebilirsiniz. Dahası bireysel öğe birleşenlerinin ilkelerini değiştirebilirsiniz (Örneğin; İlke paketleri ve veri akışı). Kısaca bir öğe, paketin kapsayıcısı, paketler de veri akışlarının kapsayıcısıdırlar. Kapsayıcılar </message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.main_para2">Her bir öğe için ekstra bir paket ve veri akışı olduğunu farkedeceksiniz. Bunlar öğeler için lisans metnini içermektedir.</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_item">Öğe Politikaları</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.subhead_bundle">İlke Paketi: {0} ({1})</message>
@@ -1342,7 +1393,7 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">{1} {2} için {0} politikası düzenle</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Grup seçilmedi</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Eylem seçilmedi</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Ad</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Bu kaynak için eylemler</message>
@@ -1399,6 +1450,41 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Eylem</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Grup</message>
 
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Öğeler</message>
 	<message key="xmlui.administrative.item.general.template_head">Koleksiyon için öğe şablonu düzenle: {0}</message>
@@ -1423,7 +1509,7 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Dosya</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Lütfen yükleyeceğiniz öğeye karşılık gelen sabit disk üzerindeki dosya adını girin. Eğer "Göz at..." butonuna tıklarsanız, yeni bir pencere açılacaktır. Bu pencere aracılığıyla yükleyeceğiniz dosyayı seçebilirsiniz.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Açıklama</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Ana Makale</i>", veya "<i>Deney verisi okumaları</i>".</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Yükle</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Yeni veri akışı yüklemek için en az bir paket üzerinde EKLEME &amp; YAZMA yetkisi gerekir.</message>
 
@@ -1471,13 +1557,13 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">evet</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">hayır</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Açıklama</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Ana Makale</i>", veya "<i>Deney verisi okumaları</i>".</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Aşağıdaki listeden dosyanın biçimini seçin. Örneğin, "<i>Adobe PDF</i>" veya "<i>Microsoft Word</i>." <strong>Eğer biçim listede yoksa</strong>, aşağıdaki giriş kutusu listesinde tanımlayın.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">İsteğe bağlı olarak, dosya için kısa bir açıklama girin. Örneğin, "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Aşağıdaki listeden dosyanın biçimini seçin. Örneğin, "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Seçilmiş Biçimler</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Biçim listede yoktur</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Eğer biçim yukarıdaki listede yoksa, <strong>"biçim listede yoktur"</strong> seçeneğini seçiniz ve aşağıdaki kutuda dosyanın biçimini tanımlayınız.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Eğer biçim yukarıdaki listede yoksa, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Diğer Biçim</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Dosyayı oluşturmak için kullanılan uygulama ve sürüm numarası (Örneğin, "<i>ACMESoft SuperApp sürüm 1.5</i>").</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Dosyayı oluşturmak için kullanılan uygulama ve sürüm numarası (Örneğin, "<i>ACMESoft SuperApp version 1.5</i>").</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Dosya Adı</message>
     <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Bu veri akışı için dosya adını değiştir. Bu ekranda veri akış URL'sini değiştirebileceğinizi unutmayın, ancak eski bağlantıların sıra kimliği değişmeyecektir.</message>
 
@@ -1485,14 +1571,14 @@
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Veri Akışı Öğesi</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Veri akışı öğesi</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Veri akışları</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Ad</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Açıklama</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Biçim</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Görüntüle</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Sıra</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Paket: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (ilk) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">görüntüle</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Yeni bir veri akışı ekle</message>
@@ -1512,7 +1598,7 @@
 	<message key="xmlui.administrative.item.EditItemMetadataForm.value_label">Değer</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.lang_label">Dil</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.submit_add">Yeni üst veri ekle</message>
-	<message key="xmlui.administrative.item.EditItemMetadataForm.para1"><strong>Lütfen not ediniz</strong>: Bu değişiklikler hiçbir şekilde doğrulanamadı. Veriyi doğru biçimde girmekle sorumlusunuz. Biçimin ne olduğundan emin değilseniz lütfen değişiklik <strong>yapmayınız</strong>.</message>
+	<message key="xmlui.administrative.item.EditItemMetadataForm.para1"/>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.head2">Üst veri</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column1">Sil</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.column2">Ad</message>
@@ -1534,9 +1620,9 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_move">Öğeyi başka bir koleksiyona taşı</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.label_delete">Öğeyi tamamen çıkar</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_authorizations">Yetkiler...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Geri Çek...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Yeniden Yükle...</message>
-    <message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Taşı...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_withdraw">Geri Çek...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_reinstate">Yeniden Yükle...</message>
+	<message key="xmlui.administrative.item.EditItemStatusForm.submit_move">Taşı...</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.submit_delete">Kalıcı olarak sil</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.na">n/a (uygulanmaz) </message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(sadece sistem yöneticileri)</message>
@@ -1619,7 +1705,7 @@
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Koleksiyon: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">Bu öğe eşleme aracıdır ve koleksiyon yöneticilerinin diğer koleksiyonlardan bu koleksiyona öğe eşlemelerine izin verir. Diğer koleksiyonlardan öğe arayabilir ve şu anda eşlenen öğelerin listesine göz atarak onları eşleyebilirsiniz.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">İstatistikler</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info">Bu koleksiyondaki <strong>{1}</strong> öğeleri <strong>{0}</strong> diğer koleksiyonlarda eşlendi.</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info">Bu koleksiyondaki <strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Ara</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Öğeleri Ara</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Eşlenen öğelere göz at.</message>
@@ -1630,7 +1716,7 @@
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Öğe ara</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Arama öğesi eşleme: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Seçilmiş  öğe eklemeleri</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Koleksiyon</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Yazar</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Başlık</message>
@@ -1640,7 +1726,7 @@
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Eşlenmiş öğelere göz at</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Eşlenmiş öğeler listeleniyor</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Seçilmiş öğelerin eşlemesini kaldır</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Koleksiyon</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Yazar</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Başlık</message>
@@ -1679,9 +1765,9 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Üst Veri Düzenleme Adımı</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Gönderici</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Varsayılan okuma erişimi</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(sadece sistem yöneticileri)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Dijital arşiv düzey grubu, sadece sistem yöneticileri)</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(bu yapılandırma için yetkiniz yok)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
         <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Koleksiyon Yöneticiliği: {0}</message>
@@ -1724,7 +1810,7 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Logo sil</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Koleksiyon sil</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Güncellemeleri kaydet</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(sadece sistem yöneticileri)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Koleksiyon Oluştur</message>
@@ -1818,7 +1904,7 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">İlişkili Gurup</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Yöneticiler</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(sadece sistem yöneticileri)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
         <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
         <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Bölüm Yöneticiliği: {0}</message>
@@ -1912,7 +1998,7 @@
 	<message key="xmlui.administrative.ControlPanel.mail_feedback_recipient">Geri Bildirim Alıcısı</message>
 	<message key="xmlui.administrative.ControlPanel.mail_admin">Genel Site Yöneticisi E-Postası</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_head">Genel Sistem Uyarıları</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Düzenlenmiş sistemler için uyarı</strong>: Sistem genelinde uyarılar Aktiv edildiğinde düğüm için etkilidir. Düğümde her bir activatenin uyarı komutu alması gereklidir.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_warning"><strong>Warning for load balanced systems</strong>: System-wide alerts are only effective for the node on which it is activated. You need to ensure that each node in the set receives the activate alert command.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_label">Uyarı mesajı</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_message_default">Sistem düzenli bakım için kapatılacak. Lütfen çalışmanızı kaydedin ve çıkış yapın.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_label">Geri Sayım</message>
@@ -1926,7 +2012,7 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Yetkili oturumları sürdür</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Yetki kısıtla, ancak güncel oturumları sürdür.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Yetki kısıtla ve güncel oturumları kapat</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Not:</strong> Site yöneticileri oturum yönetiminden muaftır.</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Aktif</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Pasif</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Güncel Etkinlik (en fazla {0} sayfa)</message>
@@ -1945,7 +2031,7 @@
 	<message key="xmlui.administrative.ControlPanel.select_panel">Bilgi görüntüleme için yukarıdaki sekmeleri seçin</message>
 
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>{0} dakika içinde</strong>: </message>
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
 
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Yetkilendirilmemiş</message>
@@ -1986,6 +2072,7 @@
     <message key="xmlui.statistics.visits.bitstreams">Dosya Ziyaretleri</message>
     <message key="xmlui.statistics.Navigation.title">İstatistikler</message>
     <message key="xmlui.statistics.Navigation.usage.view">Kullanım İstatistiklerini Göster</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
     <message key="xmlui.statistics.Navigation.search.view">Arama İstatistiklerini Göster</message>
     <message key="xmlui.statistics.Navigation.workflow.view">İş Akışı İstatistiklerini Göster</message>
     <message key="xmlui.statistics.trail">İstatistikler</message>
@@ -1993,7 +2080,7 @@
     <message key="xmlui.statistics.trail-workflow">İş Akışı İstatistikleri</message>
     <message key="xmlui.statistics.workflow.no-results">Seçilen dönem için iş akışı istatistiği yoktur.</message>
     <message key="xmlui.statistics.workflow.error">İş akışı istatistiği oluşturulurken bir hata oluştu, lütfen daha sonra yeniden deneyiniz.</message>
-    <message key="xmlui.statistics.workflow.head">>İş Akışı İstatistikleri</message>
+    <message key="xmlui.statistics.workflow.head">&gt;İş Akışı İstatistikleri</message>
     <message key="xmlui.statistics.workflow.head-dso">{0} İçin İş Akışı İstatistikleri</message>
 
 
@@ -2033,10 +2120,23 @@
     <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Tekil Kullanıcı Değerlendirme Eylemi</message>
 
 
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+                     Google Analytics Statistics Aspect
 
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
 
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2052,14 +2152,14 @@
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
 		<a href="http://di.tamu.edu" id="ds-logo-link">
-			<span id="ds-footer-logo">&#160;</span>
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Bu web sayfası Manakin kullanır ve Teksas A&amp;M Üniversitesi Kütüphaneleri tarafından DSpace için 
-			oluşturulan yeni bir ara yüzdür. Arayüz, Manakin Görünüşü ve XSL tabanlı temalar üzerinde değiştirilebilir.
-			Daha fazla bilgi için; 
-			<a href="http://di.tamu.edu">http://di.tamu.edu</a> ve
-			<a href="http://dspace.org">http://dspace.org</a> adresleri ziyaret edebilirsiniz.
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">İletişim</message>
@@ -2114,8 +2214,7 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Biçim</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Göster</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Açıklama</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Göster/<wbr/>Aç</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-access-rights">Mevcut okuma erişimi için</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Göster/<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Bu öğe ile ilişkili dosya yok.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
@@ -2150,7 +2249,8 @@
 
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core öğeleri</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terimleri</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.blocked">Engellendi</message>
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Engellendi</message>
 
 
 	<!-- Special pioneer model related text, wherever it might end up -->
@@ -2263,6 +2363,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Sonuçlar: @1@ to @2@ of @3@ for "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Seçim verileri yüklenemedi: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Yayıncı Adı</message>
@@ -2349,6 +2450,46 @@
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">Kullandığınız ürün, bu ürünün son sürümü değil. Güncel sürüm şu adreste bulunabilir:</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Uyarı</message>
     <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">İş Akışında bu ürünün daha yeni bir sürümü  bulunmaktadır.</message>
-	
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
     <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>

--- a/src/main/webapp/i18n/messages_tr.xml
+++ b/src/main/webapp/i18n/messages_tr.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
 	<!--

--- a/src/main/webapp/i18n/messages_uk.xml
+++ b/src/main/webapp/i18n/messages_uk.xml
@@ -1,4 +1,5 @@
-<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="ru">
 
 	<!--
 		The format used by all keys is as follows

--- a/src/main/webapp/i18n/messages_uk.xml
+++ b/src/main/webapp/i18n/messages_uk.xml
@@ -1,62 +1,22 @@
-﻿<?xml version="1.0"?>
-  <!--
-  messages.xml
+<catalogue xmlns:i18n="http://apache.org/cocoon/i18n/2.1" xml:lang="en">
 
-  Version: $Revision: 4909 $
- 
-  Date: $Date: 2010-05-10 10:03:35 +0000 (Mon, 10 May 2010) $
- 
-  Copyright (c) 2002-2005, Hewlett-Packard Company and Massachusetts
-  Institute of Technology.  All rights reserved.
- 
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are
-  met:
- 
-  - Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
- 
-  - Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
- 
-  - Neither the name of the Hewlett-Packard Company nor the name of the
-  Massachusetts Institute of Technology nor the names of their
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
- 
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
-  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-  DAMAGE.
--->
-<catalogue xml:lang="ru" xmlns:i18n="http://apache.org/cocoon/i18n/2.1">
-	
 	<!--
 		The format used by all keys is as follows
-		
+
 		xmlui.<Aspect>.<Java Class>.<name>
-		
-		There are a few exceptions to this nameing format,
-		1) Some general keys are in the xmlui.general namespace 
+
+		There are a few exceptions to this naming format,
+		1) Some general keys are in the xmlui.general namespace
 		   because they are used very frequently.
-		2) Some general keys which are specific to a particular aspect 
-		   may be found at xmlui.<Aspect> without specifiying a 
-		   particular java class. 
-		--> 
-	
+		2) Some general keys which are specific to a particular aspect
+		   may be found at xmlui.<Aspect> without specifying a
+		   particular java class.
+		-->
+
 	<!-- General keys -->
 	<message key="xmlui.general.dspace_home">Головна сторінка DSpace</message>
 	<message key="xmlui.general.search">Пошук</message>
-	<message key="xmlui.general.go">>></message>
+	<message key="xmlui.general.go">&gt;&gt;</message>
 	<message key="xmlui.general.go_home">Перейти на головну</message>
 	<message key="xmlui.general.save">Зберегти</message>
 	<message key="xmlui.general.cancel">Відміна</message>
@@ -65,45 +25,60 @@
 	<message key="xmlui.general.delete">Видалити</message>
 	<message key="xmlui.general.next">Далі</message>
 	<message key="xmlui.general.untitled">Немає даних</message>
-	
-	
-	<!-- 
-		Page not found keys 
-		
+        <message key="xmlui.general.perform">Perform</message>
+        <message key="xmlui.general.queue">Queue</message>
+
+        <!-- Keys which are used by exception2dri.xsl on error pages -->
+        <message key="xmlui.error.contact_msg">Please contact the site administrator if you wish to report this error. If possible, please  provide details about what you were doing at the time this error occurred.</message>
+        <message key="xmlui.error.contact">Contact site administrator</message>
+        <message key="xmlui.error.show_stack">Show underlying error stack</message>
+
+	<!--
+		Page not found keys
+
 		This is a special component that is not part of any aspect but is added
 		by manakin to all aspect chains.
 		-->
 	<message key="xmlui.PageNotFound.title">Page not found</message>
 	<message key="xmlui.PageNotFound.head">Page not found</message>
 	<message key="xmlui.PageNotFound.para1">We can't find the page you asked for.</message>
-	
-	
+
+
 	<!--
-		This section is for feed syndications (RSS, atom, etc)  
+	   The "utils" non-aspect
+       -->
+    <message key="xmlui.utils.AuthenticationUtil.onlyAdmins">Only site administrators may assume login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.onlyAuthenticatedAdmins">Only authenticated users who are administrators may assume the login as another user.</message>
+    <message key="xmlui.utils.AuthenticationUtil.notAnotherAdmin">You may not assume the login as another administrator.</message>
+
+
+	<!--
+		This section is for feed syndications (RSS, atom, etc)
 	-->
 	<message key="xmlui.feed.general_description">The DSpace digital repository system captures, stores, indexes, preserves, and distributes digital research material.</message>
+    <message key="xmlui.feed.header">RSS Feeds</message>
 	<message key="xmlui.feed.logo_title">The Channel Image</message>
 	<message key="xmlui.feed.untitled">Немає даних</message>
-	
+
 	<!--
-		Default notice header 
+		Default notice header
 	 	-->
 	<message key="xmlui.general.notice.default_head">Notice</message>
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  
+
 		             ArtifactBrowser Aspect
-	
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.AbstractSearch.java -->
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_community">Результати пошуку у Фонді: {0}</message>
 	<message key="xmlui.ArtifactBrowser.AbstractSearch.head1_collection">Результати пошуку у Колукції: {0}</message>
@@ -142,11 +117,10 @@
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_identifier">Реєстраційний номер</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_language">Мова</message>
 	<message key="xmlui.ArtifactBrowser.AdvancedSearch.type_keyword">Ключові слова</message>
-   
+
    <!--  some common other possibilities for Advanced Search Fields -->
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_contributor">Хто вніс в базу</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_creator">Автор</message>
-   <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_subject">Тема</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_description">Деякий опис</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_relation">Відношення</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.type_mime">Mime-тип</message>
@@ -158,14 +132,14 @@
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.and">І</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.or">АБО</message>
    <message key="xmlui.ArtifactBrowser.AdvancedSearch.not">НЕ</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ConfigureableBrowse.java -->
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with">Або введіть перші кілька букв:</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.starts_with_help">Шукати матеріали що починаються з цих букв</message>
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Перейти до значення в індексі:</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Оберіть місяць)</message>	
-	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Оберіть рік)</message>	
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_select">Перейти до значення в індексі:</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_month">(Оберіть місяць)</message>
+	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.choose_year">(Оберіть рік)</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year">Або введіть рік: </message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.jump_year_help">Шукати матеріали вказаного року.</message>
         <message key="xmlui.ArtifactBrowser.ConfigurableBrowse.general.no_results">Нажаль жоден матеріал не відповідає вашому запиту.</message>
@@ -191,17 +165,37 @@
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.metadata.subject">Перегляд {0} по темі {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.metadata.subject">Перегляд {0} по темі</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.title">Перегляд {0} по назві {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.title">Перегляд {0} по назві</message>
-	
+
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateissued">Перегляд {0} за датою {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateissued">Перегляд {0} за датою</message>
 
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.title.item.dateaccessioned">Перегляд {0} датою додання {1}</message>
 	<message key="xmlui.ArtifactBrowser.ConfigurableBrowse.trail.item.dateaccessioned">Перегляд {0} датою додання</message>
 
-	
+
+	<!-- org.dspace.app.xmlui.administrative.WithdrawnItems.java -->
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.title">Withdrawn Items by Title</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.title">Withdrawn Items by Title</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateissued">Withdrawn Items by Issue Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateissued">Withdrawn Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.WithdrawnItems.title.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+	<message key="xmlui.Administrative.WithdrawnItems.trail.item.dateaccessioned">Withdrawn Items by Submit Date</message>
+
+	<!-- org.dspace.app.xmlui.administrative.PrivateItems.java -->
+	<message key="xmlui.Administrative.PrivateItems.title.item.title">Private Items by Title</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.title">Private Items by Title</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateissued">Private Items by Issue Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateissued">Private Items by Issue Date</message>
+
+	<message key="xmlui.Administrative.PrivateItems.title.item.dateaccessioned">Private Items by Submit Date</message>
+	<message key="xmlui.Administrative.PrivateItems.trail.item.dateaccessioned">Private Items by Submit Date</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CollectionViewer.java -->
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.search_scope">Область пошуку</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.all_of_dspace">Всі колекції</message>
@@ -212,7 +206,7 @@
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.browse_dates">Дати</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.advanced_search_link">Розширений пошук</message>
 	<message key="xmlui.ArtifactBrowser.CollectionViewer.head_recent_submissions">Останні додані</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.CommunityBrowser.java -->
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.title">Список фондів</message>
 	<message key="xmlui.ArtifactBrowser.CommunityBrowser.trail">Список фондів</message>
@@ -231,8 +225,8 @@
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_communities">Під-фонди цього фонду</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_sub_collections">Колекції в цьому фонді:</message>
 	<message key="xmlui.ArtifactBrowser.CommunityViewer.head_recent_submissions">Останні додані</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Contact.java -->
 	<message key="xmlui.ArtifactBrowser.Contact.title">Зворотній зв'язок</message>
 	<message key="xmlui.ArtifactBrowser.Contact.trail">Зворотній зв'язок</message>
@@ -241,7 +235,7 @@
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_label">On-line форма</message>
 	<message key="xmlui.ArtifactBrowser.Contact.feedback_link">Зворотній зв'язок</message>
 	<message key="xmlui.ArtifactBrowser.Contact.email">Email</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackForm.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.title">Зворотній зв'язок</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.trail">Зворотній зв'язок</message>
@@ -251,23 +245,21 @@
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.email_help">Ця адреса буде використана для відповіді на ваш вігук.</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.comments">Відгук</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackForm.submit">Надіслати відгук</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.FeedbackSent.java -->
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.title">Зворотній зв'язок</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.trail">Зворотній зв'язок</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.head">Відгук надіслано</message>
 	<message key="xmlui.ArtifactBrowser.FeedbackSent.para1">Ваш відгук отримано.</message>
-	
-	<!-- org.dspace.app.xmlui.artifactbrowser.FrontPageSearch.java -->
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.head">Пошук</message>
-	<message key="xmlui.ArtifactBrowser.FrontPageSearch.para1">Введіть текст для пошуку:</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.ItemViewer.java -->
 	<message key="xmlui.ArtifactBrowser.ItemViewer.trail">Перегляд матеріалів</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.head_parent_collections">Даний матеріал зустрічається у наступних фондах</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_simple">Показати скорочений опис матеріалу</message>
 	<message key="xmlui.ArtifactBrowser.ItemViewer.show_full">Показати повний опис матеріалу</message>
-	
+
+        <message key="xmlui.ArtifactBrowser.ItemViewer.withdrawn">This item has been withdrawn and is no longer available.</message>
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.Navigation.java -->
 	<message key="xmlui.ArtifactBrowser.Navigation.head_browse">Перегляд</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_all_of_dspace">Всі матеріали</message>
@@ -279,14 +271,14 @@
 	<message key="xmlui.ArtifactBrowser.Navigation.browse_dateaccessioned">За датою додання</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_collection">Колекція</message>
 	<message key="xmlui.ArtifactBrowser.Navigation.head_this_community">Фонд</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.SimpleSearch.java -->
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.title">Пошук</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.trail">Пошук</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.head">Пошук</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.search_scope">Область пошуку</message>
 	<message key="xmlui.ArtifactBrowser.SimpleSearch.full_text_search">Повнотекстовий пошук</message>
-	
+
 	<!-- org.dspace.app.xmlui.artifactbrowser.RestrictedItem.java -->
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.title">Даний матеріал недоступний</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.trail">Недоступно</message>
@@ -306,9 +298,15 @@
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_item">матеріал</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.type_resource">ресурс</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.unknown">невідомо</message>
-	
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.login">Proceed to login screen</message>
+
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.head_item_withdrawn">This item is withdrawn</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_withdrawn">The selected item is withdrawn and is no longer available.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted_auth">The selected item is access restricted and requires credentials to view. Please login to access the item.</message>
+        <message key="xmlui.ArtifactBrowser.RestrictedItem.para_item_restricted">Your user account does not have the credentials to view this item. Please contact the system administrator if you have any questions.</message>
+        
 	<!-- Authentication messages used at the top of the login page:  -->
-	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Матеріал недоступний</message>	
+	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_header">Матеріал недоступний</message>
 	<message key="xmlui.ArtifactBrowser.RestrictedItem.auth_message">Запрошений вами матеріал має обмеження перегляду. Для доступу до нього ввійдіть в систему.</message>
 
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.choose_month">Щомісячні звіти</message>
@@ -318,34 +316,140 @@
     <message key="xmlui.ArtifactBrowser.StatisticsViewer.no_report.text">There are currently no reports available for this service.  Please check back later.</message>
 
     <!-- Authentication messages used for bitstream authentication -->
-	<message key="xmlui.BitstreamReader.auth_header">Файл конфіденційний</message>	
+	<message key="xmlui.BitstreamReader.auth_header">Файл конфіденційний</message>
 	<message key="xmlui.BitstreamReader.auth_message">Запрошений вами файл має обмеження перегляду. Для доступу до нього ввійдіть в систему.</message>
-	
+
 	<!-- Export Archive download messages -->
 	<message key="xmlui.ItemExportDownloadReader.auth_header">Даний експортний архів конфіденційний.</message>
 	<message key="xmlui.ItemExportDownloadReader.auth_message">Запрошений вами експортний архів має обмеження перегляду. Для доступу до нього ввійдіть в систему.</message>
 
+
+	<!-- REQUEST COPY -->
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.title">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.trail">Request a copy of the document</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.head">Request a copy of the document</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login_para">Users of this system, can login to view this document.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.login">Login</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestForm.para1">Enter the following information to request a copy of the document from the responsible person.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail">Your e-mail address</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail_help">This email address is used for sending the document.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterEmail.error">E-mail is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.message.error">Message is mandatory</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.files">Files</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.allFiles">All files (of this document) in restricted access.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.notAllFiles">Only The requested file.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.requesterName.error">Name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestForm.submit">Request copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestSent.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.title">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.trail">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.head">Your request has been sent.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestSent.para1">Your request has been sent to the author or responsible person.</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseDecisionForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para1">IF YOU ARE THE AUTHOR (OR AN AUTHOR) OF DOCUMENT "{0}" use the buttons to answer the user's request.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.para2">This repository will propose an appropriate model reply, which you may edit.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactRequester">Initial reply to requester</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.contactAuthor"> Author permission request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.send">Send copy</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseDecisionForm.dontSend">Don't send copy</message>
+
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseTrueForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.para1">This is the text to be sent to the applicant.</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseFalseForm.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.title">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.trail">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.head">Document copy request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.para1">This is the text to be sent to the applicant (together with the document).</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.message">Message</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.subject">Subject</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.mail">Send</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestResponseTrueForm.back">Back</message>
+	
+	 <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestChangeStatusForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.title">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.trail">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.head">Change permissions request</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.para1">You may use this occasion to reconsider the access restrictions on the document (to avoid having to respond to these requests), if there is no reason to keep it restricted. To do so, after inserting your name and e-mail (for authentication), click the button "Change to Open Access".</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name">Name</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email">E-mail</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.name.error">The name is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.email.error">The e-mail address is required</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestChangeStatusForm.changeToOpen">Change to open access</message>
+	        
+	<!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseFalseForm.java -->
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.title">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.trail">Request sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.head">Your request to change permissions has been sent</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para1">Your request has been sent to the administrator</message>
+	<message key="xmlui.ArtifactBrowser.ItemRequestStatusChanged.para2">Thanks</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactRequester.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.para1">Initial communication with the requester, to let them know their request is being processed.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactRequester.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestContactAuthor.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.title">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.trail">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.head">Document copy request</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.para1">This is the text to be sent to the applicant (together with the document).</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.toEmail">To</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.subject">Subject</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.message">Message</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.mail">Send</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestContactAuthor.back">Back</message>
+
+    <!-- org.dspace.app.xmlui.artifactbrowser.ItemRequestResponseSent.java -->
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.title">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.trail">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.head">Your response has been sent.</message>
+    <message key="xmlui.ArtifactBrowser.ItemRequestResponseSent.para1">Your response has been sent.</message>
+
+
+	
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                EPerson Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
 	<!-- General keys used by the EPerson aspect -->
 	<message key="xmlui.EPerson.trail_new_registration">Реєстрація нового користувача</message>
 	<message key="xmlui.EPerson.trail_forgot_password">Відновлення паролю</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.CannotRegister.java -->
 	<message key="xmlui.EPerson.CannotRegister.title">Реєстрація недоступна</message>
 	<message key="xmlui.EPerson.CannotRegister.head">Реєстрація недоступна</message>
-	<message key="xmlui.EPerson.CannotRegister.para1">На даний момент реєстрація заборонена. Зв'язок з <a href="../contact">адміністратором</a> </message>
-	
+	<message key="xmlui.EPerson.CannotRegister.para1">На даний момент реєстрація заборонена. Зв'язок з <a href="../contact">site administrator</a> with questions or comments.</message>
+
 	<!-- org.dspace.app.xmlui.eperson.EditProfile.java -->
 	<message key="xmlui.EPerson.EditProfile.title_update">Оновити профіль</message>
 	<message key="xmlui.EPerson.EditProfile.title_create">Створити профіль</message>
@@ -373,7 +477,7 @@
 	<message key="xmlui.EPerson.EditProfile.head_auth">Групи, в які ви входите</message>
 	<message key="xmlui.EPerson.EditProfile.head_identify">Identify</message>
 	<message key="xmlui.EPerson.EditProfile.head_security">Security</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.EPersonUtils.java -->
 	<message key="xmlui.EPerson.EPersonUtils.register_verify_email">Підтвердіть Email</message>
 	<message key="xmlui.EPerson.EPersonUtils.register_create_profile">Створити профіль</message>
@@ -386,14 +490,14 @@
 	<message key="xmlui.EPerson.ForgotPasswordFinished.title">Пароль скинуто</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.head">Пароль скинуто</message>
 	<message key="xmlui.EPerson.ForgotPasswordFinished.para1">Ваш пароль скинуто.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.InvalidToken.java -->
 	<message key="xmlui.EPerson.InvalidToken.title">Invalid token</message>
 	<message key="xmlui.EPerson.InvalidToken.trail">Invalid token</message>
 	<message key="xmlui.EPerson.InvalidToken.head">Invalid token</message>
 	<message key="xmlui.EPerson.InvalidToken.para1">Вказана Вами URL недійсна. URL можливо записана невірно через ваш email клієнт, наприклад:</message>
 	<message key="xmlui.EPerson.InvalidToken.para2">Якщо так, скопіюйте та вставте URL в адресну строку вашого веб браузеру повністю, а не просто клікайте на посилання. Адресна строка має містити щось подібне до:</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.Navigation.java -->
 	<message key="xmlui.EPerson.Navigation.my_account">Мій профіль</message>
 	<message key="xmlui.EPerson.Navigation.profile">Профіль</message>
@@ -405,7 +509,6 @@
 	<message key="xmlui.EPerson.PasswordLogin.title">Вхід</message>
 	<message key="xmlui.EPerson.PasswordLogin.trail">Вхід</message>
 	<message key="xmlui.EPerson.PasswordLogin.head1">Вхід</message>
-	<message key="xmlui.EPerson.PasswordLogin.title">Вхід</message>
 	<message key="xmlui.EPerson.PasswordLogin.email_address">E-Mail адреса</message>
 	<message key="xmlui.EPerson.PasswordLogin.error_bad_login">Введено неправильні email або пароль.</message>
 	<message key="xmlui.EPerson.PasswordLogin.password">Пароль</message>
@@ -414,17 +517,16 @@
 	<message key="xmlui.EPerson.PasswordLogin.head2">Реєстрація нового користувача</message>
 	<message key="xmlui.EPerson.PasswordLogin.para1">Зареєструйтесь для оповіщення по email про появу нових матеріалів у обраних вами фондах та колекціях, а також для публікації власних матеріалів.</message>
 	<message key="xmlui.EPerson.PasswordLogin.register_link">Натисніть тут для реєстрації.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LDAPLogin.java -->
 	<message key="xmlui.EPerson.LDAPLogin.title">Вхід</message>
 	<message key="xmlui.EPerson.LDAPLogin.trail">Вхід</message>
 	<message key="xmlui.EPerson.LDAPLogin.head1">Вхід</message>
-	<message key="xmlui.EPerson.LDAPLogin.title">Вхід</message>
 	<message key="xmlui.EPerson.LDAPLogin.username">Ім'я користувача</message>
 	<message key="xmlui.EPerson.LDAPLogin.error_bad_login">Введено неправильне ім'я чи пароль.</message>
 	<message key="xmlui.EPerson.LDAPLogin.password">Пароль</message>
 	<message key="xmlui.EPerson.LDAPLogin.submit">Вхід</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.LoginChooser.java -->
 	<message key="xmlui.EPerson.LoginChooser.title">Choose a Login Method</message>
 	<message key="xmlui.EPerson.LoginChooser.trail">Choose Login</message>
@@ -442,24 +544,24 @@
 	<message key="xmlui.EPerson.FailedAuthentication.title">Authentication Failed</message>
     <message key="xmlui.EPerson.FailedAuthentication.trail">Failed Authentication</message>
     <message key="xmlui.EPerson.FailedAuthentication.h1">Authentication Failed</message>
-	
+
 	<!-- Login xml files -->
 	<message key="xmlui.eperson.noAuthMethod.head">No Authentication Method Found</message>
 	<message key="xmlui.eperson.noAuthMethod.p1">No authentication method was found.  Please contact the site administrator.</message>
 	<message key="xmlui.eperson.shibbLoginFailure.head">Shibboleth Login Failed</message>
 	<message key="xmlui.eperson.shibbLoginFailure.p1">Shibboleth authentication not available at this time. Please contact the site administrator.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ProfileUpdated.java -->
 	<message key="xmlui.EPerson.ProfileUpdated.title">Профіль оновлено</message>
 	<message key="xmlui.EPerson.ProfileUpdated.trail">Профіль оновлено</message>
 	<message key="xmlui.EPerson.ProfileUpdated.head">Профіль оновлено</message>
 	<message key="xmlui.EPerson.ProfileUpdated.para1">Ваш профіль було оновлено.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.RegistrationFinished.java -->
 	<message key="xmlui.EPerson.RegistrationFinished.title">Реєстрація завершена</message>
 	<message key="xmlui.EPerson.RegistrationFinished.head">Реєстрація завершена</message>
 	<message key="xmlui.EPerson.RegistrationFinished.para1">Тепер ви зареєстрований користувач. Ви можете підписатись на отримання розсилки по email.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.ResetPassword.java -->
 	<message key="xmlui.EPerson.ResetPassword.title">Оновити пароль</message>
 	<message key="xmlui.EPerson.ResetPassword.head">Оновити пароль</message>
@@ -470,7 +572,7 @@
 	<message key="xmlui.EPerson.ResetPassword.submit">Оновити пароль</message>
 	<message key="xmlui.EPerson.ResetPassword.error_invalid_password">Мінімальна довжина пароля 6 символів.</message>
 	<message key="xmlui.EPerson.ResetPassword.error_unconfirmed_password">Павторіть пароль для підтвердження.</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartForgotPassword.java -->
 	<message key="xmlui.EPerson.StartForgotPassword.title">Відновити пароль</message>
 	<message key="xmlui.EPerson.StartForgotPassword.head">Відновити пароль</message>
@@ -479,7 +581,7 @@
 	<message key="xmlui.EPerson.StartForgotPassword.email_address_help">Введіть email адресу, яку вводили при реєстрації.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.error_not_found">Email адреса не знайдена.</message>
 	<message key="xmlui.EPerson.StartForgotPassword.submit">Відправити</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.StartRegistration.java -->
 	<message key="xmlui.EPerson.StartRegistration.title">Реєстрація нового користувача</message>
 	<message key="xmlui.EPerson.StartRegistration.head1">Ця email адреса вже використовується</message>
@@ -492,7 +594,7 @@
 	<message key="xmlui.EPerson.StartRegistration.email_address_help">Ця адреса буде використовуватись як ваш логін(ім'я при вході).</message>
 	<message key="xmlui.EPerson.StartRegistration.error_bad_email">Неможливо дівправити email за вказаною адресою.</message>
 	<message key="xmlui.EPerson.StartRegistration.submit_register">Реєстрація</message>
-	
+
 	<!-- org.dspace.app.xmlui.eperson.VerifyEmail.java -->
 	<message key="xmlui.EPerson.VerifyEmail.title">Лист для підтвердження надіслано</message>
 	<message key="xmlui.EPerson.VerifyEmail.head">Лист для підтвердження надіслано</message>
@@ -504,12 +606,12 @@
 
 
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		               Submission Aspect
-		
-		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->	
-	
-	
+
+		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+
 
 
 
@@ -520,7 +622,7 @@
 	<message key="xmlui.Submission.general.go_mydspace">До моїх наукових робіт</message>
 	<message key="xmlui.Submission.general.submission.title">Додання матеріалів</message>
 	<message key="xmlui.Submission.general.submission.trail">Додання матеріалів</message>
-	<message key="xmlui.Submission.general.submission.head">Додання матеріалів</message>	
+	<message key="xmlui.Submission.general.submission.head">Додання матеріалів</message>
 	<message key="xmlui.Submission.general.submission.previous">&lt; Назад</message>
 	<message key="xmlui.Submission.general.submission.save">Зберегти та вийти</message>
 	<message key="xmlui.Submission.general.submission.next">Далі &gt;</message>
@@ -532,25 +634,25 @@
 	<message key="xmlui.Submission.general.showsimple">Показати скорчений опис матеріалу</message>
 	<message key="xmlui.Submission.general.default.title">Submission</message>
 	<message key="xmlui.Submission.general.default.trail">Submission</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.CollectiovViewer -->
 	<message key="xmlui.Submission.CollectionViewer.link1">Додати новий матеріал до колекції</message>
-	
+
 	<!-- org.dspace.app.xmlui.submission.Navigation -->
 	<message key="xmlui.Submission.Navigation.submissions">Додати нові матеріали</message>
 
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submissions -->
 	<message key="xmlui.Submission.Submissions.title">Додання нових матеріалів</message>
 	<message key="xmlui.Submission.Submissions.trail">Нові матеріали</message>
 	<message key="xmlui.Submission.Submissions.head">Нові матеріали</message>
-	<message key="xmlui.Submission.Submissions.untitled"><i>Немає даних</i></message>
+	<message key="xmlui.Submission.Submissions.untitled"><i>Untitled</i></message>
 	<message key="xmlui.Submission.Submissions.email">email: </message>
 	<!-- Same transformer, workflow section -->
 	<message key="xmlui.Submission.Submissions.workflow_head1">Завдання робочого процесу</message>
 	<message key="xmlui.Submission.Submissions.workflow_info1">Ці завдання - матеріали, які очікують затвердження перед тим як будуть додані до репозитарію. Тут є дві черги, одна черга для матеріалів які затверджуєте ви, інша - для ваших матеріалів які ще не були розглянуті.</message>
 	<message key="xmlui.Submission.Submissions.workflow_head2">Ваші завдання</message>
-	<message key="xmlui.Submission.Submissions.workflow_column1"></message>
+	<message key="xmlui.Submission.Submissions.workflow_column1"/>
 	<message key="xmlui.Submission.Submissions.workflow_column2">Завдання</message>
 	<message key="xmlui.Submission.Submissions.workflow_column3">Елемент</message>
 	<message key="xmlui.Submission.Submissions.workflow_column4">Колекція</message>
@@ -569,7 +671,7 @@
 	<message key="xmlui.Submission.Submissions.submit_info2a">Не всі матеріали офоромлено до кінця. Ви можете продовжити роботу з ними, або</message>
 	<message key="xmlui.Submission.Submissions.submit_info2b">додати нові матеріали</message>
 	<message key="xmlui.Submission.Submissions.submit_info2c">.</message>
-	<message key="xmlui.Submission.Submissions.submit_column1"></message>
+	<message key="xmlui.Submission.Submissions.submit_column1"/>
 	<message key="xmlui.Submission.Submissions.submit_column2">Заголовок</message>
 	<message key="xmlui.Submission.Submissions.submit_column3">Колецкія</message>
 	<message key="xmlui.Submission.Submissions.submit_column4">Хто додав матеріал</message>
@@ -593,16 +695,26 @@
 	<message key="xmlui.Submission.Submissions.status_6">Надходження редагується редактором</message>
 	<message key="xmlui.Submission.Submissions.status_7">Надходження прийнято і архівовано</message>
 	<message key="xmlui.Submission.Submissions.status_unknown">Невідома стадія</message>
+        <!-- Same transformer, completed submissions section -->
+        <message key="xmlui.Submission.Submissions.completed.head">Archived Submissions</message>
+        <message key="xmlui.Submission.Submissions.completed.info">These are your completed submissions which have been accepted into DSpace.</message>
+        <message key="xmlui.Submission.Submissions.completed.column1">Date accepted</message>
+        <message key="xmlui.Submission.Submissions.completed.column2">Title</message>
+        <message key="xmlui.Submission.Submissions.completed.column3">Collection</message>
+        <message key="xmlui.Submission.Submissions.completed.limit">We've only listed 50 of your archived submissions above. </message>
+        <message key="xmlui.Submission.Submissions.completed.displayall">Display all my archived submissions.</message>
 
 	<!-- submission progress bar messages -->
 	<message key="xmlui.Submission.submit.progressbar.initial-questions">Стартові запитання</message>
 	<message key="xmlui.Submission.submit.progressbar.describe">Опис</message>
-	<message key="xmlui.Submission.submit.progressbar.upload">Завантаження</message>
+    <message key="xmlui.Submission.submit.progressbar.access">Access</message>
+    <message key="xmlui.Submission.submit.progressbar.upload">Завантаження</message>
 	<message key="xmlui.Submission.submit.progressbar.verify">Перевірка</message>
 	<message key="xmlui.Submission.submit.progressbar.creative-commons">Creative Commons</message>
-	<message key="xmlui.Submission.submit.progressbar.license">License</message>
+	<message key="xmlui.Submission.submit.progressbar.CClicense">CC License</message>
+    <message key="xmlui.Submission.submit.progressbar.license">License</message>
 	<message key="xmlui.Submission.submit.progressbar.complete">Complete</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.ResumeStep -->
 	<message key="xmlui.Submission.submit.ResumeStep.submit_resume">Продовжити</message>
 
@@ -619,7 +731,7 @@
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_save">Зберегти, я продовжу роботу з матеріалом пізніше</message>
 	<message key="xmlui.Submission.submit.SaveOrRemoveStep.submit_remove">Видалити цей матеріал</message>
 
-	
+
 	<!-- org.dpspace.app.xmlui.Submission.submit.InitialQuestionsStep -->
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.head">Стартові запитання</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.important_note">Увага: </message>
@@ -628,7 +740,7 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.open_set"> (</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.close_set">)</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles">Декілька заголовків</message>
-	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Матеріал має більш ніж один заголовок, наприклад мовою оригіналу та перекладений.</message>
+	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_help">Матеріал має більш ніж один заголовок, наприклад мовою оригіналу та перекладений.<i>e.g. a translated title</i></message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.multiple_titles_note">If the checkbox above is unchecked then the following title(s) will be removed from the item: </message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before">Публікції</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.published_before_help">Матеріал раніше публікувався.</message>
@@ -636,27 +748,76 @@
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.date_issued">Дата публікації</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.citation">Цитування</message>
 	<message key="xmlui.Submission.submit.InitialQuestionsStep.publisher">Видавник</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.DescribeStep -->
 	<message key="xmlui.Submission.submit.DescribeStep.head">Опис</message>
 	<message key="xmlui.Submission.submit.DescribeStep.unknown_field">Помилка: невідомий тип файлу</message>
 	<message key="xmlui.Submission.submit.DescribeStep.required_field">Це поле обов'язкове для заповнення</message>
-	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Прізвище</message>
-	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Ім'я, по батькові</message>
+	<message key="xmlui.Submission.submit.DescribeStep.last_name_help">Прізвище<i>e.g. Smith</i></message>
+	<message key="xmlui.Submission.submit.DescribeStep.first_name_help">Ім'я, по батькові<i>e.g. Donald Jr</i></message>
 	<message key="xmlui.Submission.submit.DescribeStep.year">Рік</message>
 	<message key="xmlui.Submission.submit.DescribeStep.month">Місяць</message>
 	<message key="xmlui.Submission.submit.DescribeStep.day">День</message>
 	<message key="xmlui.Submission.submit.DescribeStep.series_name">Series Name</message>
 	<message key="xmlui.Submission.submit.DescribeStep.report_no">Report or paper No.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.link">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.title">Subject Categories</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.label">Filter subjects</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.filter.button">Filter</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.loading">Please wait while the controlled vocabulary is loading.</message>
+	<message key="xmlui.Submission.submit.DescribeStep.controlledvocabulary.error">There was an issue when loading the controlled vocabulary, please try again later.</message>
 
-	<!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
+
+    <!-- org.dspace.app.xmlui.Submission.submit.AccessStep -->
+    <message key="xmlui.Submission.submit.AccessStep.head">Access Settings</message>
+    <message key="xmlui.Submission.submit.AccessStep.access_settings">Visible to a group of selected users (no selection needed for Anonymous)</message>
+    <message key="xmlui.Submission.submit.AccessStep.open_access">Allow access once item is accepted into archive</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo">Embargo until specific date</message>
+    <message key="xmlui.Submission.submit.AccessStep.embargo_visible">Access for selected group</message>
+    <message key="xmlui.Submission.submit.AccessStep.name">Policy name</message>
+    <message key="xmlui.Submission.submit.AccessStep.name_help">A short, descriptive name for the policy (up to 30 characters). May be shown to end users. Example: "Staff-only". Optional but recommended.</message>
+    <message key="xmlui.Submission.submit.AccessStep.description">Description</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason">Embargo reason</message>
+    <message key="xmlui.Submission.submit.AccessStep.reason_help">The reason for the embargo, typically for internal use only. Optional.</message>
+    <message key="xmlui.Submission.submit.AccessStep.submit_add_policy">Confirm Policy &amp; add another</message>
+    <message key="xmlui.Submission.submit.AccessStep.list_assigned_groups">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_format_date">Error format date</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_missing_date">When Embargo selected, date is required</message>
+    <message key="xmlui.Submission.submit.AccessStep.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_policies">Group policies</message>
+    <message key="xmlui.Submission.submit.AccessStep.policies_help">Policies listed in this section override any default policies for the collection you're submitting to. If you wish to set an embargo but the target collection allows access for any user, you must set a policy that allows access for the Anonymous group only from a specific date onwards.</message>
+    <message key="xmlui.Submission.submit.AccessStep.no_policies">No group policies have been set up for this item.</message>
+    <message key="xmlui.Submission.submit.AccessStep.new_policy_head">Embargo</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings">Private item</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_help">If selected, the item won't be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.private_settings_label">Private</message>
+    <message key="xmlui.Submission.submit.AccessStep.column0">Name</message>
+    <message key="xmlui.Submission.submit.AccessStep.column1">Action</message>
+    <message key="xmlui.Submission.submit.AccessStep.column2">Group</message>
+    <message key="xmlui.Submission.submit.AccessStep.column3">Start Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.column4">End Date</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_edit_button">Edit</message>
+    <message key="xmlui.Submission.submit.AccessStep.table_delete_button">Remove</message>
+    <message key="xmlui.administrative.authorization.AccessStep.label_date_help">The first day from which access is allowed. Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_policy_line">Name: {0}; action: {1}, group: {2}, start date: {3}, end date: {4}</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_public_item">The item will be searchable</message>
+    <message key="xmlui.Submission.submit.AccessStep.review_private_item">The item will not be searchable</message>
+
+
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditPolicyStep -->
+    <message key="xmlui.Submission.submit.EditPolicyStep.head">Edit Policy</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.UploadStep -->
 	<message key="xmlui.Submission.submit.UploadStep.head">Завантажити файл(и)</message>
 	<message key="xmlui.Submission.submit.UploadStep.file">Файл</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_help">Вкажіть повний шлях до файла на вашому компютері, або натисніть кнопку і оберіть необхідний файл.</message>
 	<message key="xmlui.Submission.submit.UploadStep.file_error">Матеріал має містити хоча б один файл</message>
 	<message key="xmlui.Submission.submit.UploadStep.upload_error">При завантаженні вказаного файла виникла помилка. Це могло статись з наступних прицин: імя'я файлу вказано невірно, або помилка в мережі - неможливо отримати файл, або ж формат файлу, який ви намагаєтесь додати, заборонений для розміщення. Будь-ласка спробуйте ще раз.</message>
-	<message key="xmlui.Submission.submit.UploadStep.description">Опис файла</message>
-	<message key="xmlui.Submission.submit.UploadStep.description_help">Короткий опис файла, наприклад "основна стаття", "результати експериментів".</message>
+	<message key="xmlui.Submission.submit.UploadStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadStep.description">Опис файла</message>
+	<message key="xmlui.Submission.submit.UploadStep.description_help">Короткий опис файла, наприклад "основна стаття", "результати експериментів".<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_upload">Завантажити цей файл, а потім іще один</message>
 	<message key="xmlui.Submission.submit.UploadStep.head2">Завантажені файли</message>
 	<message key="xmlui.Submission.submit.UploadStep.column0">Основний файл</message>
@@ -665,7 +826,7 @@
 	<message key="xmlui.Submission.submit.UploadStep.column3">Розмір</message>
 	<message key="xmlui.Submission.submit.UploadStep.column4">Опис</message>
 	<message key="xmlui.Submission.submit.UploadStep.column5">Формат</message>
-	<message key="xmlui.Submission.submit.UploadStep.column6"></message>
+	<message key="xmlui.Submission.submit.UploadStep.column6"/>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_name">Невідомий</message>
 	<message key="xmlui.Submission.submit.UploadStep.unknown_format">невідомий формат</message>
 	<message key="xmlui.Submission.submit.UploadStep.supported">(Підтримуваний)</message>
@@ -674,19 +835,54 @@
 	<message key="xmlui.Submission.submit.UploadStep.submit_edit">Змінити</message>
 	<message key="xmlui.Submission.submit.UploadStep.checksum">Контрольна сума:</message>
 	<message key="xmlui.Submission.submit.UploadStep.submit_remove">Видалити позначені файли</message>
-	
+
+
+
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head">Upload File(s)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_help">Please enter the full path of the file on your computer corresponding to your item. If you click "Browse...", a new window will allow you to select the file from your computer.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.file_error">The item must contain at least one file.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.upload_error">There was a problem uploading your file. Either the filename you entered was incorrect, there was a network problem which prevented the file from reaching us correctly, or you have attempted to upload a file format marked for internal system use only. Please try again.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_error">The file has not been uploaded as it appears to contain a virus. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.virus_checker_error">A technical problem was encountered whilst attempting to scan the file for viruses. Please contact the system administrator.</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description">File Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.description_help">Optionally, provide a brief description of the file, for example "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_upload">Upload file &amp; add another</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.head2">Files Uploaded</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column0">Primary</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column1">  </message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column2">File</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column3">Size</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column4">Description</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column5">Format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.column6"/>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_name">Unknown</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unknown_format">unknown format</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.supported">(Supported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.known">(Known)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.unsupported">(Unsupported)</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_edit">Edit</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.checksum">File checksum:</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_remove">Remove selected files</message>
+    <message key="xmlui.Submission.submit.UploadWithEmbargoStep.submit_policy">Policies</message>
+
+
 	<!-- org.dspace.app.xmlui.Submission.submit.EditFileStep -->
 	<message key="xmlui.Submission.submit.EditFileStep.head">Змінити файл</message>
 	<message key="xmlui.Submission.submit.EditFileStep.file">Ім'я</message>
 	<message key="xmlui.Submission.submit.EditFileStep.description">Опис файла</message>
-	<message key="xmlui.Submission.submit.EditFileStep.description_help">Короткий опис файла, наприклад "<i>основна стаття</i>", чи "<i>Результати експеримента</i>".</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info1">Оберіть формат файла зі списка, на приклад "<i>Adobe PDF</i>" чи "<i>Microsoft Word</i>." <strong> Якщо необхідного формату в списку немає</strong>, будь-ласка вкажіть його у полі що знаходиться під списком доступних форматів.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.description_help">Короткий опис файла, наприклад "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info1">Оберіть формат файла зі списка, на приклад "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>." <strong>If the format is not in the list</strong>, please describe it in the input box below the list.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_detected">Автоматично-визначений формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_selected">Обраний формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_default">Формат відсутній у списку</message>
-	<message key="xmlui.Submission.submit.EditFileStep.info2">Якщо необхідного формату в списку немає, будь-ласка <strong>оберіть "Формат відсутній у списку"</strong> та вкажіть необхідний формат у полі що знаходиться під списком доступних форматів.</message>
+	<message key="xmlui.Submission.submit.EditFileStep.info2">Якщо необхідного формату в списку немає, будь-ласка <strong>select "format not in list" above</strong> and describe the file's format in the box below.</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user">Інший формат</message>
 	<message key="xmlui.Submission.submit.EditFileStep.format_user_help">Вкажіть ім'я програми, якою було створено цей файл, версію цієї програми (наприклад, "<i>ACMESoft SuperApp version 1.5</i>").</message>
+
+    <!-- org.dspace.app.xmlui.Submission.submit.EditBitstreamPolicies -->
+    <message key="xmlui.Submission.submit.EditBitstreamPolicies.head">Bitstream Access</message>
+
 
 	<!-- org.dspace.app.xmlui.Submission.submit.ReviewStep -->
 	<message key="xmlui.Submission.submit.ReviewStep.head">Перевірка</message>
@@ -703,14 +899,17 @@
 	<message key="xmlui.Submission.submit.ReviewStep.unknown">невідомо</message>
 	<message key="xmlui.Submission.submit.ReviewStep.known">відомо</message>
 	<message key="xmlui.Submission.submit.ReviewStep.supported">підтримувано</message>
-	
+
 	<!-- org.dspace.app.xmlui.Submission.submit.CCLicenseStep -->
-	<message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons License</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.info1">If you wish, you may add a <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong> If you wish to select a Creative Commons license click the button below. You will be taken to the Creative Commons website, where you will be presented with several licensing options.  After selecting a license, you will be returned to this page.</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Proceed to Creative Commons website to select a license</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.license">Ліцензія</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.submit_remove">Remove this Creative Commons License</message>
-	<message key="xmlui.Submission.submit.CCLicenseStep.no_license">no creative commons license selected</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.ccws_error">An error occurred ... {0}</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.head">Creative Commons License</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.info1">If you wish, you may add a <a href="http://creativecommons.org/">Creative Commons</a> License to your item. <strong>Creative Commons licenses govern what people who read your work may then do with it.</strong></message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_choose_creative_commons">Choose a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.submit_to_creative_commons">Proceed to Creative Commons website to select a license</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.license">Ліцензія</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.select_change">Select or modify your license ...</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.no_license">no creative commons license selected</message>
+        <message key="xmlui.Submission.submit.CCLicenseStep.save_changes">You must click Next to save your changes.</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.LicenseStep -->
 	<message key="xmlui.Submission.submit.LicenseStep.head">Distribution License</message>
@@ -724,13 +923,13 @@
 	<!-- org.dspace.app.xmlui.Submission.submit.RemovedStep -->
 	<message key="xmlui.Submission.submit.RemovedStep.head">Надходження видалено</message>
 	<message key="xmlui.Submission.submit.RemovedStep.info1">Ваше надходження було видалено із системи, разом із усіма його матеріалами.</message>
-	<message key="xmlui.Submission.submit.RemovedStep.go_submission">На сторінку додання матеріалів</message>	
+	<message key="xmlui.Submission.submit.RemovedStep.go_submission">На сторінку додання матеріалів</message>
 
 	<!-- org.dspace.app.xmlui.Submission.submit.CompletedStep -->
-	<message key="xmlui.Submission.submit.CompletedStep.head">Новий матеріал успішно додано</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.info1">Тепер ваш матеріал буде додано до колекції, після чого вам надійде e-mail повідомлення.</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Перейти до сторінки нових матеріалів</message>	
-	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Додати нові матеріали</message>		
+	<message key="xmlui.Submission.submit.CompletedStep.head">Новий матеріал успішно додано</message>
+	<message key="xmlui.Submission.submit.CompletedStep.info1">Тепер ваш матеріал буде додано до колекції, після чого вам надійде e-mail повідомлення.</message>
+	<message key="xmlui.Submission.submit.CompletedStep.go_submission">Перейти до сторінки нових матеріалів</message>
+	<message key="xmlui.Submission.submit.CompletedStep.submit_again">Додати нові матеріали</message>
 
 	<!-- org.dspace.app.xmlui.Submission.workflow.PerformTaskStep -->
 	<message key="xmlui.Submission.workflow.PerformTaskStep.info1">Дії, доступні для цього завдання:</message>
@@ -742,7 +941,7 @@
 	<message key="xmlui.Submission.workflow.PerformTaskStep.approve_submit">Затвердити матеріали</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_help">Якщо ви редагували матеріали, використайте цю опцію передачі для матеріалу в архів.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.commit_submit">Передати в архів</message>
-	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Якщо ви переглядали матеріали і вважаєте їх <strong>не</strong> відповідними колекції, натисніть "Відхилити". При цьому необхідно вказати чому матеріали невідповідають вимогам колекції і чи може користувач змінити щось та переподати їх.</message>
+	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_help">Якщо ви переглядали матеріали і вважаєте їх <strong>not</strong> suitable for inclusion in the collection, select "Reject".  You will then be asked to enter a message indicating why the item is unsuitable, and whether the submitter should change something and resubmit.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.reject_submit">Відхилити матеріали</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_help">Оберіть цю опцію для зміни метаданих матеріалу.</message>
 	<message key="xmlui.Submission.workflow.PerformTaskStep.edit_submit">Редагувати метадані</message>
@@ -755,18 +954,22 @@
 	<message key="xmlui.Submission.workflow.RejectTaskStep.reason_required">Потрібно обов'язково вказати причину</message>
 	<message key="xmlui.Submission.workflow.RejectTaskStep.submit_reject">Відхилити матеріали</message>
 
-	
-	
-	
+
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		             Administrative Aspect
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
-	
-	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer --> 	
-	
-	<message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Користувача успішно додано.</message>
+
+	<!-- action-generated messages. These are referenced from the sitemap rather than a transformer -->
+
+        <message key="xmlui.administrative.FlowCurationUtils.curate_success_notice">The task was completed successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.curate_failed_notice">The task exited unexpectedly or failed. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_success_notice">The task was queued successfully.</message>
+        <message key="xmlui.administrative.FlowCurationUtils.queue_failed_notice">The task could not be queued. An error occurred. For more information, please contact the site administrator or check your system logs.</message>
+        <message key="xmlui.administrative.FlowEPersonUtils.add_eperson_success_notice">Користувача успішно додано.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.edit_eperson_success_notice">Користувача успішно змінено.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.reset_password_success_notice">Користувачу було відправлено email повідомлення в якому міститься наступний крок для генерації нового пароля.</message>
 	<message key="xmlui.administrative.FlowEPersonUtils.delete_eperson_success_notice">Цей користувач(і) був успішно видалений.</message>
@@ -793,10 +996,10 @@
 	<message key="xmlui.administrative.FlowItemUtils.bitstream_delete">Обрані файли було видалено.</message>
 	<message key="xmlui.administrative.FlowMapperUtils.map_items">Матеріали упішно відображено(mapped).</message>
 	<message key="xmlui.administrative.FlowMapperUtils.unmaped_items">Матеріали не відоражено(unmapped).</message>
-	
+
 	<!-- general items for all of the eperson classes -->
 	<message key="xmlui.administrative.eperson.general.epeople_trail">Керувати E-people</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.Navigation -->
 	<!-- contextual menu items -->
 	<message key="xmlui.administrative.Navigation.context_head">Цей матеріал</message>
@@ -811,7 +1014,7 @@
         <message key="xmlui.administrative.Navigation.context_export_collection">Експорт колекції</message>
         <message key="xmlui.administrative.Navigation.context_export_community">Експортувати фонд</message>
         <message key="xmlui.administrative.Navigation.context_export_metadata">Метадані</message>
-	
+
 	<!-- Site administrator options -->
 	<message key="xmlui.administrative.Navigation.administrative_head">Адміністрування</message>
 	<message key="xmlui.administrative.Navigation.administrative_access_control">Контроль доступу</message>
@@ -821,16 +1024,20 @@
 	<message key="xmlui.administrative.Navigation.administrative_registries">Налаштування</message>
 	<message key="xmlui.administrative.Navigation.administrative_metadata">Метадані</message>
 	<message key="xmlui.administrative.Navigation.administrative_format">Формати файлів</message>
+    <message key="xmlui.administrative.Navigation.administrative_content">Content Administration</message>
 	<message key="xmlui.administrative.Navigation.administrative_items">Матеріали</message>
     <message key="xmlui.administrative.Navigation.administrative_withdrawn">Отримання елементів</message>
-	<message key="xmlui.administrative.Navigation.administrative_control_panel">Панель керування</message>
+    <message key="xmlui.administrative.Navigation.administrative_private">Private Items</message>
+    <message key="xmlui.administrative.Navigation.administrative_control_panel">Панель керування</message>
     <message key="xmlui.administrative.Navigation.statistics">Статистика</message>
+    <message key="xmlui.administrative.Navigation.administrative_batch_import">Batch Import (ZIP)</message>
         <message key="xmlui.administrative.Navigation.administrative_import_metadata">Імпорт метаданих</message>
+        <message key="xmlui.administrative.Navigation.administrative_curation">Curation Tasks</message>
 
     <!-- my account items -->
 	<message key="xmlui.administrative.Navigation.account_export">Мої матеріали</message>
-	
-	
+
+
 	<!-- export item -->
 	<message key="xmlui.administrative.ItemExport.head">Додані мною матеріали</message>
 	<message key="xmlui.administrative.ItemExport.item.id.error">Вказаний id(ідентифікатор) матеріалу не дійсний.</message>
@@ -843,7 +1050,7 @@
 	<message key="xmlui.administrative.ItemExport.collection.success">Колекція успішно експортована. TВам надійде e-mail лист коли архів буде готовий до завантаження. Також ви можете скористатись посиланням 'Додані мною матеріали' для перегляду доступних архівів.</message>
 	<message key="xmlui.administrative.ItemExport.community.success">Фонд успішно експортовано. Вам надійде e-mail лист коли архів буде готовий до завантаження. Також ви можете скористатись посиланням 'Додані мною матеріали' для перегляду доступних архівів.</message>
 	<message key="xmlui.administrative.ItemExport.available.head">Доступні для скачування архіви матеріалів:</message>
-	
+
 
 
     <!-- org.dspace.app.xmlui.administrative.eperson.ManageEPeopleMain -->
@@ -858,14 +1065,14 @@
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_help">Користувачі шукаються по будь-якому частковому збігу email адреси чи імені</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_para1">Список користувачів, які відповідають запиту. Ви можете позначити користувачів яких хочете видалити та видалити їх, натиснувши "Видалити користувачів". Або натиснути на імені/Email користувача, редагувати його.</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_head">Результати пошуку</message>
-	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"></message>
+	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column1"/>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column2">ID</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column3">Ім'я</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.search_column4">Email</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.submit_delete">Видалити користувачів</message>
 	<message key="xmlui.administrative.eperson.ManageEPeopleMain.no_results">За вашим запитом не знайдено жодного користувача...</message>
-		
-		
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.AddEPersonForm -->
 	<message key="xmlui.administrative.eperson.AddEPersonForm.title">Додати користувача</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.trail">Додати користувача</message>
@@ -879,7 +1086,7 @@
 	<message key="xmlui.administrative.eperson.AddEPersonForm.req_certs">Необхідний Сертифікат</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.can_log_in">Може входити в систему</message>
 	<message key="xmlui.administrative.eperson.AddEPersonForm.submit_create">Створити E-Person</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.EditEPersonForm -->
 	<message key="xmlui.administrative.eperson.EditEPersonForm.title">Змінити E-Person</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.trail">Змінити E-Person</message>
@@ -896,19 +1103,19 @@
 	<message key="xmlui.administrative.eperson.EditEPersonForm.special_help">Ви також перманентно видалити цього користувача E-Person з системи, або скинути його/її пароль. При скиданні паролю користувачу буде надіслано email лист, в якому міститиметься спеціальне посилання для створення нового паролю.</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_delete">Видалити E-Person</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.submit_login_as">Ввійти як E-Person</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint">Цей користувач E-Person не може бути видалений по одній з наступних причин:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.last_conjunction">і</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.item">eperson має архівовані матеріали, один чи більше</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.workflowitem">eperson має активні надходження/завдання для розгляду редактором відповідної колекції</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.tasklistitem">eperson має нерозглянуті завдання</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.delete_constraint.unknown">eperson маєневідомі зв'язки з системою</message>
-	
+
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_head">Групи, в які входить цей користувач E-Person:</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.indirect_member">(via group: {0})</message>
 	<message key="xmlui.administrative.eperson.EditEPersonForm.member_none">жодна</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.eperson.DeleteEPeopleConfirm -->
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.title">Підтвердити видалення E-Person</message>
 	<message key="xmlui.administrative.eperson.DeleteEPeopleConfirm.trail">Підтвердити видалення</message>
@@ -933,7 +1140,7 @@
 	<message key="xmlui.administrative.group.ManageGroupsMain.actions_search">Пошук групи</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_help">Пошук групи за їх назвою</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_head">Результати пошуку</message>
-	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"></message>
+	<message key="xmlui.administrative.group.ManageGroupsMain.search_column1"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column2">ID</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column3">Ім'я</message>
 	<message key="xmlui.administrative.group.ManageGroupsMain.search_column4">Члени</message>
@@ -965,24 +1172,24 @@
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column2">Ім'я</message>
 	<message key="xmlui.administrative.group.EditGroupForm.epeople_column3">Email</message>
-	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.epeople_column4"/>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column2">Ім'я</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column3">Члени</message>
 	<message key="xmlui.administrative.group.EditGroupForm.groups_column4">Колекції</message>
-	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"></message>
+	<message key="xmlui.administrative.group.EditGroupForm.groups_column5"/>
 	<message key="xmlui.administrative.group.ManageGroupsMain.groups_collection_link">перегляд</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_head">Члени</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column1">ID</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column2">Ім'я</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_column3">Email</message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_column4"></message>
-	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">група: {0}</message>	
+	<message key="xmlui.administrative.group.EditGroupForm.members_column4"/>
+	<message key="xmlui.administrative.group.EditGroupForm.members_group_name">група: {0}</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_none">В цій групі немає користувачів.</message>
 	<message key="xmlui.administrative.group.EditGroupForm.members_pending">[очікування]</message>
 	<message key="xmlui.administrative.group.EditGroupForm.instructions_para">Видалити учасника</message>
 	<message key="xmlui.administrative.group.EditGroupForm.collection_link_para">Видалити учасника</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.group.DeleteGroupsConfirm -->
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.title">Підвердити видалення групи</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.trail">Підтвердити видалення</message>
@@ -992,11 +1199,11 @@
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column2">Ім'я</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column3">E-People</message>
 	<message key="xmlui.administrative.group.DeleteGroupsConfirm.column4">Групи</message>
-	
+
 	<!-- general items for all of the registries classes -->
 	<message key="xmlui.administrative.registries.general.format_registry_trail">Реєстр форматів</message>
-	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Реєстр метаданих</message>	
-	
+	<message key="xmlui.administrative.registries.general.metadata_registry_trail">Реєстр метаданих</message>
+
 	<!-- org.dspace.app.xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.java -->
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.title">Видилити формати файлів</message>
 	<message key="xmlui.administrative.registries.DeleteBitstreamFormatsConfirm.trail">видалити формати файлів</message>
@@ -1010,7 +1217,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.title">Видалити поля</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.trail">Видалити поля</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.head">Підтвердити видалення</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Ви <b>абсолютно</b> впевнені в тому що хочете видалити ці поля? Якщо хоча б якісь матеріали містять метадані до цих полів, ці поля не можуть бути видалені. Ви меєте пересвідчитись що жодний матеріал не використовує дані поля.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para1">Ви <b>absolutely</b> sure you want to delete these fields? If any items contain metadata for these fields, the field(s) cannot be deleted. You must ensure that no items use these fields.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.warning">ПОПЕРЕДЖЕННЯ: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.para2">Це спричинить помилкуякщо хоча б якісь матеріали містять метадані до цих полів.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataFieldsConfirm.column1">ID</message>
@@ -1021,7 +1228,7 @@
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.title">Видалення схеми</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.trail">Видалення схеми</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.head">Підтвердити видалення</message>
-	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Ви <b>абсолютно</b> впевнені що хочете видалити цю схему? Якщо хоча б якісь матеріали містять метадані до полів цієї схеми, схема не може бути видалена. Ви маєте пересвідчитись що жодні матеріали не використовують цю схему.</message>
+	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para1">Ви <b>absolutely</b> sure you want to delete this schema? If any items contain metadata for fields contained within this schema, the schema cannot be deleted. You must ensure that no items contain metadata in this schema.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.warning">ПОПЕРЕДЖЕННЯ: </message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.para2">Це спричинить помилкуякщо хоча б якісь матеріали містять метадані до полів цієї схеми.</message>
 	<message key="xmlui.administrative.registries.DeleteMetadataSchemaConfirm.column1">ID</message>
@@ -1056,7 +1263,7 @@
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head1">Схема метаданих: "{0}"</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.para1">Ця схема метаданих для "{0}". Ви можете додати нову чи оновити існучі поля метаданих цієї схеми. Поля також можуть бути видалені чи переміщені до іншої схеми. </message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.head2">Поля схеми метаданих</message>
-	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"></message>
+	<message key="xmlui.administrative.registries.EditMetadataSchema.column1"/>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column2">ID</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column3">Поле</message>
 	<message key="xmlui.administrative.registries.EditMetadataSchema.column4">Обмежуюча примітка</message>
@@ -1083,12 +1290,12 @@
 	<message key="xmlui.administrative.registries.FormatRegistryMain.head">Реєстр форматів</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.para1">Цей список форматів файлів містить інформацію про відомі формати та рівень їх підтримки. Ви можете редагувати формати файлів з допомогою цього інструменту. Формати  позначені як "Внутрішній" приховані від користувачів і використовуються тільки для адміністративних цілей.</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.new_link">Додати нофий формат файлу</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column3">Ім'я</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column4">MIME тип</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.column5">Рівень підтримки</message>
-	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>внутрішній</i>)</message>
+	<message key="xmlui.administrative.registries.FormatRegistryMain.internal">(<i>internal</i>)</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_0">Невідомий</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_1">Відомий</message>
 	<message key="xmlui.administrative.registries.FormatRegistryMain.support_2">Підримуваний</message>
@@ -1098,7 +1305,7 @@
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.title">Реєстр метаданих</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.head1">Реєстр метаданих</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.para1">Реєстр метаданих містить список всіх полів доступних у репозитарії. Ці поля можуть бути поділені між кількома схемами. Однак DSpace потребує Qualified Dublin Core схеми. Ви можете доповнити схему Dublin Core додатковими полями чи схемами.</message>
-	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"></message>
+	<message key="xmlui.administrative.registries.MetadataRegistryMain.column1"/>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column2">ID</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column3">Namespace</message>
 	<message key="xmlui.administrative.registries.MetadataRegistryMain.column4">Ім'я</message>
@@ -1123,13 +1330,13 @@
 	<message key="xmlui.administrative.registries.MoveMetadataField.para2">Перемістити до схеми: </message>
 	<message key="xmlui.administrative.registries.MoveMetadataField.submit_move">Перемістити поля</message>
 
-	
-	
-	
+
+
+
 	<!-- general authorization keywords -->
 	<message key="xmlui.administrative.authorization.general.authorize_trail">авторизація</message>
 	<message key="xmlui.administrative.authorization.general.policyList_trail">Правила доступу</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.AuthorizationMain -->
 	<message key="xmlui.administrative.authorization.AuthorizationMain.title">Адміністрування прав доступу</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.main_head">Адміністрування прав доступу</message>
@@ -1142,9 +1349,9 @@
 	<message key="xmlui.administrative.authorization.AuthorizationMain.actions_advanced_link">Натисніть тут для переходу</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_head">Правила доступу до Фонду/Колекції</message>
 	<message key="xmlui.administrative.authorization.AuthorizationMain.containerList_para">Натисніть на імені фонду/колекції для того щоб змінити правила доступу до них.</message>
-	
-	
-	
+
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditContainerPolicies -->
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.title">Зміна правил доступу</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.trail">Зміна правил доступу</message>
@@ -1153,13 +1360,16 @@
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.main_add_link">Натисніть тут для створення нового правила. </message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_add">Додати</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_id">ID</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_name">Name</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_action">Дія</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.head_group">Група</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditContainerPolicies.head_end_date">End Date</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.submit_delete">Видалити позначене</message>
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.group_edit">Змінити</message>
-	
 
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditItemPolicies -->
 	<message key="xmlui.administrative.authorization.EditItemPolicies.title">Редагувати правила доступу</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.trail">Список правил</message>
@@ -1172,10 +1382,10 @@
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_itemPolicy_link">Додати нове правило</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bundlePolicy_link">Додати нове правило доступу до пакетів</message>
 	<message key="xmlui.administrative.authorization.EditItemPolicies.add_bitstreamPolicy_link">Додати нове правило доступу до файлів</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditContainerPolicies.no_policies">Не знайдено правил доступу для цього об'єкту.</message>
-	
-	
+
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.EditPolicyForm -->
 	<message key="xmlui.administrative.authorization.EditPolicyForm.title">Змінити правило</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.trail">Змінити правило</message>
@@ -1183,11 +1393,11 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.main_head_edit">Змінити правило {0} для {1} {2}</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_group">Група не обрана</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.error_no_action">Дія не обрана</message>
-	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"></message>
+	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column4"/>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column1">ID</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column2">Ім'я</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_column3">Дозволені дії для групи</message>
-	
+
 	<message key="xmlui.administrative.authorization.EditPolicyForm.set_group">Встановити</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.current_group">поточна група</message>
 	<message key="xmlui.administrative.authorization.EditPolicyForm.groups_head">Результати пошуку</message>
@@ -1195,9 +1405,17 @@
 	<message key="xmlui.administrative.authorization.EditPolicyForm.label_search">Шукати групу</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.submit_search_groups">Пошук</message>
     <message key="xmlui.administrative.authorization.EditPolicyForm.label_action">Оберіть дію</message>
-    
-	
-	<!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
+
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_name">Name</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_description">Description</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_duplicated_policy">An identical policy for this group and this action is already in place.</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.EditPolicyForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <!-- org.dspace.app.xmlui.administrative.authorization.AdvacedAuthorizationsForm -->
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.title">Майстер налаштування правил доступу</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.trail">Майстер налаштування правил доступу</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.main_head">Майстер налаштування правил доступу</message>
@@ -1212,7 +1430,17 @@
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.actions_policyCollections">Колекція(ї)</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_add">Додати правило</message>
 	<message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.submit_remove_all">Скинути правило</message>
-	
+    <message key="xmlui.administrative.authorization.AdvacedAuthorizationsForm.label_date_help">Accepted format: yyyy, yyyy-mm, yyyy-mm-dd</message>
+
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_name">Name</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_description">Description</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_start_date">Start Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.actions_end_date">End Date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_date_format">Invalid date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_start_date_greater_than_end_date">Start date is greater than end date</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_groupIds">Select at least a group</message>
+    <message key="xmlui.administrative.authorization.AdvancedAuthorizationsForm.error_collectionIds">Select at least a collection</message>
+
 	<!-- org.dspace.app.xmlui.administrative.authorization.DeletePoliciesConfirm -->
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.title">Підтвердіть видаленя правила</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.trail">Підтвердіть видаленя правила</message>
@@ -1221,7 +1449,42 @@
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_id">ID</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_action">Дія</message>
 	<message key="xmlui.administrative.authorization.DeletePoliciesConfirm.head_group">Група</message>
-	
+
+
+    <!-- Batch Import Tool -->
+    <!-- org.dspace.app.xmlui.administrative.batchimport -->
+    <message key="xmlui.administrative.batchimport.general.select_collection">Select a collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection">Collection</message>
+    <message key="xmlui.administrative.batchimport.general.collection_help">Select the collection you wish to submit an item to.</message>
+    <message key="xmlui.administrative.batchimport.general.collection_default">Select a collection...</message>
+
+    <message key="xmlui.administrative.batchimport.general.title">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.head1">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.trail">Import Batch Load (ZIP)</message>
+    <message key="xmlui.administrative.batchimport.general.changes">changes</message>
+    <message key="xmlui.administrative.batchimport.general.no_changes">No changes were detected</message>
+    <message key="xmlui.administrative.batchimport.general.new_item">New item</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_successful">Upload successful</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_failed">Upload failed or no file selected</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.upload_badelement">Unknown metadata element in heading</message>
+    <message key="xmlui.administrative.batchimport.flow.import_successful">Import successful</message>
+    <message key="xmlui.administrative.batchimport.flow.import_failed">Import failed</message>
+    <message key="xmlui.administrative.batchimport.flow.failed_no_collection">No Destination Collection Specified</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchmportMain.submit_upload">Upload SimpleArchiveFormat ZIP</message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportConfirm -->
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.success">Successfully processed</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.changes_committed">Changes applied to item</message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_added">Added: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportConfirm.item_removed">Removed: </message>
+
+    <!-- org.dspace.app.xmlui.administrative.batchimport.BatchImportUpload -->
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_add">Add: </message>
+    <message key="xmlui.administrative.batchimport.BatchImportUpload.item_remove">Remove: </message>
+
 	<!-- general edit item messages -->
 	<message key="xmlui.administrative.item.general.item_trail">Матеріали</message>
 	<message key="xmlui.administrative.item.general.template_head">Редагувати шаблон для колекції: {0}</message>
@@ -1230,7 +1493,9 @@
 	<message key="xmlui.administrative.item.general.option_bitstreams">Файли матеріалу</message>
 	<message key="xmlui.administrative.item.general.option_metadata">Метадані матеріалу</message>
 	<message key="xmlui.administrative.item.general.option_view">Переглянути матеріал</message>
-	
+        <message key="xmlui.administrative.item.general.option_curate">Curate</message>
+        <message key="xmlui.administrative.item.general.option_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.AddBitstreamForm -->
 	<message key="xmlui.administrative.item.AddBitstreamForm.title">Завантажити файл</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.trail">Завантажити файл</message>
@@ -1240,14 +1505,14 @@
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.METADATA">Файли метаданих</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.THUMBNAIL">Мініатюра</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.LICENSE">Ліцензії</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC_LICENSE">Creative Commons Licenses</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.bundle.CC-LICENSE">Creative Commons Licenses</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_label">Файл</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.file_help">Будь-ласка введіть ім'я файлу на вашому комп'ютері для додавання до вашого матеріалу. Якщо натиснути "Обзор..." з'явиться вікно в якому ви можете обрати необхідний файл.</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.description_label">Опис</message>
-	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Дайте короткий опис файлу, наприклад "<i>Основна стаття</i>", "<i>Експерементальні дані</i>" тощо.</message>
+	<message key="xmlui.administrative.item.AddBitstreamForm.description_help">Дайте короткий опис файлу, наприклад "<i>Main article</i>", or "<i>Experiment data readings</i>".</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.submit_upload">Завантаження</message>
 	<message key="xmlui.administrative.item.AddBitstreamForm.no_bundles">Вам необхідно мати ADD &amp; WRITE права доступу хоча б до пакету, щоб мати можливість завантажити новий файл.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.DeleteBitstreamConfirm -->
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.title">Підтвердіть видалення</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.trail">Підтвердіть видалення</message>
@@ -1256,7 +1521,7 @@
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column1">Ім'я</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column2">Опис</message>
 	<message key="xmlui.administrative.item.DeleteBitstreamConfirm.column3">Формат</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.item.ConfirmItemForm -->
 	<message key="xmlui.administrative.item.ConfirmItemForm.title">Підтвердити</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.trail">Підтвердити</message>
@@ -1269,6 +1534,8 @@
 	<message key="xmlui.administrative.item.ConfirmItemForm.column3">Мова</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_withdraw">Вилучити</message>
 	<message key="xmlui.administrative.item.ConfirmItemForm.submit_reinstate">Відновити</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_private">Make it Private</message>
+    <message key="xmlui.administrative.item.ConfirmItemForm.submit_public">Make it Public</message>
 
     <!-- org.dspace.app.xmlui.aspect.administrative.item.MoveItemForm -->
 	<message key="xmlui.administrative.item.MoveItemForm.title">Перемістити</message>
@@ -1290,31 +1557,39 @@
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_yes">так</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.primary_option_no">ні</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.description_label">Опис</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Дайте короткий опис файлу, наприклад "<i>Основна стаття</i>", "<i>Експерементальні дані</i>" тощо.</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Оберіть тип файлу зі списку, наприклад "<i>Adobe PDF</i>" чи "<i>Microsoft Word</i>", <b>АБО</b> якщо в списку немає необхідного формату, будь-ласка, опишіть його у полі що нижче.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.description_help">Дайте короткий опис файлу, наприклад "<i>Main article</i>", or "<i>Experiment data readings</i>"."</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para1">Оберіть тип файлу зі списку, наприклад "<i>Adobe PDF</i>" or "<i>Microsoft Word</i>", <b>OR</b> if the format is not in the list, please describe it in the box below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_label">Оберіть формат</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.format_default">Немає в списку</message>
-	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Якщо в списку немає необхідного формату, <strong>оберіть "Немає в списку"</strong> та опишіть формат у полі що нижче.</message>
+	<message key="xmlui.administrative.item.EditBitstreamForm.para2">Якщо в списку немає необхідного формату, <strong>select "format not in list" above</strong> and describe it in the field below.</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_label">Інший формат</message>
 	<message key="xmlui.administrative.item.EditBitstreamForm.user_help">Програма якою було створено даний файл та її версія (наприкллад "<i>ACMESoft SuperApp version 1.5</i>").</message>
-	
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_label">Filename</message>
+    <message key="xmlui.administrative.item.EditBitstreamForm.name_help">Change the filename for this bitstream. Note that this will change the display bitstream URL, but old links will still resolve as long as the sequence ID does not change.</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemBitstreamsForm -->
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.title">Файли</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.trail">Файли</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.head1">Файли</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column1"/>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column2">Ім'я</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column3">Опис</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column4">Формат</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column5">Перегляд</message>
-	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Пакет: {0}</strong></message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column6">Order</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.column7"> </message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.bundle_label"><strong>Bundle: {0}</strong></message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.primary_label"> (основний) </message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.view_link">перегляд</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_add">Завантажте новий файл</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_delete">Видалити файли</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.submit_reorder">Update bitstream order</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_upload">Вам необхідно мати ADD &amp; WRITE права доступу до матеріалу та пакету, для того щоб мамти змогу завантажувати нові файли.</message>
 	<message key="xmlui.administrative.item.EditItemBitstreamsForm.no_remove">Лише системні адміністратори можуть видаляти файли.</message>
-	
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.previous_order">Previous:</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_up">Move up</message>
+	<message key="xmlui.administrative.item.EditItemBitstreamsForm.order_down">Move down</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.EditItemMetadataForm -->
 	<message key="xmlui.administrative.item.EditItemMetadataForm.title">Метадані матеріалу</message>
 	<message key="xmlui.administrative.item.EditItemMetadataForm.trail">Метадані матеріалу</message>
@@ -1353,11 +1628,22 @@
 	<message key="xmlui.administrative.item.EditItemStatusForm.sysadmins_only">(тільки системні адміністратори)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.collection_admins_only">(тільки адміністратори колекції)</message>
 	<message key="xmlui.administrative.item.EditItemStatusForm.not_allowed">(вам не дозволено виконувати цю дію)</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_private">Make item private</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.label_public">Make item public</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_private">Make it private...</message>
+    <message key="xmlui.administrative.item.EditItemStatusForm.submit_public">Make it public...</message>
+
+
 
 	<!-- org.dspace.app.xmlui.administrative.item.ViewItem -->
 	<message key="xmlui.administrative.item.ViewItem.title">Переглянути матеріал</message>
 	<message key="xmlui.administrative.item.ViewItem.trail">Переглянути матеріал</message>
-	
+        <!-- org.dspace.app.xmlui.administrative.item.CurateItemForm.java -->
+        <message key="xmlui.administrative.item.CurateItemForm.main_head">Curate Item: {0}</message>
+        <message key="xmlui.administrative.item.CurateItemForm.title">Curate Item</message>
+        <message key="xmlui.administrative.item.CurateItemForm.trail">Curator</message>
+        <message key="xmlui.administrative.item.CurateItemForm.label_name">Task</message>
+
 	<!-- org.dspace.app.xmlui.administrative.item.FindItemForm -->
 	<message key="xmlui.administrative.item.FindItemForm.title">Знайти матеріал</message>
 	<message key="xmlui.administrative.item.FindItemForm.head1">Знайти матеріал</message>
@@ -1374,6 +1660,8 @@
         <message key="xmlui.administrative.metadataimport.general.new_item">Новий матеріал</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_successful">Завантаження успішне</message>
         <message key="xmlui.administrative.metadataimport.flow.upload_failed">Завантаження неуспішне</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badschema">Unknown metadata schema in heading</message>
+        <message key="xmlui.administrative.metadataimport.flow.upload_badelement">Unknown metadata element in heading</message>
         <message key="xmlui.administrative.metadataimport.flow.import_successful">Імпорт успішний</message>
         <message key="xmlui.administrative.metadataimport.flow.import_failed">Імпорт неуспішний</message>
         <message key="xmlui.administrative.metadataimport.flow.over_limit">Перевищено максимально дозволену кількість змін. Змінити ліміт можна тут bulkedit.gui-item-limit у файлі налашувань dspace.cfg</message>
@@ -1390,7 +1678,10 @@
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_oldowner">Видалено з колекції</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_mapped">Mapped to collection</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.collection_unmapped">Unmapped from collection</message>
-        
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_deleted">Item Expunged</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_withdrawn">Item Withdrawn</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportConfirm.item_reinstated">Item Reinstated</message>
+
         <!-- org.dspace.app.xmlui.administrative.metadataimport.MetadataImportUpload -->
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_add">Додати: </message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_remove">Видалити: </message>
@@ -1401,49 +1692,53 @@
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.changes_pending">Changes pending for item</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.submit_confirm">Підтвердити зміни</message>
         <message key="xmlui.administrative.metadataimport.MetadataImportUpload.hint">Pending changes are listed below for review</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_delete">Expunge Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_withdraw">Withdraw Item</message>
+        <message key="xmlui.administrative.metadataimport.MetadataImportUpload.item_reinstate">Reinstate Item</message>
 
 	<!-- general mapper messages -->
 	<message key="xmlui.administrative.mapper.general.mapper_trail">Item mapper</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.MapperMain -->
 	<message key="xmlui.administrative.mapper.MapperMain.title">Item Mapper</message>
 	<message key="xmlui.administrative.mapper.MapperMain.head1">Item Mapper - Map Items from Other Collection</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para1">Колекція: "<strong>{0}</strong>"</message>
 	<message key="xmlui.administrative.mapper.MapperMain.para2">This is the item mapper tool that allows collection administrators to map items from other колекція into this collection. You can search for items from other collection and map them, or browse the list of currently mapped items.</message>
 	<message key="xmlui.administrative.mapper.MapperMain.stat_label">Статистика</message>
-	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other колекція</message>
+	<message key="xmlui.administrative.mapper.MapperMain.stat_info"><strong>{0} of {1}</strong> items in this collection are mapped in from other collections</message>
 	<message key="xmlui.administrative.mapper.MapperMain.search_label">Пошук</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_search">Пошук матеріалів</message>
 	<message key="xmlui.administrative.mapper.MapperMain.submit_browse">Перегляд mapped матеріалів</message>
 	<message key="xmlui.administrative.mapper.MapperMain.no_add">(Потребує права доступу ADD до колекції)</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.SearchItemForm -->
 	<message key="xmlui.administrative.mapper.SearchItemForm.title">Пошук матеріалів</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.trail">Пошук матеріалів</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.head1">Пошуку матеріалів відповідає: "{0}"</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.submit_map">Map обрані матеріали</message>
-	<message key="xmlui.administrative.mapper.SearchItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.SearchItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column2">Колекція</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column3">Автор</message>
 	<message key="xmlui.administrative.mapper.SearchItemForm.column4">Заголовок</message>
-		
+
 	<!-- org.dspace.app.xmlui.administrative.mapper.BrowseItemForm -->
 	<message key="xmlui.administrative.mapper.BrowseItemForm.title">Browse Mapped Items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.trail">Browse mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.head1">Browsing mapped items</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.submit_unmap">Unmap selected items</message>
-	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"></message>
+	<message key="xmlui.administrative.mapper.BrowseItemForm.column1"/>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column2">Колекція</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column3">Автор</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.column4">Заголовок</message>
 	<message key="xmlui.administrative.mapper.BrowseItemForm.no_remove">Необхідно мати право REMOVE для колекції, щоб мати можливість unmap матеріали з колекції.</message>
-	
+
 	<!-- General tags for collection management -->
-	<message key="xmlui.administrative.collection.general.collection_trail">колекція</message>	
-	<message key="xmlui.administrative.collection.general.options_metadata">Редагувати метадані</message>	
-	<message key="xmlui.administrative.collection.general.options_roles">Призначити ролі</message>	
-	
-	
+	<message key="xmlui.administrative.collection.general.collection_trail">колекція</message>
+	<message key="xmlui.administrative.collection.general.options_metadata">Редагувати метадані</message>
+	<message key="xmlui.administrative.collection.general.options_roles">Призначити ролі</message>
+        <message key="xmlui.administrative.collection.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.collection.general.options_queue">Queue</message>
+
 	<!-- org.dspace.app.xmlui.administrative.collection.AssignCollectionRoles.java -->
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.title">Редагвати роля колекції</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.trail">ролі</message>
@@ -1470,8 +1765,15 @@
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_wf_step3">Крок Редагувати метадані</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_submitters">Хто додає</message>
 	<message key="xmlui.administrative.collection.AssignCollectionRoles.label_default_read">Доступ за замовчуванням</message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(тільки адміністратори)</nobr></message>
-	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(у вас недостатньо прав для)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.repository_role"><br/>(Repository level group, system administrators only)</message>
+	<message key="xmlui.administrative.collection.AssignCollectionRoles.not_allowed"><nobr>(you are not allowed to configure this)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.collection.CurateCollectionForm.java -->
+        <message key="xmlui.administrative.collection.CurateCollectionForm.main_head">Curate Collection: {0}</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.title">Curate Collection</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.trail">Curator</message>
+        <message key="xmlui.administrative.collection.CurateCollectionForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.title">Підтвердити видалення</message>
@@ -1481,14 +1783,14 @@
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item1">Будь-які матеріали та незавершені надходження до цієї колекції що не містяться в інших колекціях</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item2">Зміст цих матеріалів</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionConfirm.confirm_item3">Всі пов'язані правила доступу</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.DeleteCollectionRoleConfirm.java -->
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.title">Підтвердити видалення ролі</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.trail">Підтвердити</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_head">Підтвердити видалення ролі {0}</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para_read">Ви впевнені що хочете видалити цю роль? Видалення цієї групи надасть право доступу READ для всіх елементів колекції, для всіх користувачів. Зауважте що дана операція не має зворотної дії. Існуючі матеріали все ще будуть не доступні для перегляду момент зміни правила доступу.</message>
 	<message key="xmlui.administrative.collection.DeleteCollectionRoleConfirm.main_para">Ви впевнені що хочете видалити цю роль? Всі зміни та налаштування зроблені для {0} групи будуть втрачені і їх доведеться створювати  заново.</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionMetadataForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.title">Редагувати метадані колекції</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.trail">Метадані</message>
@@ -1508,14 +1810,14 @@
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete_logo">Видалити логотип</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_delete">Видалити колекцію</message>
 	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.submit_save">Зберегти зміни</message>
-	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(лише системні адміністратори)</nobr></message>
+	<message key="xmlui.administrative.collection.EditCollectionMetadataForm.sysadmins_only"><nobr>(system administrators only)</nobr></message>
 
 	<!-- org.dspace.app.xmlui.administrative.collection.CreateCollectionForm.java -->
 	<message key="xmlui.administrative.collection.CreateCollectionForm.title">Створити колекцію</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.trail">Створити колекцію</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.main_head">Ввести метадані для нової колекції {0}</message>
 	<message key="xmlui.administrative.collection.CreateCollectionForm.submit_save">Створити</message>
-		
+
 	<!-- General to the harvesting options under collection -->
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.title">Налаштування харвестінгу(Harvesting) для колекції</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.trail">Harvesting</message>
@@ -1524,7 +1826,7 @@
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_normal">Це стандартна колекція DSpace</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.source_harvested">Ця колекція отримує(harvests) матеріали із зовнішнього ждерела</message>
 	<message key="xmlui.administrative.collection.GeneralCollectionHarvestingForm.submit_save">Зберегти</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.SetupCollectionHarvestingForm.java -->
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.main_settings_head">Розміщення отримуваної(Harvested) колекції</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.options_head">Налаштування харвестінгу(Harvesting)</message>
@@ -1536,12 +1838,11 @@
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.help_oaisetid">Точний ідентифікатор, який використовує OAI provider для визначення цільової колекції</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.error_oaisetid">Ви маєте вказати set id цільової колекції.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
-	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.label_harvest_level">Content being harvested</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_only">Harvest metadata only.</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_ref">Harvest metadata and references to bitstreams (requires ORE support).</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.option_md_and_bs">Harvest metadata and bitstreams (requires ORE support).</message>
 	<message key="xmlui.administrative.collection.SetupCollectionHarvestingForm.submit_test">тестові налаштування</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.collection.EditCollectionHarvestingForm.java -->
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.main_settings_head">Розміщення колекції харвестінгу</message>
 	<message key="xmlui.administrative.collection.EditCollectionHarvestingForm.label_oai_provider">OAI Provider</message>
@@ -1580,12 +1881,14 @@
 	<message key="xmlui.administrative.ControlPanel.harvest_head_generator_settings">Основні налаштування</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_url">OAI-PMH URL</message>
 	<message key="xmlui.administrative.ControlPanel.harvest_label_oai_source">ORE source</message>
-	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Налаштування харвестера(Harvester)</message>	
+	<message key="xmlui.administrative.ControlPanel.harvest_head_harvester_settings">Налаштування харвестера(Harvester)</message>
 
 	<!-- General tags for community management -->
 	<message key="xmlui.administrative.community.general.community_trail">Фонди</message>
 	<message key="xmlui.administrative.community.general.options_metadata">Редагувати метадані</message>
 	<message key="xmlui.administrative.community.general.options_roles">Призначити ролі</message>
+        <message key="xmlui.administrative.community.general.options_curate">Curate</message>
+        <message key="xmlui.administrative.community.general.options_queue">Queue</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.AssignCommunityRoles.java -->
 	<message key="xmlui.administrative.community.AssignCommunityRoles.title">Редагувати ролі для фонду</message>
@@ -1601,7 +1904,13 @@
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_group">Пов'язана група</message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.role_buttons">  </message>
 	<message key="xmlui.administrative.community.AssignCommunityRoles.label_admins">Адміністратори</message>
-	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(тільки для системних адміністраторів)</nobr></message>
+	<message key="xmlui.administrative.community.AssignCommunityRoles.sysadmins_only"><nobr>(system administrators only)</nobr></message>
+
+        <!-- org.dspace.app.xmlui.administrative.community.CurateCommunityForm.java -->
+        <message key="xmlui.administrative.community.CurateCommunityForm.main_head">Curate Community: {0}</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.title">Curate Community</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.trail">Curator</message>
+        <message key="xmlui.administrative.community.CurateCommunityForm.label_name">Task</message>
 
 	<!-- org.dspace.app.xmlui.administrative.community.DeleteCommunityConfirm.java -->
 	<message key="xmlui.administrative.community.DeleteCommunityConfirm.title">Підтвердити видалення</message>
@@ -1633,7 +1942,7 @@
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.label_existing_logo">Поточний логотип</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete_logo">Видалити логотип</message>
 	<message key="xmlui.administrative.community.EditCommunityMetadataForm.submit_delete">Видалити фонд</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.community.CreateCommunityForm.java -->
 	<message key="xmlui.administrative.community.CreateCommunityForm.title">Створити фонд</message>
 	<message key="xmlui.administrative.community.CreateCommunityForm.trail">Створити фонд</message>
@@ -1664,7 +1973,16 @@
 	<message key="xmlui.administrative.ControlPanel.runtime_total">Виділена пам'ять</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_used">Використовується пам'яті</message>
 	<message key="xmlui.administrative.ControlPanel.runtime_free">Вільна пам'ять</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_head">Cocoon Info</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_version">Cocoon Version</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_dir">Cocoon Cache Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_work_dir">Cocoon Work Directory</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_main_cache_size">Main Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_cache_clear">(Clear Cache Immediately)</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_persistent_cache_size">Persistent Cache Size ({0})</message>
+        <message key="xmlui.administrative.ControlPanel.cocoon_transient_cache_size">Transient Cache Size ({0})</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_head">DSpace Налаштування</message>
+        <message key="xmlui.administrative.ControlPanel.dspace_version">DSpace Version</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_dir">DSpace Installation Directory</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_url">DSpace базовий URL</message>
 	<message key="xmlui.administrative.ControlPanel.dspace_hostname">DSpace ім'я хоста</message>
@@ -1690,11 +2008,11 @@
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_30">30 хвилин</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_60">1 година</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_countdown_keep">Продовжувати зворотній відлік</message>
-	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Керування сесіями</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Дозволити аутентифікацію</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Заборонити аутентифікацію, окрім вже відкритих сесій</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Заборонити аутентифікацію і завершити всі відкриті сесії</message>	
-	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Зауваження:</strong> на адміністрацію сайту заборона аутентифікації не розповсюджується.</message>	
+	<message key="xmlui.administrative.ControlPanel.alerts_session_label">Керування сесіями</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_all_sessions">Дозволити аутентифікацію</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_current_sessions">Заборонити аутентифікацію, окрім вже відкритих сесій</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_only_administrative_sessions">Заборонити аутентифікацію і завершити всі відкриті сесії</message>
+	<message key="xmlui.administrative.ControlPanel.alerts_session_note"><strong>Note:</strong> Site administrators are exempt from session management.</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_activate">Активувати</message>
 	<message key="xmlui.administrative.ControlPanel.alerts_submit_deactivate">Деактивувати</message>
 	<message key="xmlui.administrative.ControlPanel.activity_head">Поточна активність ({0} сторінок максимум)</message>
@@ -1707,14 +2025,14 @@
 	<message key="xmlui.administrative.ControlPanel.activity_sort_ip">IP адреса</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_url">URL сторінка</message>
 	<message key="xmlui.administrative.ControlPanel.activity_sort_Agent">User-Agent</message>
-	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Анонім {0}</message>	
+	<message key="xmlui.administrative.ControlPanel.activity_anonymous">Анонім {0}</message>
 	<message key="xmlui.administrative.ControlPanel.activity_none">Переглядів не зареєстровано.</message>
-	
+
 	<message key="xmlui.administrative.ControlPanel.select_panel">Використовуйте вкладки, що вище, для перегляду відповідоної інформації</message>
-	
+
 	<!-- org.dspace.app.xmlui.administrative.SystemwideAlerts -->
-	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>Через {0} хвилин</strong>: </message>
-	
+	<message key="xmlui.administrative.SystemwideAlerts.countdown"><strong>In {0} minutes</strong>: </message>
+
 	<!-- org.dspace.app.xmlui.administrative.NotAuthorized -->
 	<message key="xmlui.administrative.NotAuthorized.title">Не авторизовано</message>
 	<message key="xmlui.administrative.NotAuthorized.trail">Не авторизовано</message>
@@ -1723,6 +2041,15 @@
 	<message key="xmlui.administrative.NotAuthorized.para1b">адміністратором</message>
 	<message key="xmlui.administrative.NotAuthorized.para1c">.</message>
 	<message key="xmlui.administrative.NotAuthorized.para2">Ввійти під іншим аккаунтом</message>
+        
+        <!-- System-wide Curation Tasks form (org.dspace.app.xmlui.aspect.administrative.CurateForm) -->
+        <message key="xmlui.administrative.CurateForm.title">System Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.trail">Curation Tasks</message>
+        <message key="xmlui.administrative.CurateForm.object_label_name">Handle of DSpace Object</message>
+        <message key="xmlui.administrative.CurateForm.object_hint">Hint: Enter [your-handle-prefix]/0 to run a task across entire site (not all tasks may support this capability)</message>
+        <message key="xmlui.administrative.CurateForm.task_label_name">Task</message>
+    <!-- Used by Curate<DSO>Form classes also -->
+        <message key="xmlui.administrative.CurateForm.taskgroup_label_name">Choose from the following groups</message>
 
 
     <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1731,6 +2058,12 @@
 
         !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
     <message key="xmlui.statistics.title">Статистика</message>
+    <message key="xmlui.statistics.search.title">Search Statistics</message>
+    <message key="xmlui.statistics.search.head">Search Statistics</message>
+    <message key="xmlui.statistics.search.head-dso">Search Statistics for {0}</message>
+    <message key="xmlui.statistics.search.error">There was an error while generating the search statistics, please try again later.</message>
+    <message key="xmlui.statistics.search.no-results">No search statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.title">Workflow Statistics</message>
     <message key="xmlui.statistics.visits.total">Відвідувань всього</message>
     <message key="xmlui.statistics.visits.month">Відвідувань ща місяць</message>
     <message key="xmlui.statistics.visits.views">Переглядів</message>
@@ -1738,20 +2071,78 @@
     <message key="xmlui.statistics.visits.cities">Найбільше переглядів з сайтів</message>
     <message key="xmlui.statistics.visits.bitstreams">Перегляди файлів</message>
     <message key="xmlui.statistics.Navigation.title">Статистика</message>
-    <message key="xmlui.statistics.Navigation.view">Переглянути статистику</message>
+    <message key="xmlui.statistics.Navigation.usage.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.usage-Elasticsearch.view">View Usage Statistics</message>
+    <message key="xmlui.statistics.Navigation.search.view">View Search Statistics</message>
+    <message key="xmlui.statistics.Navigation.workflow.view">View Workflow Statistics</message>
     <message key="xmlui.statistics.trail">Статистика</message>
+    <message key="xmlui.statistics.trail-search">Search Statistics</message>
+    <message key="xmlui.statistics.trail-workflow">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.no-results">No workflow statistics available for the selected period.</message>
+    <message key="xmlui.statistics.workflow.error">There was an error while generating the workflow statistics, please try again later.</message>
+    <message key="xmlui.statistics.workflow.head">Workflow Statistics</message>
+    <message key="xmlui.statistics.workflow.head-dso">Workflow Statistics for {0}</message>
 
-	
-	
-	
-	
-	
-	
-	
+
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-terms.head">Top Search Terms</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.search-total.head">Total</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-month">Previous month</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-6-months">Previous 6 months</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.last-year">Previous year</message>
+    <message key="xmlui.statistics.StatisticsSearchTransformer.time-filter.overall">Overall</message>
+
+
+    <message key="xmlui.statistics.display.table.column-label.search-terms">Search Term</message>
+    <message key="xmlui.statistics.display.table.column-label.searches">Searches</message>
+    <message key="xmlui.statistics.display.table.column-label.percent-total">% of Total</message>
+    <message key="xmlui.statistics.display.table.column-label.views-search">Pageviews / Search</message>
+    <message key="xmlui.statistics.display.table.column-label.step">Step</message>
+    <message key="xmlui.statistics.display.table.column-label.performed">Performed</message>
+    <message key="xmlui.statistics.display.table.column-label.average">Average</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1POOL">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP1">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2POOL">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP2">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3POOL">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.STEP3">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.claimaction">Accept/Reject Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.reviewstep.reviewaction">Accept/Reject Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.claimaction">Accept/Reject/Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.editstep.editaction">Accept/Reject/Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.claimaction">Edit Metadata Step Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.default.finaleditstep.finaleditaction">Edit Metadata Step</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.claimaction">Score Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.scoreReviewStep.scorereviewaction">Score Review</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.evaluationaction">Score Review Evaluation</message>
+    <message key="xmlui.statistics.display.table.workflow.step.scoreReview.evaluationStep.noUserSelectionAction">Score Review Evaluation Configuration</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.selectReviewerStep.claimaction">Single User Review Pool</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.autoassignAction">Single User Auto Assign Action</message>
+    <message key="xmlui.statistics.display.table.workflow.step.selectSingleReviewer.singleUserReviewStep.singleuserreviewaction">Single User Review Action</message>
+
+
+    <!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                     Google Analytics Statistics Aspect
+
+        !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
+
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.title">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.Navigation.usage.view">View Google Analytics Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.trail">Statistics</message>
+    <message key="xmlui.statisticsGoogleAnalytics.title">Google Analytics Statistics</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.dates.startDate">Start date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.endDate">End date</message>
+    <message key="xmlui.statisticsGoogleAnalytics.dates.refresh">Refresh</message>
+
+    <message key="xmlui.statisticsGoogleAnalytics.pageViews.title">Page Views</message>
+    <message key="xmlui.statisticsGoogleAnalytics.downloads.title">File Downloads</message>
+
+
 	<!--!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-		
+
 		                  dri2xhtml
-		
+
 		!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!-->
 
 
@@ -1760,18 +2151,20 @@
 
 	<!-- structural.xsl -->
 	<message key="xmlui.dri2xhtml.structural.footer-promotional">
-		<a href="http://di.tamu.edu" id="ds-logo-link">                            
-			<span id="ds-footer-logo">&#160;</span>
+		<a href="http://di.tamu.edu" id="ds-logo-link">
+			<span id="ds-footer-logo"> </span>
 		</a>
 		<p>
-			Цей вебсайт використвоує Manakin, новий користувацький інтерфейс для DSpace створений Texas A&amp;M University 
-			Libraries. Інтерфейс може бути значною мірою модифікований через Manakin Aspects та XSL based Themes.
-			Детальніше:
+			This website is using Manakin, a new front end for DSpace created by Texas A&amp;M University
+			Libraries. The interface can be extensively modified through Manakin Aspects and XSL based Themes.
+			For more information visit
+			<a href="http://di.tamu.edu">http://di.tamu.edu</a> and
+			<a href="http://dspace.org">http://dspace.org</a>
 		</p>
 	</message>
 	<message key="xmlui.dri2xhtml.structural.contact-link">Контакти</message>
 	<message key="xmlui.dri2xhtml.structural.feedback-link">Зворотній зв'язок</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.head-subtitle">00 DSpace/Manakin Repository</message>
 
 	<message key="xmlui.dri2xhtml.structural.profile">Профіль: </message>
@@ -1782,15 +2175,15 @@
 	<message key="xmlui.dri2xhtml.structural.search-advanced"> Розширений пошук</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-community">Фонд</message>
 	<message key="xmlui.dri2xhtml.structural.search-in-collection">По цій колекції</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.pagination-previous">Попередня сторінка</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-info">Зараз показуються {0}-{1} з {2}</message>
 	<message key="xmlui.dri2xhtml.structural.pagination-next">Наступна сторінка</message>
-	
+
 	<message key="xmlui.dri2xhtml.structural.link_cc">Creative Commons</message>
 	<message key="xmlui.dri2xhtml.structural.link_original_license">Original License</message>
-		
-	
+
+
 	<!-- DS-METS-1.0-MODS.xsl -->
 	<!-- DS-METS-1.0-DIM.xsl -->
 	<!-- DS-METS-1.0-QDC.xsl -->
@@ -1803,7 +2196,7 @@
         case in dri2xhtml to perform the needed function, or create your template to match 
         whatever profile you use.
     </message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-preview">Попередній перегляд</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-title">Тема</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-author">Автор</message>
@@ -1813,23 +2206,25 @@
 	<message key="xmlui.dri2xhtml.METS-1.0.item-date">Дата</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-publisher">Publisher</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-subject">Ключові слова</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-head">Долучені файли</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-file">Файл</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-name">Name</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-size">Розмір</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-format">Формат</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-view">Переглянути</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-files-description">Опис файла</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Переглянути</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.item-files-viewOpen">Переглянути<wbr/>Open</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.item-no-files">Даний матеріал не має долучених файлів.</message>
 
 	<message key="xmlui.dri2xhtml.METS-1.0.size-bytes">bytes</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-kilobytes">Kb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-megabytes">Mb</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.size-gigabytes">Gb</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.license-text">Наступні файли містять ліцензії повязані з цим матеріалом:</message>
-		
+    <message key="xmlui.dri2xhtml.METS-1.0.cc-license-text">Except where otherwise noted, this item's license is described as </message>
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-not-implemented">
 		The summaryView of a collection is not currently used or implemented. This can be fixed 
 		by overriding the dri2xhtml's template named collectionSummaryView.
@@ -1838,12 +2233,12 @@
 		The summaryView of a community is not currently used or implemented. This can be fixed 
 		by overriding the dri2xhtml's template named communitySummaryView.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.collection-logo-alt">Логотип колекції</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.community-logo-alt">Логотип фонду</message>
-	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Немає логотипу</message>		
-	<message key="xmlui.dri2xhtml.METS-1.0.news">Новини</message>	
-		
+	<message key="xmlui.dri2xhtml.METS-1.0.no-logo-alt">Немає логотипу</message>
+	<message key="xmlui.dri2xhtml.METS-1.0.news">Новини</message>
+
 	<!-- Internationalization elements specific to the Qualified Dublin Core metadata handler.
 		DS-METS-1.0-QDC.xsl -->
 	<message key="xmlui.dri2xhtml.METS-1.0.qdc-not-applicable">
@@ -1851,17 +2246,19 @@
 		this time. When using QDC, you should use the QDC crosswalk for DSpace items and either 
 		DIM or MODS for processing of фонди and колекція.
 	</message>
-	
+
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-elements">Dublin Core elements</message>
 	<message key="xmlui.dri2xhtml.METS-1.0.header-qdc-terms">Dublin Core terms</message>
-	
-	
+
+        <message key="xmlui.dri2xhtml.METS-1.0.blocked">Blocked</message>
+
+
 	<!-- Special pioneer model related text, wherever it might end up -->
 	<message key="xmlui.dri2xhtml.pioneer.preview">Попередній перегляд</message>
 	<message key="xmlui.dri2xhtml.pioneer.date">Дата</message>
 	<message key="xmlui.dri2xhtml.pioneer.title">Заголовок</message>
 	<message key="xmlui.dri2xhtml.pioneer.author">Автор</message>
-	
+
 	<!-- tag used to handle the empty textarea tag added 09/28/2006 -->
 	<message key="xmlui.dri2xhtml.default.textarea.value"> </message>
 
@@ -1966,6 +2363,7 @@
   <!-- params are: start, end, total-count, search-value -->
   <message key="xmlui.ChoiceLookupTransformer.results">Результати @1@ до @2@ з @3@ для "@4@"</message>
   <message key="xmlui.ChoiceLookupTransformer.fail">Помилка при завантаженні: </message>
+  <message key="xmlui.ChoiceLookupTransformer.lookup">Lookup</message>
 
   <!-- Choice Lookup - sample config for dc.publisher field -->
   <message key="xmlui.ChoiceLookupTransformer.field.dc_publisher.help">Ім'я Publisher</message>
@@ -1980,4 +2378,118 @@
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.title">LC Name Authority author lookup</message>
   <message key="xmlui.ChoiceLookupTransformer.field.dc_contributor_author.nonauthority">Local value "@1@" (not in Naming Authority)</message>
 
+  <!-- mobile theme -->
+  <message key="xmlui.mobile.home_mobile">DSpace Mobile</message>
+  <message key="xmlui.mobile.search_all">Search ALL</message>
+  <message key="xmlui.mobile.browse_all">Browse ALL by</message>
+  <message key="xmlui.mobile.browse_date">Date</message>
+  <message key="xmlui.mobile.browse_author">Author</message>
+  <message key="xmlui.mobile.browse_title">Title</message>
+  <message key="xmlui.mobile.browse_subject">Subject</message>
+  <message key="xmlui.mobile.related_google_scholar">Related</message>
+  <message key="xmlui.mobile.items_in_google_scholar">Items in Google Scholar</message>
+  <message key="xmlui.mobile.download">Download</message>
+
+
+    <!-- Versioning -->
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_create_version">Create version of this item</message>
+    <message key="xmlui.aspect.versioning.VersioningNavigation.context_show_version_history">Show version history</message>
+
+    <message key="xmlui.aspect.versioning.VersionItemForm.title">Create Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.head1">Create new version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionItemForm.summary">Reason for creating new version</message>
+
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.title">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.trail">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.head1">Update version of item: {0}</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_version">Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.submit_update_version">Update Version</message>
+    <message key="xmlui.aspect.versioning.VersionUpdateForm.summary">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.title">Confirm Deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.trail">Confirm deletion</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.head1">Confirm Deletion(s)</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para1">Are you sure you want to delete these versions. </message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.para2">PLEASE NOTE: That by deleting these versions, the associated items will no longer be accessible.</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.DeleteVersionsConfirm.column5">Summary</message>
+
+
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.title">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.trail">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.head1">Restore Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.para1">Are you sure you want to restore this version:</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column2">Editor</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column3">Date</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.column4">Summary</message>
+    <message key="xmlui.aspect.versioning.RestoreVersionForm.restore">Restore</message>
+
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.head2">Version History</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column1">Version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column2">Item</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column3">Editor</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column4">Date</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column5">Summary</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.column6">Actions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.restore">Restore</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.update">Update</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.legend">*Selected version</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.delete">Delete Versions</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.return">Return</message>
+    <message key="xmlui.aspect.versioning.VersionHistoryForm.collection_admins_only">(collection administrators only)</message>
+
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.new_version_help">This is not the latest version of this item. The latest version can be found at: </message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_head">Notice</message>
+    <message key="xmlui.aspect.versioning.VersionNoticeTransformer.notice.workflow_version_help">A more recent version of this item is in the Workflow.</message>
+
+    <message key="xmlui.aspect.sherpa.submission.consult">To check the copyright and self-archiving policies per journal or publisher, please consult <a href="http://www.sherpa.ac.uk/">SHERPA/RoMEO</a>.</message>
+    <message key="xmlui.aspect.sherpa.submission.title">Publisher information</message>
+    <message key="xmlui.aspect.sherpa.submission.journal">Journal: </message>
+    <message key="xmlui.aspect.sherpa.submission.publisher">Publisher information: </message>
+    <message key="xmlui.aspect.sherpa.submission.colour">RoMEO Colour: </message>
+    <message key="xmlui.aspect.sherpa.submission.more">(More info)</message>
+    <message key="xmlui.aspect.sherpa.submission.green">green</message>
+    <message key="xmlui.aspect.sherpa.submission.blue">blue</message>
+    <message key="xmlui.aspect.sherpa.submission.white">white</message>
+    <message key="xmlui.aspect.sherpa.submission.yellow">yellow</message>
+    <message key="xmlui.aspect.sherpa.submission.gray">gray</message>
+    <!-- End Versioning -->
+
+
+    <message key="xmlui.mirage2.itemSummaryView.MetaData">Metadata</message>
+    <message key="xmlui.mirage2.itemSummaryView.Collections">Collections</message>
+
+    <message key="xmlui.mirage2.discovery.reset">Reset</message>
+    <message key="xmlui.mirage2.discovery.newFilter">Add New Filter</message>
+    <message key="xmlui.mirage2.discovery.showAdvancedFilters">Show Advanced Filters</message>
+    <message key="xmlui.mirage2.discovery.hideAdvancedFilters">Hide Advanced Filters</message>
+
+
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.add">Add</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.remove">Remove</message>
+    <message key="xmlui.mirage2.forms.instancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonInstancedCompositeFields.noSuggestionError">ERROR: Input field with "suggest" (autocomplete) choice behavior is not implemented for Composite (e.g. "name") fields.</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.add">Add</message>
+    <message key="xmlui.mirage2.forms.nonCompositeFieldSet.remove">Remove</message>
+
+    <message key="xmlui.mirage2.page-structure.aboutThisRepository">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.toggleNavigation">Toggle navigation</message>
+
+    <message key="xmlui.mirage2.page-structure.heroUnit.title">About This Repository</message>
+    <message key="xmlui.mirage2.page-structure.heroUnit.content">To add your own content to this page, edit webapps/xmlui/themes/Mirage2/lib/xsl/core/page-structure.xsl and add your own content to the title, trail, and body. If you wish to add additional pages, you will need to create an additional xsl:when block and match the request-uri to whatever page you are adding. Currently, static pages created through altering XSL are only available under the URI prefix of page/.</message>
+
+    <message key="xmlui.mirage2.navigation.rss.feed">feed</message>
+
+    <message key="xmlui.mirage2.choice-authority-control.loading">Loading...</message>
+
+    <message key="xmlui.mirage2.item-list.thumbnail">Thumbnail</message>
 </catalogue>


### PR DESCRIPTION
Files where migrated using https://github.com/evelthon/dspace-xmlui-lang-util
- Translation strings from the old translation file are migrated over by comparing keys
- If a key in the latest version does not exist in the older version, it defaults to English
